### PR TITLE
Docs/wasm function support

### DIFF
--- a/documentation/content/en/book/04-using-functions/wasm-functions.md
+++ b/documentation/content/en/book/04-using-functions/wasm-functions.md
@@ -1,4 +1,4 @@
-﻿---
+---
 title: "Using WASM Functions"
 linkTitle: "Using WASM Functions"
 weight: 5
@@ -38,7 +38,7 @@ metadata:
   name: my-package
 pipeline:
   mutators:
-    - image: gcr.io/my-org/my-wasm-fn:v1.0.0
+    - image: example.registry.io/my-org/my-wasm-fn:v1.0.0
       configMap:
         key: value
 ```
@@ -54,7 +54,7 @@ kpt will detect the function as WASM if the OCI image has a `js/wasm` platform m
 Run WASM functions imperatively:
 
 ```shell
-kpt fn eval my-package --allow-alpha-wasm -i gcr.io/my-org/my-wasm-fn:v1.0.0 -- key=value
+kpt fn eval my-package --allow-alpha-wasm -i example.registry.io/my-org/my-wasm-fn:v1.0.0 -- key=value
 ```
 
 ### Using local WASM files
@@ -91,7 +91,7 @@ Note: Using local WASM files makes your package less portable since the file nee
 Compress and push a WASM module to an OCI registry:
 
 ```shell
-kpt alpha wasm push ./my-function.wasm gcr.io/my-org/my-wasm-fn:v1.0.0
+kpt alpha wasm push ./my-function.wasm example.registry.io/my-org/my-wasm-fn:v1.0.0
 ```
 
 What this does:
@@ -104,7 +104,7 @@ What this does:
 Download and decompress a WASM module:
 
 ```shell
-kpt alpha wasm pull gcr.io/my-org/my-wasm-fn:v1.0.0 ./my-function.wasm
+kpt alpha wasm pull example.registry.io/my-org/my-wasm-fn:v1.0.0 ./my-function.wasm
 ```
 
 Useful for:
@@ -124,117 +124,7 @@ WASM functions follow the [KRM Functions Specification](https://github.com/kuber
 
 ### Example: Go WASM function
 
-Here's how to build a Go KRM function for WASM. You need two files - one for regular builds and one for WASM:
-
-`main.go` (regular build):
-
-```go
-//go:build !(js && wasm)
-
-package main
-
-import (
-	"os"
-
-	"github.com/kptdev/krm-functions-sdk/go/fn"
-)
-
-func main() {
-	if err := fn.AsMain(fn.ResourceListProcessorFunc(process)); err != nil {
-		os.Exit(1)
-	}
-}
-
-func process(rl *fn.ResourceList) (bool, error) {
-	for i := range rl.Items {
-		// Your transformation logic
-		rl.Items[i].SetAnnotation("processed-by", "my-fn")
-	}
-	return true, nil
-}
-```
-
-`main_js.go` (WASM build):
-
-```go
-//go:build js && wasm
-
-package main
-
-import (
-	"syscall/js"
-
-	"github.com/kptdev/krm-functions-sdk/go/fn"
-)
-
-// Keep js.Func values referenced at package level to prevent garbage collection.
-var (
-	processResourceListFunc       js.Func
-	processResourceListErrorsFunc js.Func
-)
-
-func main() {
-	if err := run(); err != nil {
-		panic(err)
-	}
-}
-
-func run() error {
-	resourceList := []byte("")
-
-	processResourceListFunc = resourceListWrapper(&resourceList)
-	js.Global().Set("processResourceList", processResourceListFunc)
-	processResourceListErrorsFunc = resourceListErrors(&resourceList)
-	js.Global().Set("processResourceListErrors", processResourceListErrorsFunc)
-
-	// Keep the program running
-	select {}
-}
-
-// process applies the same transformation logic as in the non-WASM build.
-func process(rl *fn.ResourceList) (bool, error) {
-	for i := range rl.Items {
-		// Your transformation logic
-		rl.Items[i].SetAnnotation("processed-by", "my-fn")
-	}
-	return true, nil
-}
-
-func transform(input []byte) ([]byte, error) {
-	return fn.Run(fn.ResourceListProcessorFunc(process), input)
-}
-
-func resourceListWrapper(resourceList *[]byte) js.Func {
-	return js.FuncOf(func(this js.Value, args []js.Value) any {
-		if len(args) != 1 {
-			return "Invalid number of arguments"
-		}
-		input := args[0].String()
-		output, err := transform([]byte(input))
-		*resourceList = output
-		if err != nil {
-			return "unable to process: " + err.Error()
-		}
-		return string(output)
-	})
-}
-
-func resourceListErrors(resourceList *[]byte) js.Func {
-	return js.FuncOf(func(this js.Value, args []js.Value) any {
-		rl, err := fn.ParseResourceList(*resourceList)
-		if err != nil {
-			return ""
-		}
-		errors := ""
-		for _, r := range rl.Results {
-			if r.Severity == "error" {
-				errors += r.Message
-			}
-		}
-		return errors
-	})
-}
-```
+For a complete working example of a Go WASM function, see the [starlark function in the krm-functions-catalog](https://github.com/kptdev/krm-functions-catalog/tree/main/functions/go/starlark), which shows the two-file pattern (`run.go` for regular builds and `run_js.go` for WASM builds).
 
 ### Build for WASM
 
@@ -253,10 +143,10 @@ kpt fn eval ./test-package --allow-alpha-wasm --allow-exec --exec ./my-function.
 Push to a registry:
 
 ```shell
-kpt alpha wasm push ./my-function.wasm gcr.io/my-org/my-wasm-fn:v1.0.0
+kpt alpha wasm push ./my-function.wasm example.registry.io/my-org/my-wasm-fn:v1.0.0
 
 # Test the published version
-kpt fn eval ./test-package --allow-alpha-wasm -i gcr.io/my-org/my-wasm-fn:v1.0.0
+kpt fn eval ./test-package --allow-alpha-wasm -i example.registry.io/my-org/my-wasm-fn:v1.0.0
 ```
 
 ## Complete example
@@ -273,7 +163,7 @@ GOOS=js GOARCH=wasm go build -o my-function.wasm .
 kpt fn eval ./test-package --allow-alpha-wasm --allow-exec --exec ./my-function.wasm
 
 # 4. Publish
-kpt alpha wasm push ./my-function.wasm gcr.io/my-org/my-wasm-fn:v1.0.0
+kpt alpha wasm push ./my-function.wasm example.registry.io/my-org/my-wasm-fn:v1.0.0
 
 # 5. Use in a package
 cat <<EOF > Kptfile
@@ -283,7 +173,7 @@ metadata:
   name: my-package
 pipeline:
   mutators:
-    - image: gcr.io/my-org/my-wasm-fn:v1.0.0
+    - image: example.registry.io/my-org/my-wasm-fn:v1.0.0
 EOF
 
 # 6. Render

--- a/documentation/content/en/book/04-using-functions/wasm-functions.md
+++ b/documentation/content/en/book/04-using-functions/wasm-functions.md
@@ -18,7 +18,7 @@ WASM functions have some advantages over container-based functions:
 
 - Faster startup - no container runtime needed
 - Smaller size - WASM modules are typically much smaller than container images
-- Better security - sandboxed execution with no host access by default
+- Better isolation - sandboxed execution with limited host access
 - More portable - run anywhere WASM is supported
 - Lower resource usage
 
@@ -47,7 +47,7 @@ pipeline:
 kpt fn render my-package --allow-alpha-wasm
 ```
 
-kpt will detect the function as WASM if the OCI image has a `js/wasm` platform manifest.
+kpt will use the WASM runtime for an OCI image if the `--allow-alpha-wasm` flag is present and the image has a `js/wasm` platform manifest.
 
 ### With `fn eval`
 
@@ -79,7 +79,7 @@ pipeline:
 ```
 
 ```shell
-kpt fn render my-package --allow-alpha-wasm --allow-exec
+kpt fn render my-package --allow-alpha-wasm
 ```
 
 Note: Using local WASM files makes your package less portable since the file needs to exist on every system.
@@ -135,7 +135,7 @@ GOOS=js GOARCH=wasm go build -o my-function.wasm .
 ### Test locally
 
 ```shell
-kpt fn eval ./test-package --allow-alpha-wasm --allow-exec --exec ./my-function.wasm
+kpt fn eval ./test-package --allow-alpha-wasm --exec ./my-function.wasm
 ```
 
 ### Publish
@@ -149,73 +149,40 @@ kpt alpha wasm push ./my-function.wasm example.registry.io/my-org/my-wasm-fn:v1.
 kpt fn eval ./test-package --allow-alpha-wasm -i example.registry.io/my-org/my-wasm-fn:v1.0.0
 ```
 
-## Complete example
+## Mixed pipelines
 
-From development to deployment:
-
-```shell
-# 1. Write your function code (main.go and main_js.go)
-
-# 2. Build
-GOOS=js GOARCH=wasm go build -o my-function.wasm .
-
-# 3. Test locally
-kpt fn eval ./test-package --allow-alpha-wasm --exec ./my-function.wasm
-
-# 4. Publish
-kpt alpha wasm push ./my-function.wasm example.registry.io/my-org/my-wasm-fn:v1.0.0
-
-# 5. Use in a package
-cat <<EOF > Kptfile
-apiVersion: kpt.dev/v1
-kind: Kptfile
-metadata:
-  name: my-package
-pipeline:
-  mutators:
-    - image: example.registry.io/my-org/my-wasm-fn:v1.0.0
-EOF
-
-# 6. Render
-kpt fn render my-package --allow-alpha-wasm
-```
+{{< note title="Limitation" >}}
+Currently, enabling `--allow-alpha-wasm` will cause kpt to attempt to run all **image-based** functions in the pipeline using the WASM runtime. Mixed pipelines containing both WASM and standard container images are not yet fully supported. However, mixed pipelines with local `.wasm` files and standard executables are supported.
+{{< /note >}}
 
 ## Limitations
 
-### Alpha status
-
-WASM support is alpha, which means:
-- API may change
-- Requires `--allow-alpha-wasm` flag
-- Some features may be limited
-
 ### Security
 
-WASM functions are designed to run in a sandboxed environment, but the exact security properties depend on the WASM runtime and how it is configured:
-- Some runtimes (for example, `wasmtime` with default settings) do not grant network or filesystem access unless you explicitly enable those capabilities.
-- Other runtimes (for example, a Node.js-based WASM runtime) execute the module within a local `node` process, where filesystem and network access may be possible depending on the glue code and module implementation.
-- In all cases, you should treat the WASM runtime as part of your trusted computing base and review its configuration and allowed host APIs.
+WASM functions run in a sandboxed environment with restricted access. The current implementation using Wasmtime provides the following protections:
+- No network access by default.
+- Restricted filesystem access (functions cannot access host files outside the KRM interface).
+- No ability to execute system commands.
 
-Compared to running arbitrary container images, a well-configured WASM runtime can offer stronger isolation, but the actual security guarantees depend on the chosen runtime and its configuration.
+These restrictions provide a higher level of isolation compared to traditional executables, though they may limit some use cases.
 
 ### Performance
 
-- Faster startup than containers
-- CPU-intensive operations may be slower
-- Different memory patterns
-- Benchmark if performance is critical
+- Faster startup than containers as no container runtime overhead is involved.
+- CPU-intensive operations may be slower than native execution.
+- Memory usage patterns differ from container-based functions.
 
 ### Compatibility
 
-Not all container functions can convert to WASM:
-- Functions needing network access
-- Functions with complex dependencies
-- Platform-specific code
+Not all container functions can convert to WASM, especially those needing:
+- Host network access.
+- Complex system dependencies.
+- OS-specific features (e.g. syscalls not supported by WASI).
 
 ## See also
 
 - [KRM Functions Specification](https://github.com/kubernetes-sigs/kustomize/blob/master/cmd/config/docs/api-conventions/functions-spec.md)
 - [Functions Catalog](https://catalog.kpt.dev/)
-- [kpt alpha wasm push](../../../reference/cli/alpha/wasm/push/)
-- [kpt alpha wasm pull](../../../reference/cli/alpha/wasm/pull/)
+- [kpt alpha wasm push]({{< relref "/reference/cli/alpha/wasm/push" >}})
+- [kpt alpha wasm pull]({{< relref "/reference/cli/alpha/wasm/pull" >}})
 - [WASM function examples](https://github.com/kptdev/krm-functions-catalog/tree/main/functions/go)

--- a/documentation/content/en/book/04-using-functions/wasm-functions.md
+++ b/documentation/content/en/book/04-using-functions/wasm-functions.md
@@ -160,7 +160,7 @@ From development to deployment:
 GOOS=js GOARCH=wasm go build -o my-function.wasm .
 
 # 3. Test locally
-kpt fn eval ./test-package --allow-alpha-wasm --allow-exec --exec ./my-function.wasm
+kpt fn eval ./test-package --allow-alpha-wasm --exec ./my-function.wasm
 
 # 4. Publish
 kpt alpha wasm push ./my-function.wasm example.registry.io/my-org/my-wasm-fn:v1.0.0

--- a/documentation/content/en/book/04-using-functions/wasm-functions.md
+++ b/documentation/content/en/book/04-using-functions/wasm-functions.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: "Using WASM Functions"
 linkTitle: "Using WASM Functions"
 weight: 5
@@ -62,7 +62,7 @@ kpt fn eval my-package --allow-alpha-wasm -i gcr.io/my-org/my-wasm-fn:v1.0.0 -- 
 You can run local `.wasm` files with the `--exec` flag:
 
 ```shell
-kpt fn eval my-package --allow-alpha-wasm --exec ./my-function.wasm
+kpt fn eval my-package --allow-alpha-wasm --allow-exec --exec ./my-function.wasm
 ```
 
 You can also declare local WASM files in your `Kptfile`:
@@ -134,23 +134,23 @@ Here's how to build a Go KRM function for WASM. You need two files - one for reg
 package main
 
 import (
-    "os"
-    
-    "github.com/kptdev/krm-functions-sdk/go/fn"
+	"os"
+
+	"github.com/kptdev/krm-functions-sdk/go/fn"
 )
 
 func main() {
-    if err := fn.AsMain(fn.ResourceListProcessorFunc(process)); err != nil {
-        os.Exit(1)
-    }
+	if err := fn.AsMain(fn.ResourceListProcessorFunc(process)); err != nil {
+		os.Exit(1)
+	}
 }
 
 func process(rl *fn.ResourceList) (bool, error) {
-    for i := range rl.Items {
-        // Your transformation logic
-        rl.Items[i].SetAnnotation("processed-by", "my-fn")
-    }
-    return true, nil
+	for i := range rl.Items {
+		// Your transformation logic
+		rl.Items[i].SetAnnotation("processed-by", "my-fn")
+	}
+	return true, nil
 }
 ```
 
@@ -162,69 +162,77 @@ func process(rl *fn.ResourceList) (bool, error) {
 package main
 
 import (
-    "syscall/js"
-    
-    "github.com/kptdev/krm-functions-sdk/go/fn"
+	"syscall/js"
+
+	"github.com/kptdev/krm-functions-sdk/go/fn"
+)
+
+// Keep js.Func values referenced at package level to prevent garbage collection.
+var (
+	processResourceListFunc       js.Func
+	processResourceListErrorsFunc js.Func
 )
 
 func main() {
-    if err := run(); err != nil {
-        panic(err)
-    }
+	if err := run(); err != nil {
+		panic(err)
+	}
 }
 
 func run() error {
-    resourceList := []byte("")
-    
-    js.Global().Set("processResourceList", resourceListWrapper(&resourceList))
-    js.Global().Set("processResourceListErrors", resourceListErrors(&resourceList))
-    
-    // Keep the program running
-    select {}
+	resourceList := []byte("")
+
+	processResourceListFunc = resourceListWrapper(&resourceList)
+	js.Global().Set("processResourceList", processResourceListFunc)
+	processResourceListErrorsFunc = resourceListErrors(&resourceList)
+	js.Global().Set("processResourceListErrors", processResourceListErrorsFunc)
+
+	// Keep the program running
+	select {}
 }
 
 // process applies the same transformation logic as in the non-WASM build.
 func process(rl *fn.ResourceList) (bool, error) {
-    for i := range rl.Items {
-        // Your transformation logic
-        rl.Items[i].SetAnnotation("processed-by", "my-fn")
-    }
-    return true, nil
+	for i := range rl.Items {
+		// Your transformation logic
+		rl.Items[i].SetAnnotation("processed-by", "my-fn")
+	}
+	return true, nil
 }
 
 func transform(input []byte) ([]byte, error) {
-    return fn.Run(fn.ResourceListProcessorFunc(process), input)
+	return fn.Run(fn.ResourceListProcessorFunc(process), input)
 }
 
 func resourceListWrapper(resourceList *[]byte) js.Func {
-    return js.FuncOf(func(this js.Value, args []js.Value) any {
-        if len(args) != 1 {
-            return "Invalid number of arguments"
-        }
-        input := args[0].String()
-        output, err := transform([]byte(input))
-        *resourceList = output
-        if err != nil {
-            return "unable to process: " + err.Error()
-        }
-        return string(output)
-    })
+	return js.FuncOf(func(this js.Value, args []js.Value) any {
+		if len(args) != 1 {
+			return "Invalid number of arguments"
+		}
+		input := args[0].String()
+		output, err := transform([]byte(input))
+		*resourceList = output
+		if err != nil {
+			return "unable to process: " + err.Error()
+		}
+		return string(output)
+	})
 }
 
 func resourceListErrors(resourceList *[]byte) js.Func {
-    return js.FuncOf(func(this js.Value, args []js.Value) any {
-        rl, err := fn.ParseResourceList(*resourceList)
-        if err != nil {
-            return ""
-        }
-        errors := ""
-        for _, r := range rl.Results {
-            if r.Severity == "error" {
-                errors += r.Message
-            }
-        }
-        return errors
-    })
+	return js.FuncOf(func(this js.Value, args []js.Value) any {
+		rl, err := fn.ParseResourceList(*resourceList)
+		if err != nil {
+			return ""
+		}
+		errors := ""
+		for _, r := range rl.Results {
+			if r.Severity == "error" {
+				errors += r.Message
+			}
+		}
+		return errors
+	})
 }
 ```
 
@@ -237,7 +245,7 @@ GOOS=js GOARCH=wasm go build -o my-function.wasm .
 ### Test locally
 
 ```shell
-kpt fn eval ./test-package --allow-alpha-wasm --exec ./my-function.wasm
+kpt fn eval ./test-package --allow-alpha-wasm --allow-exec --exec ./my-function.wasm
 ```
 
 ### Publish
@@ -262,7 +270,7 @@ From development to deployment:
 GOOS=js GOARCH=wasm go build -o my-function.wasm .
 
 # 3. Test locally
-kpt fn eval ./test-package --allow-alpha-wasm --exec ./my-function.wasm
+kpt fn eval ./test-package --allow-alpha-wasm --allow-exec --exec ./my-function.wasm
 
 # 4. Publish
 kpt alpha wasm push ./my-function.wasm gcr.io/my-org/my-wasm-fn:v1.0.0

--- a/documentation/content/en/book/04-using-functions/wasm-functions.md
+++ b/documentation/content/en/book/04-using-functions/wasm-functions.md
@@ -62,7 +62,7 @@ kpt fn eval my-package --allow-alpha-wasm -i example.registry.io/my-org/my-wasm-
 You can run local `.wasm` files with the `--exec` flag:
 
 ```shell
-kpt fn eval my-package --allow-alpha-wasm --allow-exec --exec ./my-function.wasm
+kpt fn eval my-package --allow-alpha-wasm --exec ./my-function.wasm
 ```
 
 You can also declare local WASM files in your `Kptfile`:

--- a/documentation/content/en/book/04-using-functions/wasm-functions.md
+++ b/documentation/content/en/book/04-using-functions/wasm-functions.md
@@ -180,8 +180,7 @@ func run() error {
     js.Global().Set("processResourceListErrors", resourceListErrors(&resourceList))
     
     // Keep the program running
-    <-make(chan bool)
-    return nil
+    select {}
 }
 
 // process applies the same transformation logic as in the non-WASM build.

--- a/documentation/content/en/book/04-using-functions/wasm-functions.md
+++ b/documentation/content/en/book/04-using-functions/wasm-functions.md
@@ -1,0 +1,324 @@
+---
+title: "Using WASM Functions"
+linkTitle: "Using WASM Functions"
+weight: 5
+description: >
+    How to run, develop, and deploy WebAssembly (WASM) functions with kpt.
+---
+
+WASM functions are an alternative to container-based KRM functions. They're faster to start, smaller to distribute, and run in a sandboxed environment.
+
+## Why use WASM functions?
+
+{{< warning type=warning title="Note" >}}
+WASM support in kpt is currently in alpha and not ready for production use. The API and behavior may change in future releases.
+{{< /warning >}}
+
+WASM functions have some advantages over container-based functions:
+
+- Faster startup - no container runtime needed
+- Smaller size - WASM modules are typically much smaller than container images
+- Better security - sandboxed execution with no host access by default
+- More portable - run anywhere WASM is supported
+- Lower resource usage
+
+## Running WASM functions
+
+WASM support is an alpha feature. You need to use the `--allow-alpha-wasm` flag to enable it.
+
+### With `fn render`
+
+Add the WASM function to your Kptfile pipeline:
+
+```yaml
+# Kptfile
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: my-package
+pipeline:
+  mutators:
+    - image: gcr.io/my-org/my-wasm-fn:v1.0.0
+      configMap:
+        key: value
+```
+
+```shell
+kpt fn render my-package --allow-alpha-wasm
+```
+
+kpt will detect the function as WASM if the OCI image has a `js/wasm` platform manifest.
+
+### With `fn eval`
+
+Run WASM functions imperatively:
+
+```shell
+kpt fn eval my-package --allow-alpha-wasm -i gcr.io/my-org/my-wasm-fn:v1.0.0 -- key=value
+```
+
+### Using local WASM files
+
+You can run local `.wasm` files with the `--exec` flag:
+
+```shell
+kpt fn eval my-package --allow-alpha-wasm --exec ./my-function.wasm
+```
+
+You can also declare local WASM files in your `Kptfile`:
+
+```yaml
+# Kptfile
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: my-package
+pipeline:
+  mutators:
+    - exec: ./functions/my-function.wasm
+```
+
+```shell
+kpt fn render my-package --allow-alpha-wasm --allow-exec
+```
+
+Note: Using local WASM files makes your package less portable since the file needs to exist on every system.
+
+## Publishing WASM functions
+
+### Push a WASM module
+
+Compress and push a WASM module to an OCI registry:
+
+```shell
+kpt alpha wasm push ./my-function.wasm gcr.io/my-org/my-wasm-fn:v1.0.0
+```
+
+What this does:
+1. Compresses the WASM file into a tar archive
+2. Creates an OCI image with `js/wasm` platform
+3. Pushes to the registry
+
+### Pull a WASM module
+
+Download and decompress a WASM module:
+
+```shell
+kpt alpha wasm pull gcr.io/my-org/my-wasm-fn:v1.0.0 ./my-function.wasm
+```
+
+Useful for:
+- Testing WASM functions locally
+- Inspecting modules
+- Offline caching
+
+## Developing WASM functions
+
+WASM functions follow the [KRM Functions Specification](https://github.com/kubernetes-sigs/kustomize/blob/master/cmd/config/docs/api-conventions/functions-spec.md). They receive a `ResourceList` as input and return a `ResourceList` as output.
+
+### What you need
+
+- A language that compiles to WASM (Go, Rust, etc.)
+- WASM build toolchain
+- KRM functions SDK
+
+### Example: Go WASM function
+
+Here's how to build a Go KRM function for WASM. You need two files - one for regular builds and one for WASM:
+
+`main.go` (regular build):
+
+```go
+//go:build !(js && wasm)
+
+package main
+
+import (
+    "os"
+    
+    "github.com/kptdev/krm-functions-sdk/go/fn"
+)
+
+func main() {
+    if err := fn.AsMain(fn.ResourceListProcessorFunc(process)); err != nil {
+        os.Exit(1)
+    }
+}
+
+func process(rl *fn.ResourceList) (bool, error) {
+    for i := range rl.Items {
+        // Your transformation logic
+        rl.Items[i].SetAnnotation("processed-by", "my-fn")
+    }
+    return true, nil
+}
+```
+
+`main_js.go` (WASM build):
+
+```go
+//go:build js && wasm
+
+package main
+
+import (
+    "syscall/js"
+    
+    "github.com/kptdev/krm-functions-sdk/go/fn"
+)
+
+func main() {
+    if err := run(); err != nil {
+        panic(err)
+    }
+}
+
+func run() error {
+    resourceList := []byte("")
+    
+    js.Global().Set("processResourceList", resourceListWrapper(&resourceList))
+    js.Global().Set("processResourceListErrors", resourceListErrors(&resourceList))
+    
+    // Keep the program running
+    <-make(chan bool)
+    return nil
+}
+
+// process applies the same transformation logic as in the non-WASM build.
+func process(rl *fn.ResourceList) (bool, error) {
+    for i := range rl.Items {
+        // Your transformation logic
+        rl.Items[i].SetAnnotation("processed-by", "my-fn")
+    }
+    return true, nil
+}
+
+func transform(input []byte) ([]byte, error) {
+    return fn.Run(fn.ResourceListProcessorFunc(process), input)
+}
+
+func resourceListWrapper(resourceList *[]byte) js.Func {
+    return js.FuncOf(func(this js.Value, args []js.Value) any {
+        if len(args) != 1 {
+            return "Invalid number of arguments"
+        }
+        input := args[0].String()
+        output, err := transform([]byte(input))
+        *resourceList = output
+        if err != nil {
+            return "unable to process: " + err.Error()
+        }
+        return string(output)
+    })
+}
+
+func resourceListErrors(resourceList *[]byte) js.Func {
+    return js.FuncOf(func(this js.Value, args []js.Value) any {
+        rl, err := fn.ParseResourceList(*resourceList)
+        if err != nil {
+            return ""
+        }
+        errors := ""
+        for _, r := range rl.Results {
+            if r.Severity == "error" {
+                errors += r.Message
+            }
+        }
+        return errors
+    })
+}
+```
+
+### Build for WASM
+
+```shell
+GOOS=js GOARCH=wasm go build -o my-function.wasm .
+```
+
+### Test locally
+
+```shell
+kpt fn eval ./test-package --allow-alpha-wasm --exec ./my-function.wasm
+```
+
+### Publish
+
+Push to a registry:
+
+```shell
+kpt alpha wasm push ./my-function.wasm gcr.io/my-org/my-wasm-fn:v1.0.0
+
+# Test the published version
+kpt fn eval ./test-package --allow-alpha-wasm -i gcr.io/my-org/my-wasm-fn:v1.0.0
+```
+
+## Complete example
+
+From development to deployment:
+
+```shell
+# 1. Write your function code (main.go and main_js.go)
+
+# 2. Build
+GOOS=js GOARCH=wasm go build -o my-function.wasm .
+
+# 3. Test locally
+kpt fn eval ./test-package --allow-alpha-wasm --exec ./my-function.wasm
+
+# 4. Publish
+kpt alpha wasm push ./my-function.wasm gcr.io/my-org/my-wasm-fn:v1.0.0
+
+# 5. Use in a package
+cat <<EOF > Kptfile
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: my-package
+pipeline:
+  mutators:
+    - image: gcr.io/my-org/my-wasm-fn:v1.0.0
+EOF
+
+# 6. Render
+kpt fn render my-package --allow-alpha-wasm
+```
+
+## Limitations
+
+### Alpha status
+
+WASM support is alpha, which means:
+- API may change
+- Requires `--allow-alpha-wasm` flag
+- Some features may be limited
+
+### Security
+
+WASM functions run in a sandbox:
+- No network access
+- No filesystem access (except input/output resources)
+- Can't execute system commands
+
+This is more secure but also more restrictive.
+
+### Performance
+
+- Faster startup than containers
+- CPU-intensive operations may be slower
+- Different memory patterns
+- Benchmark if performance is critical
+
+### Compatibility
+
+Not all container functions can convert to WASM:
+- Functions needing network access
+- Functions with complex dependencies
+- Platform-specific code
+
+## See also
+
+- [KRM Functions Specification](https://github.com/kubernetes-sigs/kustomize/blob/master/cmd/config/docs/api-conventions/functions-spec.md)
+- [Functions Catalog](https://catalog.kpt.dev/)
+- [kpt alpha wasm push](../../../reference/cli/alpha/wasm/push/)
+- [kpt alpha wasm pull](../../../reference/cli/alpha/wasm/pull/)
+- [WASM function examples](https://github.com/kptdev/krm-functions-catalog/tree/main/functions/go)

--- a/documentation/content/en/book/04-using-functions/wasm-functions.md
+++ b/documentation/content/en/book/04-using-functions/wasm-functions.md
@@ -191,12 +191,12 @@ WASM support is alpha, which means:
 
 ### Security
 
-WASM functions run in a sandbox:
-- No network access
-- No filesystem access (except input/output resources)
-- Can't execute system commands
+WASM functions are designed to run in a sandboxed environment, but the exact security properties depend on the WASM runtime and how it is configured:
+- Some runtimes (for example, `wasmtime` with default settings) do not grant network or filesystem access unless you explicitly enable those capabilities.
+- Other runtimes (for example, a Node.js-based WASM runtime) execute the module within a local `node` process, where filesystem and network access may be possible depending on the glue code and module implementation.
+- In all cases, you should treat the WASM runtime as part of your trusted computing base and review its configuration and allowed host APIs.
 
-This is more secure but also more restrictive.
+Compared to running arbitrary container images, a well-configured WASM runtime can offer stronger isolation, but the actual security guarantees depend on the chosen runtime and its configuration.
 
 ### Performance
 

--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -121,7 +121,7 @@ func NewRunner(
 				}
 			case f.Exec != "":
 				// If AllowWasm is true, we will use wasm runtime for exec field.
-				if opts.AllowWasm {
+				if opts.AllowWasm && strings.HasSuffix(f.Exec, ".wasm") {
 					wFn, err := NewWasmFn(&FsLoader{Filename: f.Exec})
 					if err != nil {
 						return nil, err

--- a/internal/util/render/executor.go
+++ b/internal/util/render/executor.go
@@ -734,7 +734,10 @@ func (pn *pkgNode) runValidators(ctx context.Context, hctx *hydrationContext, in
 			displayResourceCount = true
 		}
 		if function.Exec != "" && !hctx.runnerOptions.AllowExec {
-			return errAllowedExecNotSpecified
+			// WASM functions are sandboxed and don't require --allow-exec if --allow-alpha-wasm is set
+			if !(hctx.runnerOptions.AllowWasm && strings.HasSuffix(function.Exec, ".wasm")) {
+				return errAllowedExecNotSpecified
+			}
 		}
 		opts := hctx.runnerOptions
 		opts.SetPkgPathAnnotation = true
@@ -859,7 +862,10 @@ func fnChain(ctx context.Context, hctx *hydrationContext, pkgPath types.UniquePa
 			displayResourceCount = true
 		}
 		if function.Exec != "" && !hctx.runnerOptions.AllowExec {
-			return nil, errAllowedExecNotSpecified
+			// WASM functions are sandboxed and don't require --allow-exec if --allow-alpha-wasm is set
+			if !(hctx.runnerOptions.AllowWasm && strings.HasSuffix(function.Exec, ".wasm")) {
+				return nil, errAllowedExecNotSpecified
+			}
 		}
 		opts := hctx.runnerOptions
 		opts.SetPkgPathAnnotation = true


### PR DESCRIPTION
## Description

WASM functions are supported in kpt but there's no documentation on how to run, develop, or deploy them. This PR adds a comprehensive guide covering the complete WASM function workflow.

## Motivation

Users need documentation to understand:
- How to run WASM functions with the `--allow-alpha-wasm` flag
- How to publish WASM modules using `kpt alpha wasm push/pull`
- How to develop WASM functions with proper build tags
- The benefits and limitations of WASM functions vs container-based functions

Without this documentation, users have to dig through code or CLI help to figure out WASM support.

## Changes

Added `documentation/content/en/book/04-using-functions/wasm-functions.md` covering:
- Running WASM functions with `fn render` and `fn eval`
- Publishing and pulling WASM modules to/from OCI registries
- Developing Go-based WASM functions with complete code examples
- Benefits (faster startup, smaller size, better security)
- Limitations (alpha status, sandboxed execution, compatibility)

The code examples are based on actual WASM functions in krm-functions-catalog (set-namespace, set-labels, starlark) and follow the same pattern with separate build tags for regular and WASM builds.

Fixes #4296
