### PR TITLE
infra: grab logs from all porch-system pods

### DIFF
--- a/.github/workflows/porch-e2e.yml
+++ b/.github/workflows/porch-e2e.yml
@@ -104,11 +104,11 @@ jobs:
       - name: porch e2e logs
         if: always()
         run: |
-          name=$(kubectl -n porch-system get pod -l app=porch-server -o custom-columns=NAME:.metadata.name --no-headers=true)
-          kubectl -n porch-system logs $name > porch-e2e-server.log
+          mkdir -p logs/
+          OUTDIR=logs/ porch/dev/cd/dump-logs
       - name: Archive logs
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: porch-e2e-server.log
-          path: porch-e2e-server.log
+          name: logs
+          path: logs/**

--- a/porch/dev/cd/dump-logs
+++ b/porch/dev/cd/dump-logs
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2024 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [[ -z "${OUTDIR:-}" ]]; then
+    echo "Must specify OUTDIR"
+    exit 1
+fi
+
+for podname in $(kubectl get pods -n porch-system -o custom-columns=NAME:.metadata.name --no-headers=true); do
+  mkdir -p ${OUTDIR}/pods/porch-system/
+  kubectl -n porch-system logs ${podname} > ${OUTDIR}/pods/porch-system/${podname}.log
+done        


### PR DESCRIPTION
We saw that the function-runner was not reachable in some test
failures, grab logs for it and all the pods in porch-system.
