### PR TITLE
  fix: remove porch references from kpt docs (#4288)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,11 +15,6 @@ Please refer to the [release notes] page for more information about the latest f
 
 A few areas of work are ongoing. (This is not exhaustive.)
 
-### Package orchestration
-
-Porch is the recommended approach for package orchestration. See the
-[package orchestration documentation](https://docs.nephio.org/docs/porch/) for more details.
-
 ### Explore various options for function runtime
 
 Currently, `kpt fn render` has dependency on docker to execute functions in pipeline.

--- a/documentation/content/en/faq.md
+++ b/documentation/content/en/faq.md
@@ -50,7 +50,7 @@ _kpt_
 - Enables workflows that combine programmatic changes ([functions]) with manual
   edits.
 - Aims to support mutating and validating admission control on derived packages.
-- Also supports packages, [package orchestration], resource actuation, and GitOps.
+- Also supports packages, package orchestration (see [Nephio documentation](https://docs.porch.nephio.org/)), resource actuation, and GitOps.
 
 ### Do kpt and kustomize work together?
 
@@ -122,8 +122,6 @@ don't have to alias it. It is pronounced "kept".
 
 [Configuration as Data]:
   https://github.com/kptdev/kpt/blob/main/docs/design-docs/06-config-as-data.md
-[package orchestration]:
-  https://github.com/kptdev/kpt/blob/main/docs/design-docs/07-package-orchestration.md
 [the kubernetes resource model]:
   https://github.com/kubernetes/design-proposals-archive/blob/main/architecture/resource-management.md
 [declarative application management in kubernetes]:


### PR DESCRIPTION
 ## Summary
  - Remove Package Orchestration section from ROADMAP.md that references Porch
  - Update FAQ to point package orchestration link to Nephio documentation instead of internal docs
  - Remove unused [package orchestration] link reference definition

  ## Changes
  - `docs/ROADMAP.md`: Remove porch reference from Package Orchestration section
  - `documentation/content/en/faq.md`: Update link to point to https://docs.porch.nephio.org/

  ## Related Issue
  Fixes #4288
