### PR TITLE
docker execution: trim "image up to date" lines

### DIFF
--- a/internal/fnruntime/container.go
+++ b/internal/fnruntime/container.go
@@ -286,6 +286,7 @@ func isdockerCLIoutput(s string) bool {
 		strings.Contains(s, ": Pull complete") ||
 		strings.Contains(s, "Digest: sha256") ||
 		strings.Contains(s, "Status: Downloaded newer image") ||
+		strings.Contains(s, "Status: Image is up to date for") ||
 		strings.Contains(s, "Unable to find image") {
 		return true
 	}


### PR DESCRIPTION
This line was recently added to docker's output, and is not part of
function execution so should be filtered.

It is also breaking our tests!
