### PR TITLE
Revise locking strategy

### DIFF
--- a/porch/pkg/cache/cache.go
+++ b/porch/pkg/cache/cache.go
@@ -142,8 +142,13 @@ func (c *Cache) OpenRepository(ctx context.Context, repositorySpec *configapi.Re
 				cr = newRepository(key, repositorySpec, r, c.objectNotifier, c.metadataStore, c.repoSyncFrequency)
 				c.repositories[key] = cr
 			}
+		} else {
+			// If there is an error from the background refresh goroutine, return it.
+			if err := cr.getRefreshError(); err != nil {
+				return nil, err
+			}
 		}
-		return cr, cr.refreshRevisionsError
+		return cr, nil
 
 	default:
 		return nil, fmt.Errorf("type %q not supported", repositoryType)

--- a/porch/pkg/cache/cache.go
+++ b/porch/pkg/cache/cache.go
@@ -142,13 +142,8 @@ func (c *Cache) OpenRepository(ctx context.Context, repositorySpec *configapi.Re
 				cr = newRepository(key, repositorySpec, r, c.objectNotifier, c.metadataStore, c.repoSyncFrequency)
 				c.repositories[key] = cr
 			}
-		} else {
-			// If there is an error from the background refresh goroutine, return it.
-			if err := cr.getRefreshError(); err != nil {
-				return nil, err
-			}
 		}
-		return cr, nil
+		return cr, cr.refreshRevisionsError
 
 	default:
 		return nil, fmt.Errorf("type %q not supported", repositoryType)

--- a/porch/pkg/cache/repository.go
+++ b/porch/pkg/cache/repository.go
@@ -118,6 +118,13 @@ func (r *cachedRepository) ListFunctions(ctx context.Context) ([]repository.Func
 	return functions, nil
 }
 
+func (r *cachedRepository) getRefreshError() error {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+
+	return r.refreshRevisionsError
+}
+
 func (r *cachedRepository) getPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
 	packageRevisions, err := r.getCachedPackageRevisions(ctx)
 	if err != nil {

--- a/porch/pkg/engine/watchermanager.go
+++ b/porch/pkg/engine/watchermanager.go
@@ -65,6 +65,18 @@ func (r *watcherManager) WatchPackageRevisions(ctx context.Context, filter repos
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
+	// reap any dead watchers
+	for i, watcher := range r.watchers {
+		if watcher == nil {
+			continue
+		}
+		if err := watcher.isDoneFunction(); err != nil {
+			klog.Infof("stopping watcher in reaper: %v", err)
+			r.watchers[i] = nil
+			continue
+		}
+	}
+
 	w := &watcher{
 		isDoneFunction: ctx.Err,
 		callback:       callback,

--- a/porch/test/e2e/e2e_test.go
+++ b/porch/test/e2e/e2e_test.go
@@ -2568,7 +2568,8 @@ func (t *PorchSuite) mustNotExist(ctx context.Context, obj client.Object) {
 // provided name and namespace is ready, i.e. the Ready condition is true.
 // It also queries for Functions and PackageRevisions, to ensure these are also
 // ready - this is an artifact of the way we've implemented the aggregated apiserver,
-// where the first fetch can sometimes be synchronous.
+// where the first fetch will block on the cache loading. Wait up to two minutes for the
+// package revisions and functions.
 func (t *PorchSuite) waitUntilRepositoryReady(ctx context.Context, name, namespace string) {
 	nn := types.NamespacedName{
 		Name:      name,
@@ -2593,7 +2594,7 @@ func (t *PorchSuite) waitUntilRepositoryReady(ctx context.Context, name, namespa
 	}
 
 	// While we're using an aggregated apiserver, make sure we can query the generated objects
-	if err := wait.PollImmediateWithContext(ctx, time.Second, 10*time.Second, func(ctx context.Context) (bool, error) {
+	if err := wait.PollImmediateWithContext(ctx, time.Second, 120*time.Second, func(ctx context.Context) (bool, error) {
 		var revisions porchapi.PackageRevisionList
 		if err := t.client.List(ctx, &revisions, client.InNamespace(nn.Namespace)); err != nil {
 			innerErr = err
@@ -2605,7 +2606,7 @@ func (t *PorchSuite) waitUntilRepositoryReady(ctx context.Context, name, namespa
 	}
 
 	// Check for functions also (until we move them to CRDs)
-	if err := wait.PollImmediateWithContext(ctx, time.Second, 10*time.Second, func(ctx context.Context) (bool, error) {
+	if err := wait.PollImmediateWithContext(ctx, time.Second, 120*time.Second, func(ctx context.Context) (bool, error) {
 		var functions porchapi.FunctionList
 		if err := t.client.List(ctx, &functions, client.InNamespace(nn.Namespace)); err != nil {
 			innerErr = err


### PR DESCRIPTION
I am unable to do partial updates of the cache. From what I can see, the way the git repo code works makes this difficult if not impossible. Instead, this PR allows reads to proceed when the cache is in the process of being reconciled, which should help with the concurrency issues we are seeing. To do that, this PR revises the locking strategy for Porch repositories, so that List operations do not block while the cache is being reconciled with the repository.

- List no longer loads the cache if it is empty. Instead, it blocks until the cache is loaded via the reconciliation background go routine.
- The `reconcileMutex` is held during reconciliation of the repo to the cache, and during any operations that mutate the underlying repository (Delete, Update)
- The `mutex` read lock is held whenever the cache *map* is iterated over or checked for nil. ~It is not necessary to hold it when checking if that map is non-nil.~
- The `mutex` write lock is held whenever mutations are happening to the map, or we are change the map the cache points to.