### PR TITLE
Expose code from `internal` package

### DIFF
--- a/commands/fn/doc/cmdfndoc.go
+++ b/commands/fn/doc/cmdfndoc.go
@@ -23,7 +23,7 @@ import (
 	"os/exec"
 
 	"github.com/kptdev/kpt/internal/docs/generated/fndocs"
-	"github.com/kptdev/kpt/internal/fnruntime"
+	fnruntime "github.com/kptdev/kpt/pkg/fn/runtime"
 	"github.com/kptdev/kpt/pkg/lib/runneroptions"
 	"github.com/kptdev/kpt/pkg/lib/util/cmdutil"
 	"github.com/kptdev/kpt/pkg/printer"

--- a/commands/fn/doc/cmdfndoc_test.go
+++ b/commands/fn/doc/cmdfndoc_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/kptdev/kpt/commands/fn/doc"
-	"github.com/kptdev/kpt/internal/fnruntime"
+	fnruntime "github.com/kptdev/kpt/pkg/fn/runtime"
 	"github.com/kptdev/kpt/pkg/printer/fake"
 	"sigs.k8s.io/kustomize/kyaml/testutil"
 )

--- a/e2e/fn_test.go
+++ b/e2e/fn_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kptdev/kpt/internal/fnruntime"
+	fnruntime "github.com/kptdev/kpt/pkg/fn/runtime"
 	"github.com/kptdev/kpt/pkg/test/runner"
 )
 

--- a/internal/hook/executor.go
+++ b/internal/hook/executor.go
@@ -19,12 +19,12 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/kptdev/kpt/internal/fnruntime"
 	"github.com/kptdev/kpt/internal/pkg"
 	"github.com/kptdev/kpt/internal/types"
 	fnresult "github.com/kptdev/kpt/pkg/api/fnresult/v1"
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
 	"github.com/kptdev/kpt/pkg/fn"
+	fnruntime "github.com/kptdev/kpt/pkg/fn/runtime"
 	"github.com/kptdev/kpt/pkg/lib/runneroptions"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"

--- a/internal/util/render/executor.go
+++ b/internal/util/render/executor.go
@@ -23,7 +23,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/kptdev/kpt/internal/fnruntime"
 	"github.com/kptdev/kpt/internal/pkg"
 	"github.com/kptdev/kpt/internal/types"
 	"github.com/kptdev/kpt/internal/util/attribution"
@@ -31,6 +30,7 @@ import (
 	fnresult "github.com/kptdev/kpt/pkg/api/fnresult/v1"
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
 	"github.com/kptdev/kpt/pkg/fn"
+	fnruntime "github.com/kptdev/kpt/pkg/fn/runtime"
 	"github.com/kptdev/kpt/pkg/kptfile/kptfileutil"
 	"github.com/kptdev/kpt/pkg/lib/errors"
 	"github.com/kptdev/kpt/pkg/lib/runneroptions"

--- a/internal/util/render/executor_test.go
+++ b/internal/util/render/executor_test.go
@@ -22,11 +22,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/kptdev/kpt/internal/fnruntime"
 	"github.com/kptdev/kpt/internal/pkg"
 	"github.com/kptdev/kpt/internal/types"
 	fnresult "github.com/kptdev/kpt/pkg/api/fnresult/v1"
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
+	fnruntime "github.com/kptdev/kpt/pkg/fn/runtime"
 	"github.com/kptdev/kpt/pkg/kptfile/kptfileutil"
 	"github.com/kptdev/kpt/pkg/printer"
 	"github.com/stretchr/testify/assert"

--- a/pkg/fn/runtime/container.go
+++ b/pkg/fn/runtime/container.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 import (
 	"bufio"

--- a/pkg/fn/runtime/container_test.go
+++ b/pkg/fn/runtime/container_test.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 import (
 	"bytes"

--- a/pkg/fn/runtime/container_utils.go
+++ b/pkg/fn/runtime/container_utils.go
@@ -1,4 +1,4 @@
-package fnruntime
+package runtime
 
 import (
 	"bytes"

--- a/pkg/fn/runtime/container_utils_test.go
+++ b/pkg/fn/runtime/container_utils_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 import (
 	"testing"

--- a/pkg/fn/runtime/exec.go
+++ b/pkg/fn/runtime/exec.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 import (
 	"bytes"

--- a/pkg/fn/runtime/fnerrors.go
+++ b/pkg/fn/runtime/fnerrors.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 import (
 	"fmt"

--- a/pkg/fn/runtime/fnerrors_test.go
+++ b/pkg/fn/runtime/fnerrors_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 import (
 	"bytes"

--- a/pkg/fn/runtime/imagepullpolicy.go
+++ b/pkg/fn/runtime/imagepullpolicy.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 import (
 	"fmt"

--- a/pkg/fn/runtime/jsglue.go
+++ b/pkg/fn/runtime/jsglue.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 // The glue code below has been tested with node.js v18.6.0.
 // It may need some small changes to work with v14 and v16.

--- a/pkg/fn/runtime/nodejs.go
+++ b/pkg/fn/runtime/nodejs.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 import (
 	"fmt"

--- a/pkg/fn/runtime/runner.go
+++ b/pkg/fn/runtime/runner.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 import (
 	"context"

--- a/pkg/fn/runtime/runner_test.go
+++ b/pkg/fn/runtime/runner_test.go
@@ -14,7 +14,7 @@
 
 // Package pipeline provides struct definitions for Pipeline and utility
 // methods to read and write a pipeline resource.
-package fnruntime
+package runtime
 
 import (
 	"bytes"

--- a/pkg/fn/runtime/tag_resolution.go
+++ b/pkg/fn/runtime/tag_resolution.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 import (
 	"context"

--- a/pkg/fn/runtime/tag_resolution_test.go
+++ b/pkg/fn/runtime/tag_resolution_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 import (
 	"context"

--- a/pkg/fn/runtime/utils.go
+++ b/pkg/fn/runtime/utils.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 import (
 	"bytes"

--- a/pkg/fn/runtime/utils_test.go
+++ b/pkg/fn/runtime/utils_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 import (
 	"testing"

--- a/pkg/fn/runtime/wasm.go
+++ b/pkg/fn/runtime/wasm.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 import (
 	"context"

--- a/pkg/fn/runtime/wasmtime.go
+++ b/pkg/fn/runtime/wasmtime.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 import (
 	"errors"
@@ -23,7 +23,7 @@ import (
 	"log"
 	"os"
 
-	wasmtime "github.com/bytecodealliance/wasmtime-go"
+	"github.com/bytecodealliance/wasmtime-go"
 	"github.com/prep/wasmexec"
 	"github.com/prep/wasmexec/wasmtimexec"
 	"sigs.k8s.io/kustomize/kyaml/yaml"

--- a/pkg/fn/runtime/wasmtime_unsupported.go
+++ b/pkg/fn/runtime/wasmtime_unsupported.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package fnruntime
+package runtime
 
 // Stub functions for running without wasmtime support compiled in.
 // wasmtime requires cgo, which is not always a viable option.

--- a/pkg/lib/errors/resolver/container.go
+++ b/pkg/lib/errors/resolver/container.go
@@ -17,7 +17,7 @@ package resolver
 import (
 	"errors"
 
-	"github.com/kptdev/kpt/internal/fnruntime"
+	fnruntime "github.com/kptdev/kpt/pkg/fn/runtime"
 )
 
 //nolint:gochecknoinits

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/kptdev/kpt/internal/fnruntime"
+	fnruntime "github.com/kptdev/kpt/pkg/fn/runtime"
 )
 
 // Runner runs an e2e test

--- a/thirdparty/kyaml/runfn/runfn.go
+++ b/thirdparty/kyaml/runfn/runfn.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/kptdev/kpt/internal/types"
+	fnruntime "github.com/kptdev/kpt/pkg/fn/runtime"
 	"github.com/kptdev/kpt/pkg/lib/runneroptions"
 	"github.com/kptdev/kpt/pkg/printer"
 	"sigs.k8s.io/kustomize/kyaml/errors"
@@ -21,7 +22,6 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 
-	"github.com/kptdev/kpt/internal/fnruntime"
 	"github.com/kptdev/kpt/internal/pkg"
 	"github.com/kptdev/kpt/internal/util/printerutil"
 	fnresult "github.com/kptdev/kpt/pkg/api/fnresult/v1"


### PR DESCRIPTION
I've moved some code from the `internal` package to `pkg` so it can be used externally. The main use-case for this is Porch at the moment.

Currently moved:
- `internal/fnruntime` → `pkg/fn/runtime`