### PR TITLE
Fix incorrect handling when unfetched packages are deleted from upstream

### DIFF
--- a/internal/printer/fake/fake.go
+++ b/internal/printer/fake/fake.go
@@ -47,8 +47,5 @@ func CtxWithDefaultPrinter() context.Context {
 // CtxWithPrinter returns a new context with Printer added.
 func CtxWithPrinter(outStream, errStream io.Writer) context.Context {
 	ctx := context.Background()
-	return printer.WithContext(ctx, &Printer{
-		outStream: outStream,
-		errStream: errStream,
-	})
+	return printer.WithContext(ctx, printer.New(outStream, errStream))
 }

--- a/internal/testutil/pkgbuilder/builder.go
+++ b/internal/testutil/pkgbuilder/builder.go
@@ -511,28 +511,27 @@ func buildPkg(pkgPath string, pkg *pkg, pkgName string, reposInfo ReposInfo) err
 }
 
 // TODO: Consider using the Kptfile struct for this instead of a template.
-var kptfileTemplate = `
-apiVersion: kpt.dev/v1alpha2
+var kptfileTemplate = `apiVersion: kpt.dev/v1alpha2
 kind: Kptfile
 metadata:
   name: {{.PkgName}}
 {{- if .Pkg.Kptfile.Upstream }}
 upstream:
   type: git
-  updateStrategy: {{.Pkg.Kptfile.Upstream.Strategy}}
   git:
+    repo: {{.Pkg.Kptfile.Upstream.Repo}}
     directory: {{.Pkg.Kptfile.Upstream.Dir}}
     ref: {{.Pkg.Kptfile.Upstream.Ref}}
-    repo: {{.Pkg.Kptfile.Upstream.Repo}}
+  updateStrategy: {{.Pkg.Kptfile.Upstream.Strategy}}
 {{- end }}
 {{- if .Pkg.Kptfile.UpstreamLock }}
 upstreamLock:
   type: git
   git:
-    commit: {{.Pkg.Kptfile.UpstreamLock.Commit}}
+    repo: {{.Pkg.Kptfile.UpstreamLock.Repo}}
     directory: {{.Pkg.Kptfile.UpstreamLock.Dir}}
     ref: {{.Pkg.Kptfile.UpstreamLock.Ref}}
-    repo: {{.Pkg.Kptfile.UpstreamLock.Repo}}
+    commit: {{.Pkg.Kptfile.UpstreamLock.Commit}}
 {{- end }}
 {{- if .Pkg.Kptfile.Pipeline }}
 pipeline:

--- a/internal/util/pkgutil/pkgutil.go
+++ b/internal/util/pkgutil/pkgutil.go
@@ -239,9 +239,16 @@ func RootPkgFirstSorter(paths []string) func(i, j int) bool {
 		if jPath == "." {
 			return false
 		}
+		// First sort based on the number of segments.
+		// TODO: Verify whether this works on Windows. It looks like it
+		// probably wont.
 		iSegmentCount := len(strings.Split(iPath, "/"))
 		jSegmentCount := len(strings.Split(jPath, "/"))
-		return iSegmentCount < jSegmentCount
+		if jSegmentCount != iSegmentCount {
+			return iSegmentCount < jSegmentCount
+		}
+		// If two paths are at the same depth, just sort lexicographically.
+		return iPath < jPath
 	}
 }
 


### PR DESCRIPTION
This PR fixes a corner case that is not handled correctly. If the upstream package contains an unfetched subpackage, it will be fetched when the package is cloned (so similar to how `sync` works in old kpt). If this package is later deleted from upstream, it should only be deleted from local if there are no local changes. Currently this doesn't work correctly, since the package in origin will be unfetched and therefore running the diff will always show changes. With this change, the update logic will fetch the full package for origin before doing a diff.

Fixes: https://github.com/GoogleContainerTools/kpt/issues/2216

Must merge after https://github.com/GoogleContainerTools/kpt/pull/2217