### PR TITLE
Move kptfile util functions to public

### DIFF
--- a/commands/live/init/cmdliveinit_test.go
+++ b/commands/live/init/cmdliveinit_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kptdev/kpt/internal/testutil"
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
 	rgfilev1alpha1 "github.com/kptdev/kpt/pkg/api/resourcegroup/v1alpha1"
+	"github.com/kptdev/kpt/pkg/kptfile/kptfileutil"
 	"github.com/kptdev/kpt/pkg/printer/fake"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -285,7 +286,7 @@ func TestCmd_Run(t *testing.T) {
 			// Otherwise, validate the kptfile values and/or resourcegroup values.
 			var actualInv kptfilev1.Inventory
 			assert.NoError(t, err)
-			kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, w.WorkspaceDirectory)
+			kf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, w.WorkspaceDirectory)
 			assert.NoError(t, err)
 
 			switch tc.rgfilename {

--- a/commands/live/migrate/migratecmd_test.go
+++ b/commands/live/migrate/migratecmd_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kptdev/kpt/internal/pkg"
 	rgfilev1alpha1 "github.com/kptdev/kpt/pkg/api/resourcegroup/v1alpha1"
+	"github.com/kptdev/kpt/pkg/kptfile/kptfileutil"
 	"github.com/kptdev/kpt/pkg/printer/fake"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -180,7 +181,7 @@ func TestKptMigrate_migrateKptfileToRG(t *testing.T) {
 				return
 			}
 			assert.NoError(t, err)
-			kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, dir)
+			kf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, dir)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/internal/errors/resolver/pkg.go
+++ b/internal/errors/resolver/pkg.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kptdev/kpt/internal/errors"
 	"github.com/kptdev/kpt/internal/pkg"
 	kptfile "github.com/kptdev/kpt/pkg/api/kptfile/v1"
+	"github.com/kptdev/kpt/pkg/kptfile/kptfileutil"
 )
 
 //nolint:gochecknoinits
@@ -33,7 +34,7 @@ func init() {
 type pkgErrorResolver struct{}
 
 func (*pkgErrorResolver) Resolve(err error) (ResolvedResult, bool) {
-	var kptfileError *pkg.KptfileError
+	var kptfileError *kptfileutil.KptfileError
 	if errors.As(err, &kptfileError) {
 		path := kptfileError.Path
 
@@ -66,7 +67,7 @@ func resolveNestedErr(err error, path string) (ResolvedResult, bool) {
 		}, true
 	}
 
-	var deprecatedv1alpha1KptfileError *pkg.DeprecatedKptfileError
+	var deprecatedv1alpha1KptfileError *kptfileutil.DeprecatedKptfileError
 	if errors.As(err, &deprecatedv1alpha1KptfileError) &&
 		deprecatedv1alpha1KptfileError.Version == "v1alpha1" {
 		msg := fmt.Sprintf("Error: Kptfile at %q has an old version (%q) of the Kptfile schema.\n", path, deprecatedv1alpha1KptfileError.Version)
@@ -77,7 +78,7 @@ func resolveNestedErr(err error, path string) (ResolvedResult, bool) {
 		}, true
 	}
 
-	var deprecatedv1alpha2KptfileError *pkg.DeprecatedKptfileError
+	var deprecatedv1alpha2KptfileError *kptfileutil.DeprecatedKptfileError
 	if errors.As(err, &deprecatedv1alpha2KptfileError) &&
 		deprecatedv1alpha2KptfileError.Version == "v1alpha2" {
 		msg := fmt.Sprintf("Error: Kptfile at %q has an old version (%q) of the Kptfile schema.\n", path, deprecatedv1alpha2KptfileError.Version)
@@ -88,7 +89,7 @@ func resolveNestedErr(err error, path string) (ResolvedResult, bool) {
 		}, true
 	}
 
-	var unknownKptfileResourceError *pkg.UnknownKptfileResourceError
+	var unknownKptfileResourceError *kptfileutil.UnknownKptfileResourceError
 	if errors.As(err, &unknownKptfileResourceError) {
 		msg := fmt.Sprintf("Error: Kptfile at %q has an unknown resource type (%q).", path, unknownKptfileResourceError.GVK.String())
 		return ResolvedResult{
@@ -98,7 +99,7 @@ func resolveNestedErr(err error, path string) (ResolvedResult, bool) {
 
 	msg := fmt.Sprintf("Error: Kptfile at %q can't be read.", path)
 	if err != nil {
-		var kptFileError *pkg.KptfileError
+		var kptFileError *kptfileutil.KptfileError
 		if errors.As(err, &kptFileError) {
 			if kptFileError.Err != nil {
 				msg += fmt.Sprintf("\n\nDetails:\n%v", kptFileError.Err)

--- a/internal/errors/resolver/pkg_test.go
+++ b/internal/errors/resolver/pkg_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kptdev/kpt/internal/pkg"
+	"github.com/kptdev/kpt/pkg/kptfile/kptfileutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,14 +30,14 @@ func TestPkgErrorResolver(t *testing.T) {
 		expected string
 	}{
 		"kptfileError has nested ErrNotExist": {
-			err: &pkg.KptfileError{
+			err: &kptfileutil.KptfileError{
 				Path: "/foo/bar",
 				Err:  os.ErrNotExist,
 			},
 			expected: "Error: No Kptfile found at \"/foo/bar\".",
 		},
 		"kptfileError doesn't have a known nested error": {
-			err: &pkg.KptfileError{
+			err: &kptfileutil.KptfileError{
 				Path: "/some/path",
 				Err:  fmt.Errorf("this is a test"),
 			},
@@ -49,7 +49,7 @@ this is a test
 `,
 		},
 		"kptfileError without nested error": {
-			err: &pkg.KptfileError{
+			err: &kptfileutil.KptfileError{
 				Path: "/some/path",
 			},
 			expected: "Error: Kptfile at \"/some/path\" can't be read.",

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 
 	"github.com/kptdev/kpt/internal/gitutil"
-	"github.com/kptdev/kpt/internal/pkg"
 	"github.com/kptdev/kpt/internal/util/addmergecomment"
 	"github.com/kptdev/kpt/internal/util/git"
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
@@ -129,11 +128,11 @@ func KptfileAwarePkgEqual(t *testing.T, pkg1, pkg2 string, addMergeCommentsToSou
 
 		// Read the Kptfiles and set the Commit field to an empty
 		// string before we compare.
-		pkg1kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Dir(pkg1Path))
+		pkg1kf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Dir(pkg1Path))
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
-		pkg2kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Dir(pkg2Path))
+		pkg2kf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Dir(pkg2Path))
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
@@ -641,12 +640,12 @@ func replaceData(repo, data string) error {
 		// For Kptfiles we want to keep the Upstream section if the Kptfile
 		// in the data directory doesn't already include one.
 		if filepath.Base(path) == "Kptfile" {
-			dataKptfile, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Dir(path))
+			dataKptfile, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Dir(path))
 			if err != nil {
 				return err
 			}
 			repoKptfileDir := filepath.Dir(filepath.Join(repo, rel))
-			repoKptfile, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, repoKptfileDir)
+			repoKptfile, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, repoKptfileDir)
 			if err != nil {
 				return err
 			}

--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -118,7 +118,7 @@ type Command struct {
 func (c *Command) Run(ctx context.Context) error {
 	c.DefaultValues()
 
-	kptFile, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, c.Path)
+	kptFile, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, c.Path)
 	if err != nil {
 		return errors.Errorf("package missing Kptfile at '%s': %v", c.Path, err)
 	}

--- a/internal/util/diff/pkgdiff.go
+++ b/internal/util/diff/pkgdiff.go
@@ -19,10 +19,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/kptdev/kpt/internal/pkg"
 	"github.com/kptdev/kpt/internal/util/attribution"
 	"github.com/kptdev/kpt/internal/util/pkgutil"
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
+	"github.com/kptdev/kpt/pkg/kptfile/kptfileutil"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/sets"
@@ -79,11 +79,11 @@ func PkgDiff(pkg1, pkg2 string) (sets.String, error) {
 }
 
 func kptfilesEqual(pkg1, pkg2, filePath string) (bool, error) {
-	pkg1Kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(pkg1, filepath.Dir(filePath)))
+	pkg1Kf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(pkg1, filepath.Dir(filePath)))
 	if err != nil {
 		return false, err
 	}
-	pkg2Kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(pkg2, filepath.Dir(filePath)))
+	pkg2Kf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(pkg2, filepath.Dir(filePath)))
 	if err != nil {
 		return false, err
 	}

--- a/internal/util/fetch/fetch.go
+++ b/internal/util/fetch/fetch.go
@@ -250,7 +250,7 @@ func (c *Cloner) ClonerUsingGitExec(ctx context.Context) error {
 
 	// Verify that if a Kptfile exists in the package, it contains the correct
 	// version of the Kptfile.
-	_, err = pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, pkgPath)
+	_, err = kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, pkgPath)
 	if err != nil {
 		// A Kptfile isn't required, so it is fine if there is no Kptfile.
 		if errors.Is(err, os.ErrNotExist) {
@@ -261,7 +261,7 @@ func (c *Cloner) ClonerUsingGitExec(ctx context.Context) error {
 		// RemoteKptfileError. This allows us to provide information about the
 		// git source of the Kptfile instead of the path to some random
 		// temporary directory.
-		var kfError *pkg.KptfileError
+		var kfError *kptfileutil.KptfileError
 		if errors.As(err, &kfError) {
 			return &pkg.RemoteKptfileError{
 				RepoSpec: c.repoSpec,

--- a/internal/util/fetch/fetch_test.go
+++ b/internal/util/fetch/fetch_test.go
@@ -19,7 +19,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/kptdev/kpt/internal/pkg"
 	pkgtesting "github.com/kptdev/kpt/internal/pkg/testing"
 	"github.com/kptdev/kpt/internal/testutil"
 	"github.com/kptdev/kpt/internal/testutil/pkgbuilder"
@@ -61,7 +60,7 @@ func createKptfile(workspace *testutil.TestWorkspace, git *kptfilev1.Git, strate
 }
 
 func setKptfileName(workspace *testutil.TestWorkspace, name string) error {
-	kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, workspace.FullPackagePath())
+	kf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, workspace.FullPackagePath())
 	if err != nil {
 		return err
 	}

--- a/internal/util/man/man.go
+++ b/internal/util/man/man.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 
 	"github.com/cpuguy83/go-md2man/v2/md2man"
-	"github.com/kptdev/kpt/internal/pkg"
 	v1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
+	"github.com/kptdev/kpt/pkg/kptfile/kptfileutil"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -57,7 +57,7 @@ func (m Command) Run() error {
 	}
 
 	// lookup the path to the man page
-	k, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, m.Path)
+	k, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, m.Path)
 	if err != nil {
 		return err
 	}

--- a/internal/util/pkgutil/pkgutil.go
+++ b/internal/util/pkgutil/pkgutil.go
@@ -327,7 +327,7 @@ func RoundTripKptfilesInPkg(pkgPath string) error {
 	pkgsPaths = append(pkgsPaths, pkgPath)
 
 	for _, pkgPath := range pkgsPaths {
-		kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, pkgPath)
+		kf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, pkgPath)
 		if err != nil {
 			// do not throw error if formatting fails
 			return err

--- a/internal/util/update/common.go
+++ b/internal/util/update/common.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 
 	"github.com/kptdev/kpt/internal/errors"
-	"github.com/kptdev/kpt/internal/pkg"
+	"github.com/kptdev/kpt/pkg/kptfile/kptfileutil"
 	"github.com/kptdev/kpt/internal/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -27,12 +27,12 @@ import (
 // upstream information than origin.
 func PkgHasUpdatedUpstream(local, origin string) (bool, error) {
 	const op errors.Op = "update.PkgHasUpdatedUpstream"
-	originKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, origin)
+	originKf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, origin)
 	if err != nil {
 		return false, errors.E(op, types.UniquePath(local), err)
 	}
 
-	localKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, local)
+	localKf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, local)
 	if err != nil {
 		return false, errors.E(op, types.UniquePath(local), err)
 	}

--- a/internal/util/update/fastforward.go
+++ b/internal/util/update/fastforward.go
@@ -117,7 +117,7 @@ func (u FastForwardUpdater) checkForLocalChanges(localPath, originalPath string)
 
 func hasKfDiff(localPath, orgPath string) (bool, error) {
 	const op errors.Op = "update.hasKfDiff"
-	localKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, localPath)
+	localKf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, localPath)
 	if err != nil {
 		return false, errors.E(op, types.UniquePath(localPath), err)
 	}
@@ -138,7 +138,7 @@ func hasKfDiff(localPath, orgPath string) (bool, error) {
 		}
 		return false, errors.E(op, types.UniquePath(localPath), err)
 	}
-	orgKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, orgPath)
+	orgKf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, orgPath)
 	if err != nil {
 		return false, errors.E(op, types.UniquePath(localPath), err)
 	}

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -454,7 +454,7 @@ func (u Command) mergePackage(ctx context.Context, localPath, updatedPath, origi
 		// Both exists, so just go ahead as normal.
 	}
 
-	pkgKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, localPath)
+	pkgKf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, localPath)
 	if err != nil {
 		return errors.E(op, types.UniquePath(localPath), err)
 	}

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kptdev/kpt/internal/pkg"
 	pkgtest "github.com/kptdev/kpt/internal/pkg/testing"
 	"github.com/kptdev/kpt/internal/testutil"
 	"github.com/kptdev/kpt/internal/testutil/pkgbuilder"
@@ -269,7 +268,7 @@ func TestCommand_Run_localPackageChanges(t *testing.T) {
 			expectedErr: "local package files have been modified",
 			expectedCommit: func(writer *testutil.TestSetupManager) (string, error) {
 				upstreamRepo := writer.Repos[testutil.Upstream]
-				f, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(writer.LocalWorkspace.WorkspaceDirectory, upstreamRepo.RepoName))
+				f, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(writer.LocalWorkspace.WorkspaceDirectory, upstreamRepo.RepoName))
 				if err != nil {
 					return "", err
 				}
@@ -2046,7 +2045,7 @@ func TestCommand_Run_local_subpackages(t *testing.T) {
 
 				expectedPath := result.expectedLocal.ExpandPkgWithName(t,
 					g.LocalWorkspace.PackageDir, testutil.ToReposInfo(g.Repos))
-				kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, expectedPath)
+				kf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, expectedPath)
 				if !assert.NoError(t, err) {
 					t.FailNow()
 				}

--- a/pkg/kptfile/kptfileutil/util_test.go
+++ b/pkg/kptfile/kptfileutil/util_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kptdev/kpt/internal/pkg"
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -1381,11 +1380,11 @@ pipeline:
 	}
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
-			localKf, err := pkg.DecodeKptfile(strings.NewReader(tc.local))
+			localKf, err := DecodeKptfile(strings.NewReader(tc.local))
 			assert.NoError(t, err)
-			updatedKf, err := pkg.DecodeKptfile(strings.NewReader(tc.update))
+			updatedKf, err := DecodeKptfile(strings.NewReader(tc.update))
 			assert.NoError(t, err)
-			originKf, err := pkg.DecodeKptfile(strings.NewReader(tc.origin))
+			originKf, err := DecodeKptfile(strings.NewReader(tc.origin))
 			assert.NoError(t, err)
 			err = merge(localKf, updatedKf, originKf)
 			if tc.err == nil {

--- a/pkg/live/load.go
+++ b/pkg/live/load.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kptdev/kpt/internal/util/pathutil"
 	"github.com/kptdev/kpt/internal/util/strings"
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
+	"github.com/kptdev/kpt/pkg/kptfile/kptfileutil"
 	rgfilev1alpha1 "github.com/kptdev/kpt/pkg/api/resourcegroup/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -213,7 +214,7 @@ func (i *InventoryFilter) Filter(object *yaml.RNode) (*yaml.RNode, error) {
 	if err != nil {
 		return object, err
 	}
-	kf, err := pkg.DecodeKptfile(bytes.NewBufferString(s))
+	kf, err := kptfileutil.DecodeKptfile(bytes.NewBufferString(s))
 	if err != nil {
 		return nil, err
 	}

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
@@ -15,7 +15,6 @@ import (
 	"github.com/google/shlex"
 	docs "github.com/kptdev/kpt/internal/docs/generated/fndocs"
 	"github.com/kptdev/kpt/internal/fnruntime"
-	"github.com/kptdev/kpt/internal/pkg"
 	"github.com/kptdev/kpt/internal/util/argutil"
 	"github.com/kptdev/kpt/internal/util/cmdutil"
 	"github.com/kptdev/kpt/internal/util/pathutil"
@@ -257,7 +256,7 @@ func (r *EvalFnRunner) updateFnList(oldFNs []kptfile.Function) ([]kptfile.Functi
 // SaveFnToKptfile adds the evaluated function and its arguments to Kptfile `pipeline.mutators` or `pipeline.validators` .
 func (r *EvalFnRunner) SaveFnToKptfile() {
 	pr := printer.FromContextOrDie(r.Ctx)
-	kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, r.runFns.Path)
+	kf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, r.runFns.Path)
 	if err != nil {
 		pr.Printf("function not added: Kptfile not exists\n")
 		return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

In your PR, please ensure that you include the following information:
* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

If you are updating the documentation, please do it in separate PRs from
code changes and the commit message should start with `Docs:`.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->

An older version of the [DecodeKptFile](https://github.com/kptdev/krm-functions-sdk/blob/9bfead305c54/go/api/util/kptfileutil.go#L26) function (from SDK) is being used by the krm-functions.
This PR moves [this](https://github.com/kptdev/kpt/blob/main/internal/pkg/pkg.go#L252) utility fn (and others) from /internal to the kptfuleutils module to make them public. 
