### PR TITLE
Reduce watch updates

### DIFF
--- a/porch/pkg/cache/cache.go
+++ b/porch/pkg/cache/cache.go
@@ -53,7 +53,7 @@ type Cache struct {
 }
 
 type objectNotifier interface {
-	NotifyPackageRevisionChange(eventType watch.EventType, obj repository.PackageRevision, objMeta meta.PackageRevisionMeta)
+	NotifyPackageRevisionChange(eventType watch.EventType, obj repository.PackageRevision, objMeta meta.PackageRevisionMeta) int
 }
 
 type CacheOptions struct {

--- a/porch/pkg/cache/fake/objectnotifier.go
+++ b/porch/pkg/cache/fake/objectnotifier.go
@@ -22,5 +22,6 @@ import (
 
 type ObjectNotifier struct{}
 
-func (o *ObjectNotifier) NotifyPackageRevisionChange(watch.EventType, repository.PackageRevision, meta.PackageRevisionMeta) {
+func (o *ObjectNotifier) NotifyPackageRevisionChange(watch.EventType, repository.PackageRevision, meta.PackageRevisionMeta) int {
+	return 0
 }

--- a/porch/pkg/cache/repository.go
+++ b/porch/pkg/cache/repository.go
@@ -311,6 +311,7 @@ func (r *cachedRepository) Close() error {
 
 	// Make sure that watch events are sent for packagerevisions that are
 	// removed as part of closing the repository.
+	sent := 0
 	for _, pr := range r.cachedPackageRevisions {
 		nn := types.NamespacedName{
 			Name:      pr.KubeObjectName(),
@@ -319,7 +320,7 @@ func (r *cachedRepository) Close() error {
 		// There isn't really any correct way to handle finalizers here. We are removing
 		// the repository, so we have to just delete the PackageRevision regardless of any
 		// finalizers.
-		klog.Infof("Deleting packagerev %s/%s because repository is closed", nn.Namespace, nn.Name)
+		klog.Infof("repo %s: deleting packagerev %s/%s because repository is closed", r.id, nn.Namespace, nn.Name)
 		pkgRevMeta, err := r.metadataStore.Delete(context.TODO(), nn, true)
 		if err != nil {
 			// There isn't much use in returning an error here, so we just log it
@@ -331,8 +332,9 @@ func (r *cachedRepository) Close() error {
 				Namespace: nn.Namespace,
 			}
 		}
-		r.objectNotifier.NotifyPackageRevisionChange(watch.Deleted, pr, pkgRevMeta)
+		sent += r.objectNotifier.NotifyPackageRevisionChange(watch.Deleted, pr, pkgRevMeta)
 	}
+	klog.Infof("repo %s: sent %d notifications for %d package revisions during close", r.id, sent, len(r.cachedPackageRevisions))
 	return r.repo.Close()
 }
 
@@ -346,14 +348,14 @@ func (r *cachedRepository) pollForever(ctx context.Context) {
 			r.pollOnce(ctx)
 
 		case <-ctx.Done():
-			klog.V(2).Infof("exiting repository poller, because context is done: %v", ctx.Err())
+			klog.V(2).Infof("repo %s: exiting repository poller, because context is done: %v", r.id, ctx.Err())
 			return
 		}
 	}
 }
 
 func (r *cachedRepository) pollOnce(ctx context.Context) {
-	klog.Infof("background-refreshing repo %q", r.id)
+	klog.Infof("repo %s: background-refreshing", r.id)
 	ctx, span := tracer.Start(ctx, "Repository::pollOnce", trace.WithAttributes())
 	defer span.End()
 
@@ -384,6 +386,9 @@ func (r *cachedRepository) refreshAllCachedPackages(ctx context.Context) (map[re
 	// TODO: Avoid simultaneous fetches?
 	// TODO: Push-down partial refresh?
 
+	klog.Infof("repo %s: start refreshAll", r.id)
+	defer klog.Infof("repo %s: finish refreshAll", r.id)
+
 	// Look up all existing PackageRevCRs so we an compare those to the
 	// actual Packagerevisions found in git/oci, and add/prune PackageRevCRs
 	// as necessary.
@@ -406,12 +411,10 @@ func (r *cachedRepository) refreshAllCachedPackages(ctx context.Context) (map[re
 
 	// Build mapping from kubeObjectName to PackageRevisions for new PackageRevisions.
 	newPackageRevisionNames := make(map[string]*cachedPackageRevision, len(newPackageRevisions))
-	klog.Infof("New packages:")
 	for _, newPackage := range newPackageRevisions {
-		klog.Infof("- %s", newPackage.KubeObjectName())
 		kname := newPackage.KubeObjectName()
 		if newPackageRevisionNames[kname] != nil {
-			klog.Warningf("found duplicate packages with name %v", kname)
+			klog.Warningf("repo %s: found duplicate packages with name %v", kname)
 		}
 
 		pkgRev := &cachedPackageRevision{
@@ -432,16 +435,16 @@ func (r *cachedRepository) refreshAllCachedPackages(ctx context.Context) (map[re
 	// PackageRevision. The ones that doesn't is removed.
 	for _, prm := range existingPkgRevCRs {
 		if _, found := newPackageRevisionNames[prm.Name]; !found {
-			klog.Infof("Deleting PackageRev %s/%s because parent PackageRevision was not found",
-				prm.Namespace, prm.Name)
+			klog.Infof("repo %s: deleting PackageRev %s/%s because parent PackageRevision was not found",
+				r.id, prm.Namespace, prm.Name)
 			if _, err := r.metadataStore.Delete(ctx, types.NamespacedName{
 				Name:      prm.Name,
 				Namespace: prm.Namespace,
 			}, true); err != nil {
 				if !apierrors.IsNotFound(err) {
 					// This will be retried the next time the sync runs.
-					klog.Warningf("unable to delete PackageRev CR for %s/%s: %w",
-						prm.Name, prm.Namespace, err)
+					klog.Warningf("repo %s: unable to delete PackageRev CR for %s/%s: %w",
+						r.id, prm.Name, prm.Namespace, err)
 				}
 			}
 		}
@@ -466,6 +469,8 @@ func (r *cachedRepository) refreshAllCachedPackages(ctx context.Context) (map[re
 	}
 
 	// Send notification for packages that changed.
+	addSent := 0
+	modSent := 0
 	for kname, newPackage := range newPackageRevisionNames {
 		oldPackage := oldPackageRevisionNames[kname]
 		metaPackage, found := existingPkgRevCRsMap[newPackage.KubeObjectName()]
@@ -473,14 +478,14 @@ func (r *cachedRepository) refreshAllCachedPackages(ctx context.Context) (map[re
 			klog.Warningf("no PackageRev CR found for PackageRevision %s", newPackage.KubeObjectName())
 		}
 		if oldPackage == nil {
-			r.objectNotifier.NotifyPackageRevisionChange(watch.Added, newPackage, metaPackage)
+			addSent += r.objectNotifier.NotifyPackageRevisionChange(watch.Added, newPackage, metaPackage)
 		} else {
 			// TODO: only if changed
-			klog.Warningf("over-notifying of package updates (even on unchanged packages)")
-			r.objectNotifier.NotifyPackageRevisionChange(watch.Modified, newPackage, metaPackage)
+			modSent += r.objectNotifier.NotifyPackageRevisionChange(watch.Modified, newPackage, metaPackage)
 		}
 	}
 
+	delSent := 0
 	// Send notifications for packages that was deleted in the SoT
 	for kname, oldPackage := range oldPackageRevisionNames {
 		if newPackageRevisionNames[kname] == nil {
@@ -488,19 +493,20 @@ func (r *cachedRepository) refreshAllCachedPackages(ctx context.Context) (map[re
 				Name:      oldPackage.KubeObjectName(),
 				Namespace: oldPackage.KubeObjectNamespace(),
 			}
-			klog.Infof("Deleting PackageRev %s/%s because PackageRevision was removed from SoT",
-				nn.Namespace, nn.Name)
+			klog.Infof("repo %s: deleting PackageRev %s/%s because PackageRevision was removed from SoT",
+				r.id, nn.Namespace, nn.Name)
 			metaPackage, err := r.metadataStore.Delete(ctx, nn, true)
 			if err != nil {
-				klog.Warningf("Error deleting PkgRevMeta %s: %v")
+				klog.Warningf("repo %s: error deleting PkgRevMeta %s: %v", r.id, nn, err)
 				metaPackage = meta.PackageRevisionMeta{
 					Name:      nn.Name,
 					Namespace: nn.Namespace,
 				}
 			}
-			r.objectNotifier.NotifyPackageRevisionChange(watch.Deleted, oldPackage, metaPackage)
+			delSent += r.objectNotifier.NotifyPackageRevisionChange(watch.Deleted, oldPackage, metaPackage)
 		}
 	}
+	klog.Infof("repo %s: addSent %d, modSent %d, delSent for %d old and %d new repo packages", r.id, addSent, modSent, len(oldPackageRevisionNames), len(newPackageRevisionNames))
 
 	newPackageRevisionMap := make(map[repository.PackageRevisionKey]*cachedPackageRevision, len(newPackageRevisions))
 	for _, newPackage := range newPackageRevisions {

--- a/porch/pkg/cache/repository.go
+++ b/porch/pkg/cache/repository.go
@@ -480,8 +480,9 @@ func (r *cachedRepository) refreshAllCachedPackages(ctx context.Context) (map[re
 		if oldPackage == nil {
 			addSent += r.objectNotifier.NotifyPackageRevisionChange(watch.Added, newPackage, metaPackage)
 		} else {
-			// TODO: only if changed
-			modSent += r.objectNotifier.NotifyPackageRevisionChange(watch.Modified, newPackage, metaPackage)
+			if oldPackage.ResourceVersion() != newPackage.ResourceVersion() {
+				modSent += r.objectNotifier.NotifyPackageRevisionChange(watch.Modified, newPackage, metaPackage)
+			}
 		}
 	}
 

--- a/porch/pkg/engine/engine.go
+++ b/porch/pkg/engine/engine.go
@@ -342,7 +342,8 @@ func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *
 	if err != nil {
 		return nil, err
 	}
-	cad.watcherManager.NotifyPackageRevisionChange(watch.Added, repoPkgRev, pkgRevMeta)
+	sent := cad.watcherManager.NotifyPackageRevisionChange(watch.Added, repoPkgRev, pkgRevMeta)
+	klog.Infof("engine: sent %d for new PackageRevision %s/%s", sent, repoPkgRev.KubeObjectNamespace(), repoPkgRev.KubeObjectName())
 	return &PackageRevision{
 		repoPackageRevision: repoPkgRev,
 		packageRevisionMeta: pkgRevMeta,
@@ -576,7 +577,8 @@ func (cad *cadEngine) UpdatePackageRevision(ctx context.Context, repositoryObj *
 			return nil, err
 		}
 
-		cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, repoPkgRev, pkgRevMeta)
+		sent := cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, repoPkgRev, pkgRevMeta)
+		klog.Infof("engine: sent %d for updated PackageRevision metadata %s/%s", sent, repoPkgRev.KubeObjectNamespace(), repoPkgRev.KubeObjectName())
 		return ToPackageRevision(repoPkgRev, pkgRevMeta), nil
 	}
 	switch lifecycle := newObj.Spec.Lifecycle; lifecycle {
@@ -601,7 +603,8 @@ func (cad *cadEngine) UpdatePackageRevision(ctx context.Context, repositoryObj *
 			return nil, err
 		}
 
-		cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, repoPkgRev, pkgRevMeta)
+		sent := cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, repoPkgRev, pkgRevMeta)
+		klog.Infof("engine: sent %d for reclone and replay PackageRevision %s/%s", sent, repoPkgRev.KubeObjectNamespace(), repoPkgRev.KubeObjectName())
 		return ToPackageRevision(repoPkgRev, pkgRevMeta), nil
 	}
 
@@ -701,7 +704,8 @@ func (cad *cadEngine) UpdatePackageRevision(ctx context.Context, repositoryObj *
 		return nil, err
 	}
 
-	cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, repoPkgRev, pkgRevMeta)
+	sent := cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, repoPkgRev, pkgRevMeta)
+	klog.Infof("engine: sent %d for updated PackageRevision %s/%s", sent, repoPkgRev.KubeObjectNamespace(), repoPkgRev.KubeObjectName())
 	return ToPackageRevision(repoPkgRev, pkgRevMeta), nil
 }
 
@@ -851,7 +855,8 @@ func (cad *cadEngine) DeletePackageRevision(ctx context.Context, repositoryObj *
 
 	if len(pkgRevMeta.Finalizers) > 0 {
 		klog.Infof("PackageRevision %s deleted, but still have finalizers: %s", oldPackage.KubeObjectName(), strings.Join(pkgRevMeta.Finalizers, ","))
-		cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, oldPackage.repoPackageRevision, oldPackage.packageRevisionMeta)
+		sent := cad.watcherManager.NotifyPackageRevisionChange(watch.Modified, oldPackage.repoPackageRevision, oldPackage.packageRevisionMeta)
+		klog.Infof("engine: sent %d modified for deleted PackageRevision %s/%s with finalizers", sent, oldPackage.repoPackageRevision.KubeObjectNamespace(), oldPackage.KubeObjectName())
 		return nil
 	}
 	klog.Infof("PackageRevision %s deleted for real since no finalizers", oldPackage.KubeObjectName())
@@ -876,7 +881,8 @@ func (cad *cadEngine) deletePackageRevision(ctx context.Context, repo repository
 		klog.Warningf("Error deleting PkgRevMeta %s: %v", nn.String(), err)
 	}
 
-	cad.watcherManager.NotifyPackageRevisionChange(watch.Deleted, repoPkgRev, pkgRevMeta)
+	sent := cad.watcherManager.NotifyPackageRevisionChange(watch.Deleted, repoPkgRev, pkgRevMeta)
+	klog.Infof("engine: sent %d for deleted PackageRevision %s/%s", sent, repoPkgRev.KubeObjectNamespace(), repoPkgRev.KubeObjectName())
 	return nil
 }
 

--- a/porch/pkg/engine/fake/packagerevision.go
+++ b/porch/pkg/engine/fake/packagerevision.go
@@ -47,6 +47,10 @@ func (pr *PackageRevision) UID() types.UID {
 	return pr.Uid
 }
 
+func (pr *PackageRevision) ResourceVersion() string {
+	return pr.PackageRevision.ResourceVersion
+}
+
 func (pr *PackageRevision) Key() repository.PackageRevisionKey {
 	return pr.PackageRevisionKey
 }

--- a/porch/pkg/engine/watchermanager.go
+++ b/porch/pkg/engine/watchermanager.go
@@ -89,10 +89,11 @@ func (r *watcherManager) WatchPackageRevisions(ctx context.Context, filter repos
 }
 
 // notifyPackageRevisionChange is called to send a change notification to all interested listeners.
-func (r *watcherManager) NotifyPackageRevisionChange(eventType watch.EventType, obj repository.PackageRevision, objMeta meta.PackageRevisionMeta) {
+func (r *watcherManager) NotifyPackageRevisionChange(eventType watch.EventType, obj repository.PackageRevision, objMeta meta.PackageRevisionMeta) int {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
+	sent := 0
 	for i, watcher := range r.watchers {
 		if watcher == nil {
 			continue
@@ -106,5 +107,8 @@ func (r *watcherManager) NotifyPackageRevisionChange(eventType watch.EventType, 
 			klog.Infof("stopping watcher in response to !keepGoing")
 			r.watchers[i] = nil
 		}
+		sent += 1
 	}
+
+	return sent
 }

--- a/porch/pkg/git/git.go
+++ b/porch/pkg/git/git.go
@@ -1658,7 +1658,9 @@ func (r *gitRepository) discoverPackagesInTree(commit *object.Commit, opt Discov
 		return nil, err
 	}
 
-	klog.V(2).Infof("discovered packages @%v with prefix %q: %#v", commit.Hash, opt.FilterPrefix, t.packages)
+	if opt.FilterPrefix == "" {
+		klog.Infof("discovered %d packages @%v", len(t.packages), commit.Hash)
+	}
 	return t, nil
 }
 

--- a/porch/pkg/git/package.go
+++ b/porch/pkg/git/package.go
@@ -78,6 +78,10 @@ func (p *gitPackageRevision) UID() types.UID {
 	return p.uid()
 }
 
+func (p *gitPackageRevision) ResourceVersion() string {
+	return p.commit.String()
+}
+
 func (p *gitPackageRevision) Key() repository.PackageRevisionKey {
 	// if the repository has been registered with a directory, then the
 	// package name is the package path relative to the registered directory

--- a/porch/pkg/git/package_tree.go
+++ b/porch/pkg/git/package_tree.go
@@ -122,7 +122,6 @@ type DiscoverPackagesOptions struct {
 // discoverPackages is the recursive function we use to traverse the tree and find packages.
 // tree is the git-tree we are search, treePath is the repo-relative-path to tree.
 func (t *packageList) discoverPackages(tree *object.Tree, treePath string, recurse bool) error {
-	found := 0
 	for _, e := range tree.Entries {
 		if e.Name == "Kptfile" {
 			p := path.Join(treePath, e.Name)
@@ -132,7 +131,6 @@ func (t *packageList) discoverPackages(tree *object.Tree, treePath string, recur
 			}
 
 			// Found a package
-			found += 1
 			t.packages[treePath] = &packageListEntry{
 				path:     treePath,
 				treeHash: tree.Hash,
@@ -140,8 +138,6 @@ func (t *packageList) discoverPackages(tree *object.Tree, treePath string, recur
 			}
 		}
 	}
-
-	klog.Infof("discoveryPackages in %s found %d valid package Kptfiles", treePath, found)
 
 	if recurse {
 		for _, e := range tree.Entries {

--- a/porch/pkg/git/package_tree.go
+++ b/porch/pkg/git/package_tree.go
@@ -122,6 +122,7 @@ type DiscoverPackagesOptions struct {
 // discoverPackages is the recursive function we use to traverse the tree and find packages.
 // tree is the git-tree we are search, treePath is the repo-relative-path to tree.
 func (t *packageList) discoverPackages(tree *object.Tree, treePath string, recurse bool) error {
+	found := 0
 	for _, e := range tree.Entries {
 		if e.Name == "Kptfile" {
 			p := path.Join(treePath, e.Name)
@@ -131,7 +132,7 @@ func (t *packageList) discoverPackages(tree *object.Tree, treePath string, recur
 			}
 
 			// Found a package
-			klog.Infof("found package %q with Kptfile hash %q", p, e.Hash)
+			found += 1
 			t.packages[treePath] = &packageListEntry{
 				path:     treePath,
 				treeHash: tree.Hash,
@@ -139,6 +140,8 @@ func (t *packageList) discoverPackages(tree *object.Tree, treePath string, recur
 			}
 		}
 	}
+
+	klog.Infof("discoveryPackages in %s found %d valid package Kptfiles", treePath, found)
 
 	if recurse {
 		for _, e := range tree.Entries {

--- a/porch/pkg/oci/oci.go
+++ b/porch/pkg/oci/oci.go
@@ -395,6 +395,10 @@ func (p *ociPackageRevision) UID() types.UID {
 	return p.uid
 }
 
+func (p *ociPackageRevision) ResourceVersion() string {
+	return p.resourceVersion
+}
+
 func (p *ociPackageRevision) Key() repository.PackageRevisionKey {
 	return repository.PackageRevisionKey{
 		Repository:    p.parent.name,

--- a/porch/pkg/registry/porch/watch.go
+++ b/porch/pkg/registry/porch/watch.go
@@ -235,7 +235,6 @@ func (w *watcher) listAndWatchInner(ctx context.Context, r packageReader, filter
 
 func (w *watcher) sendWatchEvent(ev watch.Event) {
 	// TODO: Handle the case that the watch channel is full?
-	klog.Infof("sending watch event %v", ev)
 	w.resultChan <- ev
 }
 

--- a/porch/pkg/repository/repository.go
+++ b/porch/pkg/repository/repository.go
@@ -91,6 +91,9 @@ type PackageRevision interface {
 	// GetLock returns the current revision's lock information.
 	// This will be the upstream info for downstream revisions.
 	GetLock() (kptfile.Upstream, kptfile.UpstreamLock, error)
+
+	// ResourceVersion returns the Kube resource version of the package
+	ResourceVersion() string
 }
 
 // Package is an abstract package.


### PR DESCRIPTION
Fixes #4023 

This replaces the previous PR. The fixes in here are a mitigation based on the current theory of the problem, but there are some things I am not sure about yet. I am submitting this PR so we at least have a mitigation in place, and we can continue working on the problem.

Current hypothesis:

1) Something is leaking resources such that CPU continuously increases. This PR eliminates the watch over-notification which seems to mitigate this, but this PR is not clearly a root cause fix for the CPU problem.
2) As CPU gets tight, the polling for repo cache updates takes longer and longer. At some point, it starts taking longer than one minute.
3) The ticker goes off every minute, so once we exceed one minute runs, we start to accumulate attempts at concurrent polls. There won't be concurrent polls due to the mutex, but they will back up and start to increase memory use.
4) Once enough waiting poll go routines are there, they fill up memory and it gets OOMKilled.

So, that all sounds great, except that for 3), I don't see a new go routine per tick, but rather one per "newRepository" call. So, maybe the issue is that somewhere we are re-creating repositories? Maybe the fix in #4049 is sufficient in that case. But we need a mitigation now, we can check that later.

