### PR TITLE
Removal of duplicated license section from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,6 @@ You can read about the big upcoming features in the [roadmap doc](/docs/ROADMAP.
 
 If you are interested in contributing please start with [contribution guidelines](CONTRIBUTING.md).
 
-## License
-
-Code is under the [Apache License 2.0](LICENSE), documentation is [CC BY 4.0](LICENSE-documentation).
-
 ## Contact
 
 We would love to keep in touch:


### PR DESCRIPTION
README.md has two *LICENSE* sections. This change removes one of them. 