### PR TITLE
licensescan: Add a few more licenses for recent updates

### DIFF
--- a/tools/licensescan/modules/github.com/GoogleContainerTools/kpt/(devel).yaml
+++ b/tools/licensescan/modules/github.com/GoogleContainerTools/kpt/(devel).yaml
@@ -1,4 +1,5 @@
 # https://pkg.go.dev/github.com/GoogleContainerTools/kpt@(devel)
 license: Apache-2.0
+# Specifying the licenseURL here avoids picking up the demo-magic license
 licenseURLs:
 - https://raw.githubusercontent.com/GoogleContainerTools/kpt/main/LICENSE

--- a/tools/licensescan/modules/github.com/GoogleContainerTools/kpt/v1.0.0-beta.23.0.20221117142901-c67b11f2e138.yaml
+++ b/tools/licensescan/modules/github.com/GoogleContainerTools/kpt/v1.0.0-beta.23.0.20221117142901-c67b11f2e138.yaml
@@ -1,2 +1,5 @@
 # https://pkg.go.dev/github.com/GoogleContainerTools/kpt@v1.0.0-beta.23.0.20221117142901-c67b11f2e138
 license: Apache-2.0
+# Specifying the licenseURL here avoids picking up the demo-magic license
+licenseURLs:
+- https://raw.githubusercontent.com/GoogleContainerTools/kpt/v1.0.0-beta.23/LICENSE

--- a/tools/licensescan/modules/github.com/GoogleContainerTools/kpt/v1.0.0-beta.24.yaml
+++ b/tools/licensescan/modules/github.com/GoogleContainerTools/kpt/v1.0.0-beta.24.yaml
@@ -1,2 +1,5 @@
 # https://pkg.go.dev/github.com/GoogleContainerTools/kpt@v1.0.0-beta.24
 license: Apache-2.0
+# Specifying the licenseURL here avoids picking up the demo-magic license
+licenseURLs:
+- https://raw.githubusercontent.com/GoogleContainerTools/kpt/v1.0.0-beta.24/LICENSE

--- a/tools/licensescan/modules/github.com/docker/docker/v24.0.7+incompatible.yaml
+++ b/tools/licensescan/modules/github.com/docker/docker/v24.0.7+incompatible.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/docker/docker@v24.0.7+incompatible
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/emicklei/go-restful/v2.16.0+incompatible.yaml
+++ b/tools/licensescan/modules/github.com/emicklei/go-restful/v2.16.0+incompatible.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/emicklei/go-restful@v2.16.0+incompatible
+license: MIT

--- a/tools/licensescan/modules/github.com/opencontainers/image-spec/v1.1.0-rc3.yaml
+++ b/tools/licensescan/modules/github.com/opencontainers/image-spec/v1.1.0-rc3.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/opencontainers/image-spec@v1.1.0-rc3
+license: Apache-2.0

--- a/tools/licensescan/modules/golang.org/x/crypto/v0.14.0.yaml
+++ b/tools/licensescan/modules/golang.org/x/crypto/v0.14.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/crypto@v0.14.0
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/mod/v0.8.0.yaml
+++ b/tools/licensescan/modules/golang.org/x/mod/v0.8.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/mod@v0.8.0
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/net/v0.17.0.yaml
+++ b/tools/licensescan/modules/golang.org/x/net/v0.17.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/net@v0.17.0
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/sys/v0.13.0.yaml
+++ b/tools/licensescan/modules/golang.org/x/sys/v0.13.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/sys@v0.13.0
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/term/v0.13.0.yaml
+++ b/tools/licensescan/modules/golang.org/x/term/v0.13.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/term@v0.13.0
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/text/v0.13.0.yaml
+++ b/tools/licensescan/modules/golang.org/x/text/v0.13.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/text@v0.13.0
+license: BSD-3-Clause


### PR DESCRIPTION
Also explicitly specify the license url for kpt itself, to avoid
picking up the demo-magic license.
