### PR TITLE
Deprecate node version from 24 to 22 for firebase

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
       - name: Generate Site
         run: make site-run-server
       - name: Generate sitemap


### PR DESCRIPTION
Firebase does not support node version 24, we get the error message below on the workflow run
```
 /opt/hostedtoolcache/node/24.7.0/x64/bin/npx firebase-tools@latest deploy --only hosting --project kpt-dev --json
  npm warn exec The following package was not found and will be installed: firebase-tools@14.15.1
  npm warn EBADENGINE Unsupported engine ***
  npm warn EBADENGINE   package: 'superstatic@9.2.0',
  npm warn EBADENGINE   required: *** node: '18 || 20 || 22' ***,
  npm warn EBADENGINE   current: *** node: 'v24.7.0', npm: '11.5.1' ***
  npm warn EBADENGINE ***
```

Firebase have a PR up to fix this but it's not merged yet. In the meantime, let's deprecate the node version in this workflow until Firebase fix this issue.

https://github.com/firebase/superstatic/pull/493