### PR TITLE
Disable APF

### DIFF
--- a/porch/deployments/porch/3-porch-server.yaml
+++ b/porch/deployments/porch/3-porch-server.yaml
@@ -73,7 +73,7 @@ spec:
             - --cache-directory=/cache
             - --cert-dir=/tmp/certs
             - --secure-port=4443
-
+            - --feature-gates=APIPriorityAndFairness=false
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Fixes #4023 

The upstream bug is currently patched in kubernetes/kubernetes but has not been cherry-picked to release branches. We can try re-enabling this after that is done or we have upgraded to the 1.29 packages. Given that Porch is an aggregated API server, it may be that APF in the primary API server already protects Porch, but that has not been verified.
