### PR TITLE
Switch porch-server to use distroless image

### DIFF
--- a/porch/build/Dockerfile.porch
+++ b/porch/build/Dockerfile.porch
@@ -31,6 +31,7 @@ RUN echo "Downloading porch modules ..." \
 RUN echo "Downloading api modules ..." \
  && cd porch/api && go mod download
 
+ENV CGO_ENABLED=0
 # Prebuild some library dependencies to warm the cache
 RUN cd porch; go build -v \
   google.golang.org/grpc \
@@ -53,15 +54,7 @@ COPY porch/func porch/func
 
 RUN cd porch; go build -v -o /porch ./cmd/porch
 
-FROM debian:bookworm-slim
-RUN apt update && apt install -y ca-certificates && apt install -y git && rm -rf /var/lib/apt && rm -rf /var/cache/apt
-
-RUN useradd -s /bin/bash -d /home/porch/ -m -u 1999 porch
-WORKDIR /home/porch
-
-COPY --from=builder /porch /home/porch/porch
-RUN chown porch:porch /home/porch/porch; chmod +x /home/porch/porch
-
-USER porch
-
-ENTRYPOINT ["/home/porch/porch"]
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder --chown=nonroot:nonroot /porch /home/nonroot/porch
+USER nonroot:nonroot
+ENTRYPOINT ["/home/nonroot/porch"]


### PR DESCRIPTION
The debian:bookworm-slim has several vulnerabilities. This switches to use a distroless image.