### PR TITLE
Fix packagerevisions for repos with subdirs

### DIFF
--- a/porch/pkg/cache/cache.go
+++ b/porch/pkg/cache/cache.go
@@ -119,7 +119,7 @@ func (c *Cache) OpenRepository(ctx context.Context, repositorySpec *configapi.Re
 		if !isPackageContent(repositorySpec.Spec.Content) {
 			return nil, fmt.Errorf("git repository supports Package content only; got %q", string(repositorySpec.Spec.Content))
 		}
-		key := "git://" + gitSpec.Repo
+		key := "git://" + gitSpec.Repo + gitSpec.Directory
 
 		c.mutex.Lock()
 		defer c.mutex.Unlock()

--- a/porch/pkg/cache/cache.go
+++ b/porch/pkg/cache/cache.go
@@ -175,7 +175,7 @@ func (c *Cache) CloseRepository(repositorySpec *configapi.Repository) error {
 		if git == nil {
 			return fmt.Errorf("git not configured for %s:%s", repositorySpec.ObjectMeta.Namespace, repositorySpec.ObjectMeta.Name)
 		}
-		key = "git://" + git.Repo
+		key = "git://" + git.Repo + git.Directory
 
 	default:
 		return fmt.Errorf("unknown repository type: %q", repositorySpec.Spec.Type)

--- a/porch/pkg/cache/repository.go
+++ b/porch/pkg/cache/repository.go
@@ -309,7 +309,9 @@ func (r *cachedRepository) Close() error {
 			// There isn't much use in returning an error here, so we just log it
 			// and create a PackageRevisionMeta with just name and namespace. This
 			// makes sure that the Delete event is sent.
-			klog.Warningf("Error looking up PackageRev CR for %s: %v")
+			if !apierrors.IsNotFound(err) {
+				klog.Warningf("Error deleting PackageRev CR %s/%s: %s", nn.Namespace, nn.Name, err)
+			}
 			pkgRevMeta = meta.PackageRevisionMeta{
 				Name:      nn.Name,
 				Namespace: nn.Namespace,

--- a/porch/pkg/git/git.go
+++ b/porch/pkg/git/git.go
@@ -316,7 +316,9 @@ func (r *gitRepository) listPackageRevisions(ctx context.Context, filter reposit
 				if err != nil {
 					return nil, fmt.Errorf("failed to load package draft %q: %w", name.String(), err)
 				}
-				draftLoaded += 1
+				if draft != nil {
+					draftLoaded += 1
+				}
 			}
 			if draft != nil {
 				drafts = append(drafts, draft)
@@ -342,7 +344,9 @@ func (r *gitRepository) listPackageRevisions(ctx context.Context, filter reposit
 					// this tag is not associated with any package (e.g. could be a release tag)
 					continue
 				}
-				tagLoaded += 1
+				if tagged != nil {
+					tagLoaded += 1
+				}
 			}
 			if tagged != nil && filter.Matches(tagged) {
 				result = append(result, tagged)

--- a/porch/pkg/registry/porch/background.go
+++ b/porch/pkg/registry/porch/background.go
@@ -174,7 +174,7 @@ func (b *background) isSharedRepository(ctx context.Context, repo *configapi.Rep
 				return true, nil
 			}
 		case configapi.RepositoryTypeGit:
-			if r.Spec.Git.Repo == repo.Spec.Git.Repo {
+			if r.Spec.Git.Repo == repo.Spec.Git.Repo && r.Spec.Git.Directory == repo.Spec.Git.Directory {
 				return true, nil
 			}
 		default:


### PR DESCRIPTION
When the same underlying git repository is registered multiple times with different `directory` values, all of the package revisions from one of the directories were showing up multiple times, and none from the others.

The issue is that the cache was mapping them all to the same underlying gitRepository, which is not correct. This separates them properly. It means extra polling of the same repo, but that's OK. Doing it any other way would be more complicated, especially when you consider there could be different permissions for each registration.

The "load" counts were also wrong in this case, fixed that too.