### PR TITLE
infra: Don't run CI on dependabot PRs

### DIFF
--- a/.github/workflows/checkDocSync.yml
+++ b/.github/workflows/checkDocSync.yml
@@ -16,6 +16,8 @@ name: Check Documentation Synchronized
 on:
   pull_request:
   push:
+    branches:
+    - '!dependabot/*'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/checkLicenses.yml
+++ b/.github/workflows/checkLicenses.yml
@@ -16,6 +16,8 @@ name: Check Licenses
 on:
   pull_request:
   push:
+    branches:
+    - '!dependabot/*'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/checkSite.yml
+++ b/.github/workflows/checkSite.yml
@@ -18,6 +18,8 @@ on:
     paths:
       - "site/**"
   push:
+    branches:
+    - '!dependabot/*'
     paths:
       - "site/**"
 jobs:

--- a/.github/workflows/e2eEnvironment.yml
+++ b/.github/workflows/e2eEnvironment.yml
@@ -19,6 +19,8 @@ on:
       - "docs/**"
       - "site/**"
   push:
+    branches:
+    - '!dependabot/*'
     paths-ignore:
       - "docs/**"
       - "site/**"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,6 +26,8 @@ on:
       - "site/**"
       - "**.md"
   push:
+    branches:
+    - '!dependabot/*'
 
 env:
   GOPATH: ${{ github.workspace }}/go

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -19,6 +19,8 @@ on:
       - "docs/**"
       - "site/**"
   push:
+    branches:
+    - '!dependabot/*'
     paths-ignore:
       - "docs/**"
       - "site/**"

--- a/.github/workflows/porch-e2e.yml
+++ b/.github/workflows/porch-e2e.yml
@@ -15,6 +15,8 @@
 name: Porch End-to-End Tests
 on:
   push:
+    branches:
+    - '!dependabot/*'
     paths-ignore:
       - "docs/**"
       - "site/**"

--- a/.github/workflows/porch.yml
+++ b/.github/workflows/porch.yml
@@ -16,6 +16,8 @@ name: Porch
 
 on:
   push:
+    branches:
+    - '!dependabot/*'
     paths-ignore:
       - "docs/**"
       - "site/**"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,10 @@
 name: kpt Release
 on:
   push:
+    branches:
+    - '!dependabot/*'
     tags:
-      - "v[1-9].*.*"
+    - "v[1-9].*.*"
 
 jobs:
   build:

--- a/.github/workflows/verifyContent.yml
+++ b/.github/workflows/verifyContent.yml
@@ -20,6 +20,8 @@ on:
       - "commands/**"
       - "internal/**"
   push:
+    branches:
+    - '!dependabot/*'
     paths:
       - "site/**"
       - "commands/**"


### PR DESCRIPTION
Because dependabot pushes branches to this repo, we were running all
the tests twice.

Signed-off-by: justinsb <justinsb@google.com>
