### PR TITLE
fix: issues with the given samples

### DIFF
--- a/site/book/05-developing-functions/02-developing-in-Go.md
+++ b/site/book/05-developing-functions/02-developing-in-Go.md
@@ -32,7 +32,7 @@ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-sdk.git/go/get
 cd ${FUNCTION_NAME}
 
 # Initialize the Go module
-go mod init
+go mod init kpt-fn/set-annotation
 go mod tidy
 ```
 
@@ -78,7 +78,7 @@ adds the annotation. After the iteration, it adds some user message to the `Reso
 ```go
 func Run(rl *fn.ResourceList) (bool, error) {
     for _, kubeObject := range rl.Items {
-        if kubeObject.IsGVK("apps/v1", "Deployment") {
+        if kubeObject.IsGVK("apps", "v1", "Deployment") {
             kubeObject.SetAnnotation("config.kubernetes.io/managed-by", "kpt")
         }
     }


### PR DESCRIPTION
- Running `go mod init` without. a module name throws an error
- The `kubeObject.IsGVK` function has three arguments `group, version, kind string`

