### PR TITLE
Update the SLSA github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
     with:
-      compile-generator: true # Workaround for https://github.com/slsa-framework/slsa-github-generator/issues/1163
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true # upload to a new release


### PR DESCRIPTION
The v1.10.0 version of the SLSA github action references `actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32` which is no longer available. Updating to v2.0.0
