### PR TITLE
Suppress NotFound error logging on delete calls

### DIFF
--- a/porch/pkg/cache/repository.go
+++ b/porch/pkg/cache/repository.go
@@ -499,7 +499,9 @@ func (r *cachedRepository) refreshAllCachedPackages(ctx context.Context) (map[re
 				r.id, nn.Namespace, nn.Name)
 			metaPackage, err := r.metadataStore.Delete(ctx, nn, true)
 			if err != nil {
-				klog.Warningf("repo %s: error deleting PkgRevMeta %s: %v", r.id, nn, err)
+				if !apierrors.IsNotFound(err) {
+					klog.Warningf("repo %s: error deleting PkgRevMeta %s: %v", r.id, nn, err)
+				}
 				metaPackage = meta.PackageRevisionMeta{
 					Name:      nn.Name,
 					Namespace: nn.Namespace,

--- a/porch/pkg/engine/engine.go
+++ b/porch/pkg/engine/engine.go
@@ -878,7 +878,9 @@ func (cad *cadEngine) deletePackageRevision(ctx context.Context, repo repository
 	}
 	if _, err := cad.metadataStore.Delete(ctx, nn, true); err != nil {
 		// If this fails, the CR will be cleaned up by the background job.
-		klog.Warningf("Error deleting PkgRevMeta %s: %v", nn.String(), err)
+		if !apierrors.IsNotFound(err) {
+			klog.Warningf("Error deleting PkgRevMeta %s: %v", nn.String(), err)
+		}
 	}
 
 	sent := cad.watcherManager.NotifyPackageRevisionChange(watch.Deleted, repoPkgRev, pkgRevMeta)


### PR DESCRIPTION
In some situations, Porch will attempt to delete PackageRev CRs even if they don't exist. This suppresses the logging when this happens, as it is not really an error.