### PR TITLE
Update governance link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # How to Contribute
 
 We'd love to accept your patches and contributions to this project. To learn more about the project structure and
-organization, please refer to Project [Governance](governance.md) information. There are just a few small guidelines you
+organization, please refer to Project [Governance](https://github.com/kptdev/governance) information. There are just a few small guidelines you
 need to follow.
 
 ## Developer Certificate of Origin (DCO)


### PR DESCRIPTION
There is still a link to `governance.md` in `CONTRIBUTING.md`.
`governance.md` was removed in https://github.com/kptdev/kpt/pull/4197, and I believe the latest reference to governance is https://github.com/kptdev/governance