### PR TITLE
Add OCI Lock Support

### DIFF
--- a/pkg/api/kptfile/v1/types.go
+++ b/pkg/api/kptfile/v1/types.go
@@ -49,6 +49,9 @@ type KptFile struct {
 	// UpstreamLock is a resolved locator for the last fetch of the package.
 	UpstreamLock *UpstreamLock `yaml:"upstreamLock,omitempty" json:"upstreamLock,omitempty"`
 
+	// Origin is a resolved locator for the last pull or push of the package.
+	Origin *Origin `yaml:"origin,omitempty" json:"origin,omitempty"`
+
 	// Info contains metadata such as license, documentation, etc.
 	Info *PackageInfo `yaml:"info,omitempty" json:"info,omitempty"`
 
@@ -65,6 +68,9 @@ type OriginType string
 const (
 	// GitOrigin specifies a package as having been cloned from a git repository.
 	GitOrigin OriginType = "git"
+
+	// OciOrigin specifies a package as having been pulled from an OCI image repository.
+	OciOrigin OriginType = "oci"
 )
 
 // UpdateStrategyType defines the strategy for updating a package from upstream.
@@ -121,6 +127,9 @@ type Upstream struct {
 	// Git is the locator for a package stored on Git.
 	Git *Git `yaml:"git,omitempty" json:"git,omitempty"`
 
+	// Oci is the locator for a package stored in an OCI image registry.
+	Oci *Oci `yaml:"oci,omitempty" json:"oci,omitempty"`
+
 	// UpdateStrategy declares how a package will be updated from upstream.
 	UpdateStrategy UpdateStrategyType `yaml:"updateStrategy,omitempty" json:"updateStrategy,omitempty"`
 }
@@ -139,6 +148,16 @@ type Git struct {
 	Ref string `yaml:"ref,omitempty" json:"ref,omitempty"`
 }
 
+// Oci is the user-specified locator for a package in an OCI image registry.
+type Oci struct {
+	// Image is the OCI image repository for the package.
+	// e.g. 'LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/app-frontend:latest'
+	Image string `yaml:"image,omitempty" json:"image,omitempty"`
+
+	// Directory is the sub-package of the image.
+	Directory string `yaml:"directory,omitempty" json:"directory,omitempty"`
+}
+
 // UpstreamLock is a resolved locator for the last fetch of the package.
 type UpstreamLock struct {
 	// Type is the type of origin.
@@ -146,6 +165,21 @@ type UpstreamLock struct {
 
 	// Git is the resolved locator for a package on Git.
 	Git *GitLock `yaml:"git,omitempty" json:"git,omitempty"`
+
+	// Oci is the resolved locator for a package in an OCI image registry.
+	Oci *OciLock `yaml:"oci,omitempty" json:"oci,omitempty"`
+}
+
+// Origin is a resolved locator when the package was last pulled or pushed.
+type Origin struct {
+	// Type is the type of origin.
+	Type OriginType `yaml:"type,omitempty" json:"type,omitempty"`
+
+	// Git is the resolved locator for a package on Git.
+	Git *GitLock `yaml:"git,omitempty" json:"git,omitempty"`
+
+	// Oci is the resolved locator for a package in an OCI image registry.
+	Oci *OciLock `yaml:"oci,omitempty" json:"oci,omitempty"`
 }
 
 // GitLock is the resolved locator for a package on Git.
@@ -165,6 +199,19 @@ type GitLock struct {
 	// Commit is the SHA-1 for the last fetch of the package.
 	// This is set by kpt for bookkeeping purposes.
 	Commit string `yaml:"commit,omitempty" json:"commit,omitempty"`
+}
+
+// OciLock is the resolved locator for a package in an OCI image registry.
+type OciLock struct {
+	// Image is the OCI image repository for the package.
+	// e.g. 'LOCATION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/app-frontend@sha256:b0c94f11d856e59673daca566857a7ead126ef8e2b6915ed662804f858d7eaea'
+	Image string `yaml:"image,omitempty" json:"image,omitempty"`
+
+	// Directory is the sub-package of the image.
+	Directory string `yaml:"directory,omitempty" json:"directory,omitempty"`
+
+	// Digest is the unique sha of the image when it was last pulled.
+	Digest string `yaml:"digest,omitempty" json:"digest,omitempty"`
 }
 
 // PackageInfo contains optional information about the package such as license, documentation, etc.

--- a/porch/pkg/oci/oci.go
+++ b/porch/pkg/oci/oci.go
@@ -386,7 +386,20 @@ func (p *ociPackageRevision) GetPackageRevision() *v1alpha1.PackageRevision {
 }
 
 func (p *ociPackageRevision) GetUpstreamLock() (kptfile.Upstream, kptfile.UpstreamLock, error) {
-	return kptfile.Upstream{}, kptfile.UpstreamLock{}, fmt.Errorf("UpstreamLock is not supported for OCI packages (%s)", p.KubeObjectName())
+	return kptfile.Upstream{
+			Type: kptfile.OciOrigin,
+			Oci: &kptfile.Oci{
+				Image:     p.digestName.Image,
+				Directory: p.packageName,
+			},
+		}, kptfile.UpstreamLock{
+			Type: kptfile.OciOrigin,
+			Oci: &kptfile.OciLock{
+				Image:     p.digestName.Image,
+				Directory: p.packageName,
+				Digest:    p.digestName.String(),
+			},
+		}, nil
 }
 
 func (p *ociPackageRevision) Lifecycle() v1alpha1.PackageRevisionLifecycle {


### PR DESCRIPTION
Include OCI upstream lock in Kptfile schema.
Implement OCI lock support in OCI repository adapter.
