### PR TITLE
Do not refresh if no repo changes

### DIFF
--- a/porch/pkg/engine/fake/repository.go
+++ b/porch/pkg/engine/fake/repository.go
@@ -34,6 +34,10 @@ func (r *Repository) Close() error {
 	return nil
 }
 
+func (r *Repository) Version(ctx context.Context) (string, error) {
+	return "foo", nil
+}
+
 func (r *Repository) ListPackageRevisions(_ context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
 	var revs []repository.PackageRevision
 	for _, rev := range r.PackageRevisions {

--- a/porch/pkg/git/git.go
+++ b/porch/pkg/git/git.go
@@ -192,6 +192,8 @@ func (r *gitRepository) Close() error {
 func (r *gitRepository) Version(ctx context.Context) (string, error) {
 	ctx, span := tracer.Start(ctx, "gitRepository::Version", trace.WithAttributes())
 	defer span.End()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 
 	if err := r.fetchRemoteRepository(ctx); err != nil {
 		return "", err

--- a/porch/pkg/repository/repository.go
+++ b/porch/pkg/repository/repository.go
@@ -206,6 +206,9 @@ type Repository interface {
 	// DeletePackage deletes a package
 	DeletePackage(ctx context.Context, old Package) error
 
+	// Version returns a string that is guaranteed to be different if any change has been made to the repo contents
+	Version(ctx context.Context) (string, error)
+
 	// Close cleans up any resources associated with the repository
 	Close() error
 }


### PR DESCRIPTION
This is a partial fix to the issue of Porch repository polling taking a long time when polling a repo, and holding the lock. It avoids any refresh at all during a steady state.

This helps but is insufficient to resolve the problem completely. Future PR will do partial refreshes, where we hold the lock only long enough to load new or changed revisions.