### PR TITLE
[WIP] Prevent runaway memory consumption

### DIFF
--- a/porch/pkg/cache/cache.go
+++ b/porch/pkg/cache/cache.go
@@ -53,7 +53,7 @@ type Cache struct {
 }
 
 type objectNotifier interface {
-	NotifyPackageRevisionChange(eventType watch.EventType, obj repository.PackageRevision, objMeta meta.PackageRevisionMeta)
+	NotifyPackageRevisionChange(eventType watch.EventType, obj repository.PackageRevision, objMeta meta.PackageRevisionMeta) int
 }
 
 type CacheOptions struct {

--- a/porch/pkg/cache/fake/objectnotifier.go
+++ b/porch/pkg/cache/fake/objectnotifier.go
@@ -22,5 +22,6 @@ import (
 
 type ObjectNotifier struct{}
 
-func (o *ObjectNotifier) NotifyPackageRevisionChange(watch.EventType, repository.PackageRevision, meta.PackageRevisionMeta) {
+func (o *ObjectNotifier) NotifyPackageRevisionChange(watch.EventType, repository.PackageRevision, meta.PackageRevisionMeta) int {
+	return 0
 }

--- a/porch/pkg/cache/repository.go
+++ b/porch/pkg/cache/repository.go
@@ -355,7 +355,8 @@ func (r *cachedRepository) pollForever(ctx context.Context) {
 }
 
 func (r *cachedRepository) pollOnce(ctx context.Context) {
-	klog.Infof("repo %s: background-refreshing", r.id)
+	start := time.Now()
+	klog.Infof("repo %s: poll start", r.id)
 	ctx, span := tracer.Start(ctx, "Repository::pollOnce", trace.WithAttributes())
 	defer span.End()
 
@@ -369,6 +370,8 @@ func (r *cachedRepository) pollOnce(ctx context.Context) {
 	if _, err := r.getFunctions(ctx, true); err != nil {
 		klog.Warningf("error polling repo functions %s: %v", r.id, err)
 	}
+
+	klog.Infof("repo %s: poll finish in %f secs", r.id, time.Since(start).Seconds())
 }
 
 func (r *cachedRepository) flush() {

--- a/porch/pkg/engine/engine.go
+++ b/porch/pkg/engine/engine.go
@@ -342,7 +342,8 @@ func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *
 	if err != nil {
 		return nil, err
 	}
-	cad.watcherManager.NotifyPackageRevisionChange(watch.Added, repoPkgRev, pkgRevMeta)
+	sent := cad.watcherManager.NotifyPackageRevisionChange(watch.Added, repoPkgRev, pkgRevMeta)
+	klog.Infof("engine: sent %d for new PackageRevision %s/%s", sent, repoPkgRev.KubeObjectNamespace(), repoPkgRev.KubeObjectName())
 	return &PackageRevision{
 		repoPackageRevision: repoPkgRev,
 		packageRevisionMeta: pkgRevMeta,
@@ -576,7 +577,8 @@ func (cad *cadEngine) UpdatePackageRevision(ctx context.Context, repositoryObj *
 			return nil, err
 		}
 
-		cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, repoPkgRev, pkgRevMeta)
+		sent := cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, repoPkgRev, pkgRevMeta)
+		klog.Infof("engine: sent %d for updated PackageRevision metadata %s/%s", sent, repoPkgRev.KubeObjectNamespace(), repoPkgRev.KubeObjectName())
 		return ToPackageRevision(repoPkgRev, pkgRevMeta), nil
 	}
 	switch lifecycle := newObj.Spec.Lifecycle; lifecycle {
@@ -601,7 +603,8 @@ func (cad *cadEngine) UpdatePackageRevision(ctx context.Context, repositoryObj *
 			return nil, err
 		}
 
-		cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, repoPkgRev, pkgRevMeta)
+		sent := cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, repoPkgRev, pkgRevMeta)
+		klog.Infof("engine: sent %d for reclone and replay PackageRevision %s/%s", sent, repoPkgRev.KubeObjectNamespace(), repoPkgRev.KubeObjectName())
 		return ToPackageRevision(repoPkgRev, pkgRevMeta), nil
 	}
 
@@ -701,7 +704,8 @@ func (cad *cadEngine) UpdatePackageRevision(ctx context.Context, repositoryObj *
 		return nil, err
 	}
 
-	cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, repoPkgRev, pkgRevMeta)
+	sent := cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, repoPkgRev, pkgRevMeta)
+	klog.Infof("engine: sent %d for updated PackageRevision %s/%s", sent, repoPkgRev.KubeObjectNamespace(), repoPkgRev.KubeObjectName())
 	return ToPackageRevision(repoPkgRev, pkgRevMeta), nil
 }
 
@@ -851,7 +855,8 @@ func (cad *cadEngine) DeletePackageRevision(ctx context.Context, repositoryObj *
 
 	if len(pkgRevMeta.Finalizers) > 0 {
 		klog.Infof("PackageRevision %s deleted, but still have finalizers: %s", oldPackage.KubeObjectName(), strings.Join(pkgRevMeta.Finalizers, ","))
-		cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, oldPackage.repoPackageRevision, oldPackage.packageRevisionMeta)
+		sent := cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, oldPackage.repoPackageRevision, oldPackage.packageRevisionMeta)
+		klog.Infof("engine: sent %d modified for deleted PackageRevision %s/%s with finalizers", sent, oldPackage.repoPackageRevision.KubeObjectNamespace(), oldPackage.KubeObjectName())
 		return nil
 	}
 	klog.Infof("PackageRevision %s deleted for real since no finalizers", oldPackage.KubeObjectName())
@@ -876,7 +881,8 @@ func (cad *cadEngine) deletePackageRevision(ctx context.Context, repo repository
 		klog.Warningf("Error deleting PkgRevMeta %s: %v", nn.String(), err)
 	}
 
-	cad.watcherManager.NotifyPackageRevisionChange(watch.Deleted, repoPkgRev, pkgRevMeta)
+	sent := cad.watcherManager.NotifyPackageRevisionChange(watch.Deleted, repoPkgRev, pkgRevMeta)
+	klog.Infof("engine: sent %d for deleted PackageRevision %s/%s", sent, repoPkgRev.KubeObjectNamespace(), repoPkgRev.KubeObjectName())
 	return nil
 }
 

--- a/porch/pkg/engine/watchermanager.go
+++ b/porch/pkg/engine/watchermanager.go
@@ -89,10 +89,11 @@ func (r *watcherManager) WatchPackageRevisions(ctx context.Context, filter repos
 }
 
 // notifyPackageRevisionChange is called to send a change notification to all interested listeners.
-func (r *watcherManager) NotifyPackageRevisionChange(eventType watch.EventType, obj repository.PackageRevision, objMeta meta.PackageRevisionMeta) {
+func (r *watcherManager) NotifyPackageRevisionChange(eventType watch.EventType, obj repository.PackageRevision, objMeta meta.PackageRevisionMeta) int {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
+	sent := 0
 	for i, watcher := range r.watchers {
 		if watcher == nil {
 			continue
@@ -106,5 +107,8 @@ func (r *watcherManager) NotifyPackageRevisionChange(eventType watch.EventType, 
 			klog.Infof("stopping watcher in response to !keepGoing")
 			r.watchers[i] = nil
 		}
+		sent += 1
 	}
+
+	return sent
 }

--- a/porch/pkg/git/git.go
+++ b/porch/pkg/git/git.go
@@ -1647,7 +1647,9 @@ func (r *gitRepository) discoverPackagesInTree(commit *object.Commit, opt Discov
 		return nil, err
 	}
 
-	klog.V(2).Infof("discovered packages @%v with prefix %q: %#v", commit.Hash, opt.FilterPrefix, t.packages)
+	if opt.FilterPrefix == "" {
+		klog.Infof("discovered %d packages @%v", len(t.packages), commit.Hash)
+	}
 	return t, nil
 }
 

--- a/porch/pkg/git/package_tree.go
+++ b/porch/pkg/git/package_tree.go
@@ -122,7 +122,6 @@ type DiscoverPackagesOptions struct {
 // discoverPackages is the recursive function we use to traverse the tree and find packages.
 // tree is the git-tree we are search, treePath is the repo-relative-path to tree.
 func (t *packageList) discoverPackages(tree *object.Tree, treePath string, recurse bool) error {
-	found := 0
 	for _, e := range tree.Entries {
 		if e.Name == "Kptfile" {
 			p := path.Join(treePath, e.Name)
@@ -132,7 +131,6 @@ func (t *packageList) discoverPackages(tree *object.Tree, treePath string, recur
 			}
 
 			// Found a package
-			found += 1
 			t.packages[treePath] = &packageListEntry{
 				path:     treePath,
 				treeHash: tree.Hash,
@@ -140,8 +138,6 @@ func (t *packageList) discoverPackages(tree *object.Tree, treePath string, recur
 			}
 		}
 	}
-
-	klog.Infof("discoveryPackages in %s found %d valid package Kptfiles", treePath, found)
 
 	if recurse {
 		for _, e := range tree.Entries {

--- a/porch/pkg/git/package_tree.go
+++ b/porch/pkg/git/package_tree.go
@@ -122,6 +122,7 @@ type DiscoverPackagesOptions struct {
 // discoverPackages is the recursive function we use to traverse the tree and find packages.
 // tree is the git-tree we are search, treePath is the repo-relative-path to tree.
 func (t *packageList) discoverPackages(tree *object.Tree, treePath string, recurse bool) error {
+	found := 0
 	for _, e := range tree.Entries {
 		if e.Name == "Kptfile" {
 			p := path.Join(treePath, e.Name)
@@ -131,7 +132,7 @@ func (t *packageList) discoverPackages(tree *object.Tree, treePath string, recur
 			}
 
 			// Found a package
-			klog.Infof("found package %q with Kptfile hash %q", p, e.Hash)
+			found += 1
 			t.packages[treePath] = &packageListEntry{
 				path:     treePath,
 				treeHash: tree.Hash,
@@ -139,6 +140,8 @@ func (t *packageList) discoverPackages(tree *object.Tree, treePath string, recur
 			}
 		}
 	}
+
+	klog.Infof("discoveryPackages in %s found %d valid package Kptfiles", treePath, found)
 
 	if recurse {
 		for _, e := range tree.Entries {

--- a/porch/pkg/registry/porch/watch.go
+++ b/porch/pkg/registry/porch/watch.go
@@ -235,7 +235,6 @@ func (w *watcher) listAndWatchInner(ctx context.Context, r packageReader, filter
 
 func (w *watcher) sendWatchEvent(ev watch.Event) {
 	// TODO: Handle the case that the watch channel is full?
-	klog.Infof("sending watch event %v", ev)
 	w.resultChan <- ev
 }
 


### PR DESCRIPTION
Fixes #4023

- Abort a poll of a repository if one is already in progress. Previously, these would build up, with a new poll starting every minute for each repository. If they took longer than a minute, they would accumulate and overwhelm them system.
- Use package revision ResourceVersion to avoid sending unnecessary watch updates for package revisions.
- Reduce noisy logging.
- Not clear this fixes the root cause, but it likely will fix the periodic failures.