### PR TITLE
porch: Fix watcher duplication bug

### DIFF
--- a/.github/workflows/porch-e2e.yml
+++ b/.github/workflows/porch-e2e.yml
@@ -53,6 +53,8 @@ jobs:
           - "kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9"
 
     steps:
+      - name: Free up disk space
+        run: sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/porch/pkg/engine/watchermanager.go
+++ b/porch/pkg/engine/watchermanager.go
@@ -71,10 +71,14 @@ func (r *watcherManager) WatchPackageRevisions(ctx context.Context, filter repos
 		filter:         filter,
 	}
 
+	active := 0
 	// See if we have an empty slot in the watchers list
 	inserted := false
 	for i, watcher := range r.watchers {
-		if watcher == nil {
+		if watcher != nil {
+			active += 1
+		} else if !inserted {
+			active += 1
 			r.watchers[i] = w
 			inserted = true
 		}
@@ -82,9 +86,11 @@ func (r *watcherManager) WatchPackageRevisions(ctx context.Context, filter repos
 
 	if !inserted {
 		// We didn't slot it in to an existing slot, append it
+		active += 1
 		r.watchers = append(r.watchers, w)
 	}
 
+	klog.Infof("added watcher %p; there are now %d active watchers and %d slots", w, active, len(r.watchers))
 	return nil
 }
 


### PR DESCRIPTION
As mentioned in #4050, it probably wasn't the root cause of the porch-server issues. It did help a lot, but after about 8 days we saw CPU spike and the API server became unavailable.

I found something curious. I noticed way way more "stopping watcher" messages than there should have been watchers. Thousands. Poking around I found something interesting. The WatcherManager maintains an array of watchers, which it sends watch events to. When one is stopped, it sets the array entry to nil, see here:

https://github.com/kptdev/kpt/blob/8b5e2f5450de1d468307d8026790914c92a25c1f/porch/pkg/engine/watchermanager.go#L97

When a new watcher is created, it goes through the array and attempts to fill an empty spot, appending if it doesn't find one. That is done in this this little gem:

https://github.com/kptdev/kpt/blob/8b5e2f5450de1d468307d8026790914c92a25c1f/porch/pkg/engine/watchermanager.go#L76

Notice what's missing in that loop? The `break` statement. Without that, this new watcher gets copied to EVERY empty spot. I suspect this is the root cause. Basically, as watchers come and go, the spots get freed, but they all get refilled immediately with duplicates. The array thus doesn't grow just to the peak number of watchers, but in fact grows continuously with at least one new entry for every two new watchers. This means that eventually the list gets full of many duplicates, so any watch event is sent a zillion times to the watchers.

Hard to say if this is the cause of the CPU spike, but it is likely. And then, I wonder if the K8s APF bug means that the API server does not recover well after the spike. But that's just speculation.

In any case, this PR should fix it. I don't `break` but instead continue looping so I can count all filled slots in the array, just to log it. An array isn't really the right data structure here...