### PR TITLE
Ignore render status during fast-forward update

### DIFF
--- a/documentation/content/en/reference/cli/pkg/update/_index.md
+++ b/documentation/content/en/reference/cli/pkg/update/_index.md
@@ -216,6 +216,10 @@ For associative lists:
 The fast-forward strategy updates a local package with the changes from upstream, but will
 fail if the local package has been modified since it was fetched.
 
+Render status (`status.renderStatus` and the `Rendered` condition in `status.conditions`) written by `kpt fn render` 
+is not considered a local modification. It is automatically cleared from the local Kptfile after a successful 
+fast-forward update.
+
 #### Force-delete-replace strategy
 
 The force-delete-replace strategy updates a local package with changes from upstream, but will

--- a/documentation/content/en/reference/cli/pkg/update/_index.md
+++ b/documentation/content/en/reference/cli/pkg/update/_index.md
@@ -216,8 +216,8 @@ For associative lists:
 The fast-forward strategy updates a local package with the changes from upstream, but will
 fail if the local package has been modified since it was fetched.
 
-Render status (`status.renderStatus` and the `Rendered` condition in `status.conditions`) written by `kpt fn render` 
-is not considered a local modification. It is automatically cleared from the local Kptfile after a successful 
+Render status (`status.renderStatus` and the `Rendered` condition in `status.conditions`) written by `kpt fn render`
+is not considered a local modification. It is automatically cleared from the local Kptfile after a successful
 fast-forward update.
 
 #### Force-delete-replace strategy

--- a/internal/testutil/pkgbuilder/builder.go
+++ b/internal/testutil/pkgbuilder/builder.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The kpt Authors
+// Copyright 2020-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -329,6 +329,7 @@ type Kptfile struct {
 	UpstreamLock *UpstreamLock
 	Pipeline     *Pipeline
 	Inventory    *Inventory
+	Status       *kptfilev1.Status
 }
 
 func NewKptfile() *Kptfile {
@@ -385,6 +386,30 @@ func (k *Kptfile) WithUpstreamLockRef(repoRef, dir, ref string, index int) *Kptf
 		Dir:     dir,
 		Ref:     ref,
 		Index:   index,
+	}
+	return k
+}
+
+// WithStatusCondition adds a status condition to the Kptfile.
+func (k *Kptfile) WithStatusCondition(condition kptfilev1.Condition) *Kptfile {
+	if k.Status == nil {
+		k.Status = &kptfilev1.Status{
+			Conditions: []kptfilev1.Condition{},
+		}
+	}
+	k.Status.Conditions = append(k.Status.Conditions, condition)
+	return k
+}
+
+// WithStatusRenderStatus adds render status info to the Kptfile.
+func (k *Kptfile) WithStatusRenderStatus(mutationSteps []kptfilev1.PipelineStepResult, validationSteps []kptfilev1.PipelineStepResult, errorSummary string) *Kptfile {
+	if k.Status == nil {
+		k.Status = &kptfilev1.Status{}
+	}
+	k.Status.RenderStatus = &kptfilev1.RenderStatus{
+		MutationSteps:   mutationSteps,
+		ValidationSteps: validationSteps,
+		ErrorSummary:    errorSummary,
 	}
 	return k
 }
@@ -644,6 +669,9 @@ func buildKptfile(pkg *pkg, pkgName string, reposInfo ReposInfo) string {
 		if inventory.ID != "" {
 			kptfile.Inventory.InventoryID = inventory.ID
 		}
+	}
+	if pkg.Kptfile.Status != nil {
+		kptfile.Status = pkg.Kptfile.Status
 	}
 	b, err := yaml.Marshal(kptfile)
 	if err != nil {

--- a/internal/util/update/fastforward.go
+++ b/internal/util/update/fastforward.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"slices"
 
 	"github.com/kptdev/kpt/internal/pkg"
@@ -186,7 +185,7 @@ func clearRenderStatus(kf *kptfilev1.KptFile) {
 	if len(kf.Status.Conditions) == 0 {
 		kf.Status.Conditions = nil
 	}
-	if reflect.DeepEqual(*kf.Status, kptfilev1.Status{}) {
+	if kf.Status.IsEmpty() {
 		kf.Status = nil
 	}
 }

--- a/internal/util/update/fastforward.go
+++ b/internal/util/update/fastforward.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"slices"
 
 	"github.com/kptdev/kpt/internal/pkg"
 	"github.com/kptdev/kpt/internal/types"
@@ -55,6 +57,16 @@ func (u FastForwardUpdater) Update(options updatetypes.Options) error {
 	}
 
 	if err := (&ReplaceUpdater{}).Update(options); err != nil {
+		return errors.E(op, types.UniquePath(options.LocalPath), err)
+	}
+
+	// Remove stale render status from the updated local Kptfile.
+	localKf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, options.LocalPath)
+	if err != nil {
+		return errors.E(op, types.UniquePath(options.LocalPath), err)
+	}
+	clearRenderStatus(localKf)
+	if err := kptfileutil.WriteFile(options.LocalPath, localKf); err != nil {
 		return errors.E(op, types.UniquePath(options.LocalPath), err)
 	}
 	return nil
@@ -126,6 +138,7 @@ func hasKfDiff(localPath, orgPath string) (bool, error) {
 	}
 	localKf.Upstream = nil
 	localKf.UpstreamLock = nil
+	clearRenderStatus(localKf)
 
 	_, err = os.Stat(filepath.Join(orgPath, kptfilev1.KptFileName))
 	if err != nil {
@@ -146,6 +159,7 @@ func hasKfDiff(localPath, orgPath string) (bool, error) {
 		return false, errors.E(op, types.UniquePath(localPath), err)
 	}
 
+	clearRenderStatus(orgKf)
 	orgKf.Name = localKf.Name
 	equal, err := kptfileutil.Equal(localKf, orgKf)
 	if err != nil {
@@ -158,4 +172,21 @@ func hasKfDiff(localPath, orgPath string) (bool, error) {
 func isDefaultKptfile(localKf *kptfilev1.KptFile, name string) (bool, error) {
 	defaultKf := kptfileutil.DefaultKptfile(name)
 	return kptfileutil.Equal(localKf, defaultKf)
+}
+
+func clearRenderStatus(kf *kptfilev1.KptFile) {
+	if kf.Status == nil {
+		return
+	}
+	kf.Status.RenderStatus = nil
+
+	kf.Status.Conditions = slices.DeleteFunc(kf.Status.Conditions, func(condition kptfilev1.Condition) bool {
+		return condition.Type == kptfilev1.ConditionTypeRendered
+	})
+	if len(kf.Status.Conditions) == 0 {
+		kf.Status.Conditions = nil
+	}
+	if reflect.DeepEqual(*kf.Status, kptfilev1.Status{}) {
+		kf.Status = nil
+	}
 }

--- a/internal/util/update/fastforward_test.go
+++ b/internal/util/update/fastforward_test.go
@@ -27,8 +27,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const setLabelsImageV01 = "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1"
+
 func TestUpdate_FastForward(t *testing.T) {
-	setLabelsImage := "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1"
 	testCases := map[string]struct {
 		origin         *pkgbuilder.RootPkg
 		local          *pkgbuilder.RootPkg
@@ -175,7 +176,7 @@ func TestUpdate_FastForward(t *testing.T) {
 						WithStatusCondition(kptfilev1.NewRenderedCondition(
 							kptfilev1.ConditionTrue, kptfilev1.ReasonRenderSuccess, "")).
 						WithStatusRenderStatus(
-							[]kptfilev1.PipelineStepResult{{Image: setLabelsImage, ExitCode: 0}},
+							[]kptfilev1.PipelineStepResult{{Image: setLabelsImageV01, ExitCode: 0}},
 							nil, ""),
 				).
 				WithResource(pkgbuilder.DeploymentResource),
@@ -216,7 +217,7 @@ func TestUpdate_FastForward(t *testing.T) {
 						WithStatusCondition(kptfilev1.NewRenderedCondition(
 							kptfilev1.ConditionTrue, kptfilev1.ReasonRenderSuccess, "")).
 						WithStatusRenderStatus(
-							[]kptfilev1.PipelineStepResult{{Image: setLabelsImage, ExitCode: 0}},
+							[]kptfilev1.PipelineStepResult{{Image: setLabelsImageV01, ExitCode: 0}},
 							nil, ""),
 				).
 				WithResource(pkgbuilder.DeploymentResource),
@@ -262,7 +263,7 @@ func TestUpdate_FastForward(t *testing.T) {
 						WithStatusCondition(kptfilev1.NewRenderedCondition(
 							kptfilev1.ConditionTrue, kptfilev1.ReasonRenderSuccess, "")).
 						WithStatusRenderStatus(
-							[]kptfilev1.PipelineStepResult{{Image: setLabelsImage, ExitCode: 0}},
+							[]kptfilev1.PipelineStepResult{{Image: setLabelsImageV01, ExitCode: 0}},
 							nil, ""),
 				).
 				WithResource(pkgbuilder.DeploymentResource),
@@ -288,7 +289,7 @@ func TestUpdate_FastForward(t *testing.T) {
 						WithStatusCondition(kptfilev1.NewRenderedCondition(
 							kptfilev1.ConditionFalse, kptfilev1.ReasonRenderFailed, "function failed")).
 						WithStatusRenderStatus(
-							[]kptfilev1.PipelineStepResult{{Image: setLabelsImage, ExitCode: 1, ExecutionError: "validation error"}},
+							[]kptfilev1.PipelineStepResult{{Image: setLabelsImageV01, ExitCode: 1, ExecutionError: "validation error"}},
 							nil, "render failed"),
 				).
 				WithResource(pkgbuilder.DeploymentResource),
@@ -348,11 +349,11 @@ func TestFastForward_RenderStatusDoesNotMaskLocalEdits(t *testing.T) {
 			pkgbuilder.NewKptfile().
 				WithUpstream(kptRepo, "/", "master", "fast-forward").
 				WithUpstreamLock(kptRepo, "/", "master", "abc123").
-				WithPipeline(pkgbuilder.NewFunction("ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1")).
+				WithPipeline(pkgbuilder.NewFunction(setLabelsImageV01)).
 				WithStatusCondition(kptfilev1.NewRenderedCondition(
 					kptfilev1.ConditionTrue, kptfilev1.ReasonRenderSuccess, "")).
 				WithStatusRenderStatus(
-					[]kptfilev1.PipelineStepResult{{Image: "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1", ExitCode: 0}},
+					[]kptfilev1.PipelineStepResult{{Image: setLabelsImageV01, ExitCode: 0}},
 					nil, ""),
 		).
 		WithResource(pkgbuilder.DeploymentResource).
@@ -372,6 +373,7 @@ func TestFastForward_RenderStatusDoesNotMaskLocalEdits(t *testing.T) {
 		UpdatedPath:    filepath.Join(updated, "/"),
 		IsRoot:         true,
 	})
-	assert.Error(t, err, "local pipeline change should block fast-forward even with render status present")
-	assert.Contains(t, err.Error(), "local package files have been modified")
+	if assert.Error(t, err, "local pipeline change should block fast-forward even with render status present") {
+		assert.Contains(t, err.Error(), "local package files have been modified")
+	}
 }

--- a/internal/util/update/fastforward_test.go
+++ b/internal/util/update/fastforward_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The kpt Authors
+// Copyright 2021-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,11 +22,13 @@ import (
 	"github.com/kptdev/kpt/internal/testutil"
 	"github.com/kptdev/kpt/internal/testutil/pkgbuilder"
 	"github.com/kptdev/kpt/internal/util/update"
-	updatetypes "github.com/kptdev/kpt/pkg/lib/update/updatetypes"
+	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
+	"github.com/kptdev/kpt/pkg/lib/update/updatetypes"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestUpdate_FastForward(t *testing.T) {
+	setLabelsImage := "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1"
 	testCases := map[string]struct {
 		origin         *pkgbuilder.RootPkg
 		local          *pkgbuilder.RootPkg
@@ -161,8 +163,149 @@ func TestUpdate_FastForward(t *testing.T) {
 				).
 				WithResource(pkgbuilder.ConfigMapResource),
 		},
+		"render status on local Kptfile does not block fast-forward": {
+			origin: pkgbuilder.NewRootPkg().
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource),
+			local: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstream(kptRepo, "/", "master", "fast-forward").
+						WithUpstreamLock(kptRepo, "/", "master", "abc123").
+						WithStatusCondition(kptfilev1.NewRenderedCondition(
+							kptfilev1.ConditionTrue, kptfilev1.ReasonRenderSuccess, "")).
+						WithStatusRenderStatus(
+							[]kptfilev1.PipelineStepResult{{Image: setLabelsImage, ExitCode: 0}},
+							nil, ""),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+			updated: pkgbuilder.NewRootPkg().
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource),
+			relPackagePath: "/",
+			isRoot:         true,
+			expected: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstream(kptRepo, "/", "master", "fast-forward").
+						WithUpstreamLock(kptRepo, "/", "master", "abc123"),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+		},
+		"non-rendered conditions are preserved after fast-forward": {
+			origin: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithStatusCondition(kptfilev1.Condition{
+							Type:   "Ready",
+							Status: kptfilev1.ConditionTrue,
+							Reason: "AllReady",
+						}),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+			local: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstream(kptRepo, "/", "master", "fast-forward").
+						WithUpstreamLock(kptRepo, "/", "master", "abc123").
+						WithStatusCondition(kptfilev1.Condition{
+							Type:   "Ready",
+							Status: kptfilev1.ConditionTrue,
+							Reason: "AllReady",
+						}).
+						WithStatusCondition(kptfilev1.NewRenderedCondition(
+							kptfilev1.ConditionTrue, kptfilev1.ReasonRenderSuccess, "")).
+						WithStatusRenderStatus(
+							[]kptfilev1.PipelineStepResult{{Image: setLabelsImage, ExitCode: 0}},
+							nil, ""),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+			updated: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithStatusCondition(kptfilev1.Condition{
+							Type:   "Ready",
+							Status: kptfilev1.ConditionTrue,
+							Reason: "AllReady",
+						}),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+			relPackagePath: "/",
+			isRoot:         true,
+			expected: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstream(kptRepo, "/", "master", "fast-forward").
+						WithUpstreamLock(kptRepo, "/", "master", "abc123").
+						WithStatusCondition(kptfilev1.Condition{
+							Type:   "Ready",
+							Status: kptfilev1.ConditionTrue,
+							Reason: "AllReady",
+						}),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+		},
+		"upstream render status is cleared after fast-forward": {
+			origin: pkgbuilder.NewRootPkg().
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource),
+			local: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstream(kptRepo, "/", "master", "fast-forward").
+						WithUpstreamLock(kptRepo, "/", "master", "abc123"),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+			updated: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithStatusCondition(kptfilev1.NewRenderedCondition(
+							kptfilev1.ConditionTrue, kptfilev1.ReasonRenderSuccess, "")).
+						WithStatusRenderStatus(
+							[]kptfilev1.PipelineStepResult{{Image: setLabelsImage, ExitCode: 0}},
+							nil, ""),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+			relPackagePath: "/",
+			isRoot:         true,
+			expected: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstream(kptRepo, "/", "master", "fast-forward").
+						WithUpstreamLock(kptRepo, "/", "master", "abc123"),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+		},
+		"failed render status is cleared after fast-forward": {
+			origin: pkgbuilder.NewRootPkg().
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource),
+			local: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstream(kptRepo, "/", "master", "fast-forward").
+						WithUpstreamLock(kptRepo, "/", "master", "abc123").
+						WithStatusCondition(kptfilev1.NewRenderedCondition(
+							kptfilev1.ConditionFalse, kptfilev1.ReasonRenderFailed, "function failed")).
+						WithStatusRenderStatus(
+							[]kptfilev1.PipelineStepResult{{Image: setLabelsImage, ExitCode: 1, ExecutionError: "validation error"}},
+							nil, "render failed"),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+			updated: pkgbuilder.NewRootPkg().
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource),
+			relPackagePath: "/",
+			isRoot:         true,
+			expected: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstream(kptRepo, "/", "master", "fast-forward").
+						WithUpstreamLock(kptRepo, "/", "master", "abc123"),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+		},
 	}
-
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
 			repos := testutil.EmptyReposInfo
@@ -187,4 +330,48 @@ func TestUpdate_FastForward(t *testing.T) {
 			testutil.KptfileAwarePkgEqual(t, local, expected, false)
 		})
 	}
+}
+
+// TestFastForward_RenderStatusDoesNotMaskLocalEdits verifies that real local
+// changes (e.g. pipeline edits) still block fast-forward even when render
+// status is also present.
+func TestFastForward_RenderStatusDoesNotMaskLocalEdits(t *testing.T) {
+	repos := testutil.EmptyReposInfo
+
+	origin := pkgbuilder.NewRootPkg().
+		WithKptfile().
+		WithResource(pkgbuilder.DeploymentResource).
+		ExpandPkg(t, repos)
+
+	local := pkgbuilder.NewRootPkg().
+		WithKptfile(
+			pkgbuilder.NewKptfile().
+				WithUpstream(kptRepo, "/", "master", "fast-forward").
+				WithUpstreamLock(kptRepo, "/", "master", "abc123").
+				WithPipeline(pkgbuilder.NewFunction("ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1")).
+				WithStatusCondition(kptfilev1.NewRenderedCondition(
+					kptfilev1.ConditionTrue, kptfilev1.ReasonRenderSuccess, "")).
+				WithStatusRenderStatus(
+					[]kptfilev1.PipelineStepResult{{Image: "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1", ExitCode: 0}},
+					nil, ""),
+		).
+		WithResource(pkgbuilder.DeploymentResource).
+		ExpandPkg(t, repos)
+
+	updated := pkgbuilder.NewRootPkg().
+		WithKptfile().
+		WithResource(pkgbuilder.DeploymentResource).
+		ExpandPkg(t, repos)
+
+	updater := &update.FastForwardUpdater{}
+
+	err := updater.Update(updatetypes.Options{
+		RelPackagePath: "/",
+		OriginPath:     filepath.Join(origin, "/"),
+		LocalPath:      filepath.Join(local, "/"),
+		UpdatedPath:    filepath.Join(updated, "/"),
+		IsRoot:         true,
+	})
+	assert.Error(t, err, "local pipeline change should block fast-forward even with render status present")
+	assert.Contains(t, err.Error(), "local package files have been modified")
 }

--- a/pkg/api/kptfile/v1/types.go
+++ b/pkg/api/kptfile/v1/types.go
@@ -414,6 +414,11 @@ type Status struct {
 	RenderStatus *RenderStatus `yaml:"renderStatus,omitempty" json:"renderStatus,omitempty"`
 }
 
+// IsEmpty returns true if the Status has no meaningful content.
+func (s Status) IsEmpty() bool {
+	return len(s.Conditions) == 0 && s.RenderStatus == nil
+}
+
 // RenderStatus represents the result of performing render operation
 // on a package's resources.
 type RenderStatus struct {


### PR DESCRIPTION
`kpt fn render` writes render status (`status.renderStatus` and a `Rendered` condition) to the Kptfile. This caused `kpt pkg update --strategy fast-forward` to fail with "local package files have been modified" even though the user made no manual changes.

Closes https://github.com/kptdev/kpt/issues/4475

  ### Changes

  - Add `clearRenderStatus()` to strip render status from both local and origin Kptfiles before comparison in `hasKfDiff`, so it's not treated as a local modification
  - Clear stale render status from the local Kptfile after a successful fast-forward update
  - Preserve non-rendered conditions (e.g. `Ready`)
  - Update `pkg update` docs for the fast-forward strategy section

  ### Tests
  - Render status on local doesn't block fast-forward
  - Upstream render status is cleared after update
  - Failed render status is cleared after update
  - Non-rendered conditions are preserved
  - Real local edits (e.g. pipeline changes) still block fast-forward