### PR TITLE
Fixing the contributions documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,15 @@
 # How to Contribute
 
-We'd love to accept your patches and contributions to this project. To learn more about the project structure and organization, please refer to Project [Governance](governance.md) information. There are
-just a few small guidelines you need to follow.
+We'd love to accept your patches and contributions to this project. To learn more about the project structure and
+organization, please refer to Project [Governance](governance.md) information. There are just a few small guidelines you
+need to follow.
 
-## Contributor License Agreement
+## Developer Certificate of Origin (DCO)
 
-Contributions to this project must be accompanied by a Contributor License
-Agreement. You (or your employer) retain the copyright to your contribution;
-this simply gives us permission to use and redistribute your contributions as
-part of the project. Head over to <https://cla.developers.google.com/> to see
-your current agreements on file or to sign a new one.
-
-You generally only need to submit a CLA once, so if you've already submitted one
-(even if it was for a different project), you probably don't need to do it
-again.
+Contributors of this project should state that they agree with the terms published at https://developercertificate.org/
+for their contribution. To do this when creating a commit with the Git CLI, a sign-off can be added with
+[the -s option](https://git-scm.com/docs/git-commit#git-commit--s). The sign-off is stored as part of the commit message
+itself. 
 
 ## Contributing large features
 


### PR DESCRIPTION
Kpt does not require a CLA anymore, but it requires a DCO.
Fixes #4120