### PR TITLE
fix: deletionProposed branch throws error for `main` revisions

### DIFF
--- a/porch/pkg/git/git.go
+++ b/porch/pkg/git/git.go
@@ -426,7 +426,7 @@ func (r *gitRepository) DeletePackageRevision(ctx context.Context, old repositor
 		refSpecs.AddRefToDelete(ref)
 
 		// If this revision was proposed for deletion, we need to delete the associated branch.
-		if err := r.removeDeletionProposedBranchIfExists(ctx, oldGit.path, oldGit.revision, oldGit.commit); err != nil {
+		if err := r.removeDeletionProposedBranchIfExists(ctx, oldGit.path, oldGit.revision); err != nil {
 			return err
 		}
 
@@ -443,7 +443,7 @@ func (r *gitRepository) DeletePackageRevision(ctx context.Context, old repositor
 
 		// Remove the proposed for deletion branch. We end up here when users
 		// try to delete the main branch version of a packagerevision.
-		if err := r.removeDeletionProposedBranchIfExists(ctx, oldGit.path, oldGit.revision, oldGit.commit); err != nil {
+		if err := r.removeDeletionProposedBranchIfExists(ctx, oldGit.path, oldGit.revision); err != nil {
 			return err
 		}
 
@@ -461,10 +461,10 @@ func (r *gitRepository) DeletePackageRevision(ctx context.Context, old repositor
 	return nil
 }
 
-func (r *gitRepository) removeDeletionProposedBranchIfExists(ctx context.Context, path, revision string, commit plumbing.Hash) error {
+func (r *gitRepository) removeDeletionProposedBranchIfExists(ctx context.Context, path, revision string) error {
 	refSpecsForDeletionProposed := newPushRefSpecBuilder()
 	deletionProposedBranch := createDeletionProposedName(path, revision)
-	refSpecsForDeletionProposed.AddRefToDelete(plumbing.NewHashReference(deletionProposedBranch.RefInLocal(), commit))
+	refSpecsForDeletionProposed.AddRefToDelete(plumbing.NewHashReference(deletionProposedBranch.RefInLocal(), plumbing.ZeroHash))
 	if err := r.pushAndCleanup(ctx, refSpecsForDeletionProposed); err != nil {
 		if strings.HasPrefix(err.Error(),
 			fmt.Sprintf("remote ref %s%s required to be", branchPrefixInRemoteRepo, deletionProposedBranch)) &&

--- a/porch/pkg/git/git.go
+++ b/porch/pkg/git/git.go
@@ -466,13 +466,9 @@ func (r *gitRepository) removeDeletionProposedBranchIfExists(ctx context.Context
 	deletionProposedBranch := createDeletionProposedName(path, revision)
 	refSpecsForDeletionProposed.AddRefToDelete(plumbing.NewHashReference(deletionProposedBranch.RefInLocal(), plumbing.ZeroHash))
 	if err := r.pushAndCleanup(ctx, refSpecsForDeletionProposed); err != nil {
-		if strings.HasPrefix(err.Error(),
-			fmt.Sprintf("remote ref %s%s required to be", branchPrefixInRemoteRepo, deletionProposedBranch)) &&
-			strings.HasSuffix(err.Error(), "but is absent") {
-
+		if errors.Is(err, git.NoErrAlreadyUpToDate) {
 			// the deletionProposed branch might not have existed, so we ignore this error
 			klog.Warningf("branch %s does not exist", deletionProposedBranch)
-
 		} else {
 			klog.Errorf("unexpected error while removing deletionProposed branch: %v", err)
 			return err


### PR DESCRIPTION
TODO: See if I can add tests

When following these steps:
1. Create two PackageRevisions belonging to different packages in the same repo and propose and publish both.
2. Propose deletion of both "main" packagerevisions that get created.
3. Delete the first PackageRevision from "main" and wait over a minute until the sync has happened.
4. Delete the second PackageRevision from "main" and an error occurs complaining that the commit is incorrect.

The error is thrown because when we try to delete the deletionProposed branch, we are passing in the commit from the latest ref on the main branch. In our case, when we try to delete the second packagerevision, we pass in the latest commit from main which was created when the first packagerevision was deleted. This commit doesn't exist in the second deletionProposed branch because the deletion of the first packagerevision happened on the main branch after the second packagerevision was proposed for deletion. 

Since we're trying to delete the deletionProposed branch entirely and are using its existence as a boolean, I don't think we care what commit its on. We can pass in the zero-hash commit for it to delete the branch regardless of what commit its on. This makes the error go away for me locally. 



