### PR TITLE
Revise package revision caching strategy

### DIFF
--- a/e2e/testdata/porch/rpkg-update/config.yaml
+++ b/e2e/testdata/porch/rpkg-update/config.yaml
@@ -61,6 +61,7 @@ commands:
     stdout: |
       NAME                                           PACKAGE             WORKSPACENAME   REVISION   LATEST   LIFECYCLE   REPOSITORY
       git-3f036055f7ba68706372cbe0c4b14d553794f7c4   basens-edit         update-1                   false    Draft       git
+      git-804ab1a9d043e44255ef3fb77820d5ad7b1576a9   basens-edit         update-3        main       false    Published   git
       git-7fcdd499f0790ac3bd8f805e3e5e00825641eb60   basens-edit         update-3        v1         true     Published   git
       git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0   basens-edit-clone   update-2                   false    Draft       git
   - args:
@@ -82,6 +83,7 @@ commands:
     stdout: |
       PACKAGE REVISION                               UPSTREAM REPOSITORY   UPSTREAM UPDATES
       git-3f036055f7ba68706372cbe0c4b14d553794f7c4                         No update available
+      git-804ab1a9d043e44255ef3fb77820d5ad7b1576a9                         No update available
       git-7fcdd499f0790ac3bd8f805e3e5e00825641eb60                         No update available
       git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0   git                   v1
   - args:
@@ -110,6 +112,7 @@ commands:
     stdout: |
       PACKAGE REVISION                               UPSTREAM REPOSITORY   UPSTREAM UPDATES
       git-3f036055f7ba68706372cbe0c4b14d553794f7c4                         No update available
+      git-804ab1a9d043e44255ef3fb77820d5ad7b1576a9                         No update available
       git-7fcdd499f0790ac3bd8f805e3e5e00825641eb60                         No update available
       git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0   git                   No update available
   - args:

--- a/porch/pkg/cache/draft.go
+++ b/porch/pkg/cache/draft.go
@@ -16,6 +16,7 @@ package cache
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
 )
@@ -28,9 +29,20 @@ type cachedDraft struct {
 var _ repository.PackageDraft = &cachedDraft{}
 
 func (cd *cachedDraft) Close(ctx context.Context) (repository.PackageRevision, error) {
-	if closed, err := cd.PackageDraft.Close(ctx); err != nil {
+	closed, err := cd.PackageDraft.Close(ctx)
+	if err != nil {
 		return nil, err
-	} else {
-		return cd.cache.update(ctx, closed)
 	}
+
+	err = cd.cache.reconcileCache(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cpr := cd.cache.getPackageRevision(closed.Key())
+	if cpr == nil {
+		return nil, fmt.Errorf("closed draft not found")
+	}
+
+	return cpr, nil
 }

--- a/porch/pkg/cache/draft.go
+++ b/porch/pkg/cache/draft.go
@@ -34,7 +34,7 @@ func (cd *cachedDraft) Close(ctx context.Context) (repository.PackageRevision, e
 		return nil, err
 	}
 
-	err = cd.cache.reconcileCache(ctx)
+	err = cd.cache.reconcileCache(ctx, "close-draft")
 	if err != nil {
 		return nil, err
 	}

--- a/porch/pkg/engine/fake/packagerevision.go
+++ b/porch/pkg/engine/fake/packagerevision.go
@@ -35,6 +35,10 @@ type PackageRevision struct {
 	Kptfile            kptfile.KptFile
 }
 
+func (pr *PackageRevision) CachedIdentifier() repository.CachedIdentifier {
+	return repository.CachedIdentifier{Key: pr.Key().String(), Version: pr.Key().Revision}
+}
+
 func (pr *PackageRevision) KubeObjectName() string {
 	return pr.Name
 }

--- a/porch/pkg/git/git.go
+++ b/porch/pkg/git/git.go
@@ -1177,7 +1177,12 @@ func (r *gitRepository) loadTasks(ctx context.Context, startCommit *object.Commi
 
 	var tasks []v1alpha1.Task
 
+	done := false
 	visitCommit := func(commit *object.Commit) error {
+		if done {
+			return nil
+		}
+
 		gitAnnotations, err := ExtractGitAnnotations(commit)
 		if err != nil {
 			return err
@@ -1202,6 +1207,7 @@ func (r *gitRepository) loadTasks(ctx context.Context, startCommit *object.Commi
 				if gitAnnotation.Task != nil && (gitAnnotation.Task.Type == v1alpha1.TaskTypeClone || gitAnnotation.Task.Type == v1alpha1.TaskTypeInit) {
 					// we have reached the beginning of this package revision and don't need to
 					// continue further
+					done = true
 					break
 				}
 			}

--- a/porch/pkg/git/git.go
+++ b/porch/pkg/git/git.go
@@ -393,7 +393,7 @@ func (r *gitRepository) listPackageRevisions(ctx context.Context, filter reposit
 		}
 	}
 
-	klog.Infof("git-repo-list: %d draftCache, %d draftLoaded, %d tagCache, %d tagLoaded, %d mainCache, %d mainLoaded",
+	klog.Infof("repo %s/%s: %d draftCache, %d draftLoaded, %d tagCache, %d tagLoaded, %d mainCache, %d mainLoaded", r.namespace, r.name,
 		draftCache, draftLoaded, tagCache, tagLoaded, mainCache, mainLoaded)
 	return result, nil
 }
@@ -1133,8 +1133,6 @@ func (r *gitRepository) pushAndCleanup(ctx context.Context, ph *pushRefSpecBuild
 		return err
 	}
 
-	klog.Infof("pushing refs: %v", specs)
-
 	if err := r.doGitWithAuth(ctx, func(auth transport.AuthMethod) error {
 		return r.repo.Push(&git.PushOptions{
 			RemoteName:        OriginName,
@@ -1753,9 +1751,6 @@ func (r *gitRepository) discoverPackagesInTree(commit *object.Commit, opt Discov
 		return nil, err
 	}
 
-	if opt.FilterPrefix == "" {
-		klog.Infof("discovered %d packages @%v", len(t.packages), commit.Hash)
-	}
 	return t, nil
 }
 

--- a/porch/pkg/git/git.go
+++ b/porch/pkg/git/git.go
@@ -278,6 +278,14 @@ func (r *gitRepository) listPackageRevisions(ctx context.Context, filter reposit
 
 	mainBranch := r.branch.RefInLocal() // Looking for the registered branch
 
+	// if a cache is available, use it
+	cache := repository.PackageRevisionCacheFromContext(ctx)
+	draftCache := 0
+	tagCache := 0
+	mainCache := 0
+	draftLoaded := 0
+	tagLoaded := 0
+	mainLoaded := 0
 	for {
 		ref, err := refs.Next()
 		if err == io.EOF {
@@ -290,9 +298,25 @@ func (r *gitRepository) listPackageRevisions(ctx context.Context, filter reposit
 			continue
 
 		case isProposedBranchNameInLocal(ref.Name()), isDraftBranchNameInLocal(ref.Name()):
-			draft, err := r.loadDraft(ctx, ref)
-			if err != nil {
-				return nil, fmt.Errorf("failed to load package draft %q: %w", name.String(), err)
+			var draft *gitPackageRevision
+			if entry, ok := cache[ref.Name().String()]; ok {
+				if entry.Version == ref.Hash().String() {
+					dd, good := entry.PackageRevision.(*gitPackageRevision)
+					if !good {
+						klog.Warningf("Found current cached branch %s version %s, but it is not a gitPackageRevision", ref.Name(), entry.Version)
+					} else {
+						draft = dd
+						draftCache += 1
+					}
+				}
+			}
+
+			if draft == nil {
+				draft, err = r.loadDraft(ctx, ref)
+				if err != nil {
+					return nil, fmt.Errorf("failed to load package draft %q: %w", name.String(), err)
+				}
+				draftLoaded += 1
 			}
 			if draft != nil {
 				drafts = append(drafts, draft)
@@ -300,24 +324,61 @@ func (r *gitRepository) listPackageRevisions(ctx context.Context, filter reposit
 				klog.Warningf("no package draft found for ref %v", ref)
 			}
 		case isTagInLocalRepo(ref.Name()):
-			tagged, err := r.loadTaggedPackages(ctx, ref)
-			if err != nil {
-				// this tag is not associated with any package (e.g. could be a release tag)
-				continue
-			}
-			for _, p := range tagged {
-				if filter.Matches(p) {
-					result = append(result, p)
+			var tagged *gitPackageRevision
+			if entry, ok := cache[ref.Name().String()]; ok {
+				if entry.Version == ref.Hash().String() {
+					dd, good := entry.PackageRevision.(*gitPackageRevision)
+					if !good {
+						klog.Warningf("Found current cached branch %s version %s, but it is not a gitPackageRevision", ref.Name(), entry.Version)
+					} else {
+						tagged = dd
+						tagCache += 1
+					}
 				}
+			}
+			if tagged == nil {
+				tagged, err = r.loadTaggedPackage(ctx, ref)
+				if err != nil {
+					// this tag is not associated with any package (e.g. could be a release tag)
+					continue
+				}
+				tagLoaded += 1
+			}
+			if tagged != nil && filter.Matches(tagged) {
+				result = append(result, tagged)
 			}
 		}
 	}
 
 	if main != nil {
+		// Look for any package whose cached identifier starts with main.Name()
+		// There will be one for each pacakge found in main, but they all will have the same
+		// hash. If that matches main.Hash() there is no change in main and so we can just
+		// copy all the packages rather than rediscovering.
+		var mainpkgs []*gitPackageRevision
+		for k, v := range cache {
+			if strings.Index(k, main.Name().String()) == 0 {
+				if v.Version != main.Hash().String() {
+					continue
+				}
+				gpr, ok := v.PackageRevision.(*gitPackageRevision)
+				if !ok {
+					klog.Warningf("Found current cached main package %s version %s, but it is not a gitPackageRevision", k, v.Version)
+				} else {
+					mainpkgs = append(mainpkgs, gpr)
+					mainCache += 1
+				}
+			}
+		}
+
 		// TODO: ignore packages that are unchanged in main branch, compared to a tagged version?
-		mainpkgs, err := r.discoverFinalizedPackages(ctx, main)
-		if err != nil {
-			return nil, err
+		if len(mainpkgs) == 0 {
+			mp, err := r.discoverFinalizedPackages(ctx, main)
+			if err != nil {
+				return nil, err
+			}
+			mainpkgs = mp
+			mainLoaded = len(mainpkgs)
 		}
 		for _, p := range mainpkgs {
 			if filter.Matches(p) {
@@ -332,6 +393,8 @@ func (r *gitRepository) listPackageRevisions(ctx context.Context, filter reposit
 		}
 	}
 
+	klog.Infof("git-repo-list: %d draftCache, %d draftLoaded, %d tagCache, %d tagLoaded, %d mainCache, %d mainLoaded",
+		draftCache, draftLoaded, tagCache, tagLoaded, mainCache, mainLoaded)
 	return result, nil
 }
 
@@ -753,8 +816,8 @@ func parseDraftName(draft *plumbing.Reference) (name string, workspaceName v1alp
 	return name, workspaceName, nil
 }
 
-func (r *gitRepository) loadTaggedPackages(ctx context.Context, tag *plumbing.Reference) ([]*gitPackageRevision, error) {
-	ctx, span := tracer.Start(ctx, "gitRepository::loadTaggedPackages", trace.WithAttributes())
+func (r *gitRepository) loadTaggedPackage(ctx context.Context, tag *plumbing.Reference) (*gitPackageRevision, error) {
+	ctx, span := tracer.Start(ctx, "gitRepository::loadTaggedPackage", trace.WithAttributes())
 	defer span.End()
 
 	name, ok := getTagNameInLocalRepo(tag.Name())
@@ -803,9 +866,7 @@ func (r *gitRepository) loadTaggedPackages(ctx context.Context, tag *plumbing.Re
 		return nil, err
 	}
 
-	return []*gitPackageRevision{
-		packageRevision,
-	}, nil
+	return packageRevision, nil
 
 }
 

--- a/porch/pkg/git/package.go
+++ b/porch/pkg/git/package.go
@@ -78,6 +78,18 @@ func (p *gitPackageRevision) UID() types.UID {
 	return p.uid()
 }
 
+func (p *gitPackageRevision) CachedIdentifier() repository.CachedIdentifier {
+	if p.ref != nil {
+		k := p.ref.Name().String()
+		if p.revision == string(p.repo.branch) {
+			k += ":" + p.path
+		}
+		return repository.CachedIdentifier{Key: k, Version: p.ref.Hash().String()}
+	}
+
+	return repository.CachedIdentifier{}
+}
+
 func (p *gitPackageRevision) ResourceVersion() string {
 	return p.commit.String()
 }

--- a/porch/pkg/oci/oci.go
+++ b/porch/pkg/oci/oci.go
@@ -402,6 +402,10 @@ type ociPackageRevision struct {
 	lifecycle v1alpha1.PackageRevisionLifecycle
 }
 
+func (p *ociPackageRevision) CachedIdentifier() repository.CachedIdentifier {
+	return repository.CachedIdentifier{Key: p.packageName + ":" + string(p.workspaceName), Version: p.resourceVersion}
+}
+
 var _ repository.PackageRevision = &ociPackageRevision{}
 
 func (p *ociPackageRevision) GetResources(ctx context.Context) (*v1alpha1.PackageRevisionResources, error) {


### PR DESCRIPTION
This maintains a separate, lower level cache for the git package revisions. This is somewhat hokey - but I expect the entire "cache" repository type to go away completely with #3630, so this is just trying to optimizing things in the short term.

This makes it so that each "refresh" now only loads changed packages - except for those in main, where it loads all packages if main has changed.

Since loading is now much faster, rather than trying to maintain the cache through mutations, we just refresh the cache after any mutating call.
