### PR TITLE
Bump the version of node.js in workflows

### DIFF
--- a/.github/workflows/checkSite.yml
+++ b/.github/workflows/checkSite.yml
@@ -34,7 +34,7 @@ jobs:
 #          path: href-checker
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '22'
       - name: Lint site content
         run: npm i && npm run lint-check
         working-directory: site

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '22'
       - name: Generate Site
         run: make site-run-server
       - name: Generate sitemap


### PR DESCRIPTION
Github workflows are failing because they are using version 16.x.x of Node.js that is deprecated. This PR upgrades the Node.js version to 22.x.x.