### PR TITLE
Display non-KRM files in kpt pkg tree output

### DIFF
--- a/internal/docs/generated/pkgdocs/docs.go
+++ b/internal/docs/generated/pkgdocs/docs.go
@@ -211,6 +211,13 @@ var InitExamples = `
 var TreeShort = `Display resources, files and packages in a tree structure.`
 var TreeLong = `
   kpt pkg tree [DIR]
+
+Args:
+
+  DIR:
+    Path to a local package directory. Defaults to the current directory.
+    Displays KRM resources with their Kind and Name, and non-KRM text files
+    as plain filenames. Dotfiles and symlinks are excluded.
 `
 var TreeExamples = `
   # Show resources in the current directory.

--- a/thirdparty/cmdconfig/commands/cmdtree/cmdtree.go
+++ b/thirdparty/cmdconfig/commands/cmdtree/cmdtree.go
@@ -1,11 +1,26 @@
-// Copyright 2019 The Kubernetes Authors.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright 2019,2026 The kpt Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package cmdtree
 
 import (
 	"context"
+	"fmt"
+	"io/fs"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/kptdev/kpt/internal/docs/generated/pkgdocs"
 	"github.com/kptdev/kpt/internal/util/argutil"
@@ -45,6 +60,9 @@ type TreeRunner struct {
 }
 
 func (r *TreeRunner) runE(c *cobra.Command, args []string) error {
+	if err := r.Ctx.Err(); err != nil {
+		return err
+	}
 	var input kio.Reader
 	var root = "."
 	if len(args) == 0 {
@@ -69,10 +87,47 @@ func (r *TreeRunner) runE(c *cobra.Command, args []string) error {
 		Inputs:  []kio.Reader{input},
 		Filters: fltrs,
 		Outputs: []kio.Writer{TreeWriter{
-			Root:   root,
-			Writer: printer.FromContextOrDie(r.Ctx).OutStream(),
+			Root:        root,
+			Writer:      printer.FromContextOrDie(r.Ctx).OutStream(),
+			NonKRMFiles: discoverNonKRMFiles(r.Ctx, resolvedPath),
 		}},
 	}.Execute())
+}
+
+// discoverNonKRMFiles walks the package tree and returns filenames
+// indexed by their package-relative directory path. Symlinks are skipped.
+// Files that are successfully rendered as KRM resources will be deduplicated
+// by the TreeWriter.
+func discoverNonKRMFiles(ctx context.Context, root string) map[string][]string {
+	result := map[string][]string{}
+	pr := printer.FromContextOrDie(ctx)
+
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			fmt.Fprintf(pr.ErrStream(), "[WARN] %s: %v\n", path, err)
+			return nil
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		name := d.Name()
+		if d.IsDir() {
+			if path != root && strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasPrefix(name, ".") {
+			return nil
+		}
+		if name == kptfilev1.KptFileName {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, filepath.Dir(path))
+		result[rel] = append(result[rel], name)
+		return nil
+	})
+	return result
 }
 
 func (r *TreeRunner) getMatchFilesGlob() []string {

--- a/thirdparty/cmdconfig/commands/cmdtree/cmdtree.go
+++ b/thirdparty/cmdconfig/commands/cmdtree/cmdtree.go
@@ -95,17 +95,20 @@ func (r *TreeRunner) runE(c *cobra.Command, args []string) error {
 }
 
 // discoverNonKRMFiles walks the package tree and returns filenames
-// indexed by their package-relative directory path. Symlinks are skipped.
-// Files that are successfully rendered as KRM resources will be deduplicated
-// by the TreeWriter.
+// indexed by their containing directory path relative to root.
+// Symlinks are skipped. Files that are successfully rendered as KRM resources
+// will be deduplicated by the TreeWriter.
 func discoverNonKRMFiles(ctx context.Context, root string) map[string][]string {
 	result := map[string][]string{}
 	pr := printer.FromContextOrDie(ctx)
 
-	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			fmt.Fprintf(pr.ErrStream(), "[WARN] %s: %v\n", path, err)
 			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
 		}
 		if d.Type()&os.ModeSymlink != 0 {
 			return nil
@@ -123,10 +126,16 @@ func discoverNonKRMFiles(ctx context.Context, root string) map[string][]string {
 		if name == kptfilev1.KptFileName {
 			return nil
 		}
-		rel, _ := filepath.Rel(root, filepath.Dir(path))
+		rel, err := filepath.Rel(root, filepath.Dir(path))
+		if err != nil {
+			fmt.Fprintf(pr.ErrStream(), "[WARN] %s: %v\n", path, err)
+			return nil
+		}
 		result[rel] = append(result[rel], name)
 		return nil
-	})
+	}); err != nil && ctx.Err() == nil {
+		fmt.Fprintf(pr.ErrStream(), "[WARN] failed to walk %s: %v\n", root, err)
+	}
 	return result
 }
 

--- a/thirdparty/cmdconfig/commands/cmdtree/cmdtree.go
+++ b/thirdparty/cmdconfig/commands/cmdtree/cmdtree.go
@@ -1,4 +1,5 @@
-// Copyright 2019,2026 The kpt Authors.
+// Copyright 2019 The Kubernetes Authors.
+// Copyright 2026 The kpt Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/thirdparty/cmdconfig/commands/cmdtree/cmdtree_test.go
+++ b/thirdparty/cmdconfig/commands/cmdtree/cmdtree_test.go
@@ -1,5 +1,16 @@
-// Copyright 2019 The Kubernetes Authors.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright 2019,2026 The kpt Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package cmdtree
 
@@ -8,11 +19,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kptdev/kpt/internal/testutil"
 	"github.com/kptdev/kpt/pkg/printer/fake"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTreeCommandDefaultCurDir_files(t *testing.T) {
@@ -207,7 +220,8 @@ resources:
 	}
 
 	if !assert.Equal(t, fmt.Sprintf(`%s
-└── [f2.yaml]  Deployment bar
+├── [f2.yaml]  Deployment bar
+└── Kustomization
 `, filepath.Base(d)), b.String()) {
 		return
 	}
@@ -479,4 +493,106 @@ spec:
 		return
 	}
 	assert.Contains(t, stderr.String(), "please note that the symlinks within the package are ignored")
+}
+
+// TestTreeCommand_NonKRMInSubpackage verifies non-KRM files in a subpackage
+// appear under the subpackage branch, not the parent.
+func TestTreeCommand_NonKRMInSubpackage(t *testing.T) {
+	d := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(d, "Kptfile"), []byte("apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: root\n"), 0600))
+	require.NoError(t, os.MkdirAll(filepath.Join(d, "sub"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(d, "sub", "Kptfile"), []byte("apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: sub\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(d, "sub", "NOTES.txt"), []byte("hello\n"), 0600))
+
+	b := &bytes.Buffer{}
+	r := GetTreeRunner(fake.CtxWithPrinter(b, nil), "")
+	r.Command.SetArgs([]string{d})
+	r.Command.SetOut(b)
+	require.NoError(t, r.Command.Execute())
+
+	out := b.String()
+	assert.Contains(t, out, "NOTES.txt")
+	subIdx := strings.Index(out, `Package "sub"`)
+	notesIdx := strings.Index(out, "NOTES.txt")
+	assert.Greater(t, notesIdx, subIdx, "NOTES.txt should be under the subpackage branch")
+}
+
+// TestTreeCommand_DotfilesExcluded verifies dotfiles and dot-dirs are excluded.
+func TestTreeCommand_DotfilesExcluded(t *testing.T) {
+	d := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(d, "Kptfile"), []byte("apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: root\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(d, ".hidden"), []byte("secret\n"), 0600))
+	require.NoError(t, os.MkdirAll(filepath.Join(d, ".git"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(d, ".git", "config"), []byte("[core]\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(d, "visible.txt"), []byte("hi\n"), 0600))
+
+	b := &bytes.Buffer{}
+	r := GetTreeRunner(fake.CtxWithPrinter(b, nil), "")
+	r.Command.SetArgs([]string{d})
+	r.Command.SetOut(b)
+	require.NoError(t, r.Command.Execute())
+
+	out := b.String()
+	assert.Contains(t, out, "visible.txt")
+	assert.NotContains(t, out, ".hidden")
+	assert.NotContains(t, out, ".git")
+	assert.NotContains(t, out, "config")
+}
+
+// TestTreeCommand_SymlinkFileSkipped verifies symlinked files inside a package are skipped.
+func TestTreeCommand_SymlinkFileSkipped(t *testing.T) {
+	d := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(d, "Kptfile"), []byte("apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: root\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(d, "real.txt"), []byte("content\n"), 0600))
+	require.NoError(t, os.Symlink(filepath.Join(d, "real.txt"), filepath.Join(d, "link.txt")))
+
+	b := &bytes.Buffer{}
+	r := GetTreeRunner(fake.CtxWithPrinter(b, nil), "")
+	r.Command.SetArgs([]string{d})
+	r.Command.SetOut(b)
+	require.NoError(t, r.Command.Execute())
+
+	out := b.String()
+	assert.Contains(t, out, "real.txt")
+	assert.NotContains(t, out, "link.txt")
+}
+
+// TestTreeCommand_MultipleNonKRMSorted verifies multiple non-KRM files are sorted.
+func TestTreeCommand_MultipleNonKRMSorted(t *testing.T) {
+	d := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(d, "Kptfile"), []byte("apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: root\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(d, "zebra.md"), []byte("z\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(d, "alpha.txt"), []byte("a\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(d, "middle.log"), []byte("m\n"), 0600))
+
+	b := &bytes.Buffer{}
+	r := GetTreeRunner(fake.CtxWithPrinter(b, nil), "")
+	r.Command.SetArgs([]string{d})
+	r.Command.SetOut(b)
+	require.NoError(t, r.Command.Execute())
+
+	out := b.String()
+	alphaIdx := strings.Index(out, "alpha.txt")
+	middleIdx := strings.Index(out, "middle.log")
+	zebraIdx := strings.Index(out, "zebra.md")
+	assert.Less(t, alphaIdx, middleIdx, "alpha.txt should come before middle.log")
+	assert.Less(t, middleIdx, zebraIdx, "middle.log should come before zebra.md")
+}
+
+// TestTreeCommand_DedupKRMFile verifies a YAML file rendered as KRM is not
+// duplicated in the non-KRM list.
+func TestTreeCommand_DedupKRMFile(t *testing.T) {
+	d := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(d, "Kptfile"), []byte("apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: root\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(d, "cm.yaml"), []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg\n"), 0600))
+
+	b := &bytes.Buffer{}
+	r := GetTreeRunner(fake.CtxWithPrinter(b, nil), "")
+	r.Command.SetArgs([]string{d})
+	r.Command.SetOut(b)
+	require.NoError(t, r.Command.Execute())
+
+	out := b.String()
+	assert.Contains(t, out, "[cm.yaml]  ConfigMap cfg")
+	assert.Equal(t, 1, strings.Count(out, "cm.yaml"), "cm.yaml should appear exactly once (as KRM, not duplicated)")
 }

--- a/thirdparty/cmdconfig/commands/cmdtree/cmdtree_test.go
+++ b/thirdparty/cmdconfig/commands/cmdtree/cmdtree_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -511,7 +512,8 @@ func TestTreeCommand_NonKRMInSubpackage(t *testing.T) {
 	require.NoError(t, r.Command.Execute())
 
 	out := b.String()
-	assert.Contains(t, out, "NOTES.txt")
+	require.Contains(t, out, `Package "sub"`)
+	require.Contains(t, out, "NOTES.txt")
 	subIdx := strings.Index(out, `Package "sub"`)
 	notesIdx := strings.Index(out, "NOTES.txt")
 	assert.Greater(t, notesIdx, subIdx, "NOTES.txt should be under the subpackage branch")
@@ -541,6 +543,9 @@ func TestTreeCommand_DotfilesExcluded(t *testing.T) {
 
 // TestTreeCommand_SymlinkFileSkipped verifies symlinked files inside a package are skipped.
 func TestTreeCommand_SymlinkFileSkipped(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
 	d := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(d, "Kptfile"), []byte("apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: root\n"), 0600))
 	require.NoError(t, os.WriteFile(filepath.Join(d, "real.txt"), []byte("content\n"), 0600))
@@ -575,8 +580,40 @@ func TestTreeCommand_MultipleNonKRMSorted(t *testing.T) {
 	alphaIdx := strings.Index(out, "alpha.txt")
 	middleIdx := strings.Index(out, "middle.log")
 	zebraIdx := strings.Index(out, "zebra.md")
+	require.NotEqual(t, -1, alphaIdx, "alpha.txt should be present in output")
+	require.NotEqual(t, -1, middleIdx, "middle.log should be present in output")
+	require.NotEqual(t, -1, zebraIdx, "zebra.md should be present in output")
 	assert.Less(t, alphaIdx, middleIdx, "alpha.txt should come before middle.log")
 	assert.Less(t, middleIdx, zebraIdx, "middle.log should come before zebra.md")
+}
+
+// TestTreeCommand_NonKRMInNonPackageSubdir verifies that non-KRM files inside
+// a non-package subdirectory (no Kptfile) are rendered under the parent package
+// branch (not as a spurious directory branch), and KRM files in that subdir are
+// deduplicated properly.
+func TestTreeCommand_NonKRMInNonPackageSubdir(t *testing.T) {
+	d := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(d, "Kptfile"), []byte("apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: root\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(d, "deployment.yaml"), []byte("apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: root-deploy\n"), 0600))
+	require.NoError(t, os.MkdirAll(filepath.Join(d, "docs"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(d, "docs", "README.md"), []byte("# Hello\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(d, "docs", "svc.yaml"), []byte("apiVersion: v1\nkind: Service\nmetadata:\n  name: my-svc\n"), 0600))
+
+	b := &bytes.Buffer{}
+	r := GetTreeRunner(fake.CtxWithPrinter(b, nil), "")
+	r.Command.SetArgs([]string{d})
+	r.Command.SetOut(b)
+	require.NoError(t, r.Command.Execute())
+
+	out := b.String()
+	// KRM file in subdir should appear as a resource under the "docs" branch
+	assert.Contains(t, out, "[svc.yaml]  Service my-svc")
+	// Non-KRM file should appear under the same "docs" branch
+	assert.Contains(t, out, "README.md")
+	// "docs" should NOT appear as a Package branch (no Kptfile)
+	assert.NotContains(t, out, `Package "docs"`)
+	// svc.yaml should appear only once (as KRM, not duplicated as non-KRM)
+	assert.Equal(t, 1, strings.Count(out, "svc.yaml"), "svc.yaml should appear exactly once")
 }
 
 // TestTreeCommand_DedupKRMFile verifies a YAML file rendered as KRM is not

--- a/thirdparty/cmdconfig/commands/cmdtree/cmdtree_test.go
+++ b/thirdparty/cmdconfig/commands/cmdtree/cmdtree_test.go
@@ -1,4 +1,5 @@
-// Copyright 2019,2026 The kpt Authors.
+// Copyright 2019 The Kubernetes Authors.
+// Copyright 2026 The kpt Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -544,7 +545,7 @@ func TestTreeCommand_DotfilesExcluded(t *testing.T) {
 // TestTreeCommand_SymlinkFileSkipped verifies symlinked files inside a package are skipped.
 func TestTreeCommand_SymlinkFileSkipped(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.SkipNow()
+		t.Skip("symlinks require elevated privileges on Windows")
 	}
 	d := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(d, "Kptfile"), []byte("apiVersion: kpt.dev/v1\nkind: Kptfile\nmetadata:\n  name: root\n"), 0600))

--- a/thirdparty/cmdconfig/commands/cmdtree/tree.go
+++ b/thirdparty/cmdconfig/commands/cmdtree/tree.go
@@ -48,7 +48,7 @@ type TreeWriter struct {
 	Root        string
 	Fields      []TreeWriterField
 	Structure   TreeStructure
-	NonKRMFiles map[string][]string // package-relative dir → filenames
+	NonKRMFiles map[string][]string // root-relative dir → file basenames in that dir, or relative paths after roll-up from subdirs
 }
 
 // TreeWriterField configures a Resource field to be included in the tree
@@ -67,18 +67,37 @@ func (p TreeWriter) packageStructure(nodes []*yaml.RNode) error {
 	// p.sort sorts nodes within each package (side-effect) and returns sorted keys.
 	allKeys := p.sort(indexByPackage)
 
-	// Merge keys from NonKRMFiles that aren't already in allKeys.
+	// Merge NonKRMFiles keys that already exist in the KRM index (these dirs
+	// already have branches). For dirs not in the index, roll files up to the
+	// nearest ancestor dir that IS in the index, prefixing with the relative path.
+	nonKRM := map[string][]string{}
 	if len(p.NonKRMFiles) > 0 {
-		seen := map[string]bool{}
+		krmKeys := map[string]bool{}
 		for _, k := range allKeys {
-			seen[k] = true
+			krmKeys[k] = true
 		}
-		for k := range p.NonKRMFiles {
-			if !seen[k] {
-				allKeys = append(allKeys, k)
+		for dir, files := range p.NonKRMFiles {
+			if krmKeys[dir] {
+				nonKRM[dir] = append(nonKRM[dir], files...)
+				continue
+			}
+			// Find nearest ancestor that is a known key.
+			ancestor := dir
+			for !krmKeys[ancestor] && ancestor != "." {
+				ancestor = filepath.Dir(ancestor)
+			}
+			if !krmKeys[ancestor] {
+				ancestor = "."
+			}
+			// Prefix filenames with the relative path from ancestor to dir.
+			rel, err := filepath.Rel(ancestor, dir)
+			if err != nil {
+				continue
+			}
+			for _, f := range files {
+				nonKRM[ancestor] = append(nonKRM[ancestor], filepath.Join(rel, f))
 			}
 		}
-		sort.Strings(allKeys)
 	}
 
 	// add each package to the tree
@@ -114,17 +133,24 @@ func (p TreeWriter) packageStructure(nodes []*yaml.RNode) error {
 		}
 
 		// print non-KRM files (skip files already rendered as KRM resources)
-		if len(p.NonKRMFiles[pkg]) > 0 {
+		if len(nonKRM[pkg]) > 0 {
 			rendered := map[string]bool{}
 			for _, node := range indexByPackage[pkg] {
 				_ = kioutil.CopyLegacyAnnotations(node)
 				meta, _ := node.GetMeta()
 				if pathAnno := meta.Annotations[kioutil.PathAnnotation]; pathAnno != "" {
-					rendered[filepath.Base(pathAnno)] = true
+					// pathAnno is relative to root; strip pkg prefix to get path relative to package
+					rel := pathAnno
+					if pkg != "." {
+						if r, err := filepath.Rel(pkg, pathAnno); err == nil {
+							rel = r
+						}
+					}
+					rendered[rel] = true
 				}
 			}
-			names := make([]string, 0, len(p.NonKRMFiles[pkg]))
-			for _, name := range p.NonKRMFiles[pkg] {
+			names := make([]string, 0, len(nonKRM[pkg]))
+			for _, name := range nonKRM[pkg] {
 				if !rendered[name] {
 					names = append(names, name)
 				}

--- a/thirdparty/cmdconfig/commands/cmdtree/tree.go
+++ b/thirdparty/cmdconfig/commands/cmdtree/tree.go
@@ -1,5 +1,16 @@
-// Copyright 2019 The Kubernetes Authors.
-// SPDX-License-Identifier: Apache-2.0
+// Copyright 2019,2026 The kpt Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package cmdtree
 
@@ -33,10 +44,11 @@ var GraphStructures = []string{string(TreeStructurePackage)}
 // TODO(pwittrock): test this package better.  it is lower-risk since it is only
 // used for printing rather than updating or editing.
 type TreeWriter struct {
-	Writer    io.Writer
-	Root      string
-	Fields    []TreeWriterField
-	Structure TreeStructure
+	Writer      io.Writer
+	Root        string
+	Fields      []TreeWriterField
+	Structure   TreeStructure
+	NonKRMFiles map[string][]string // package-relative dir → filenames
 }
 
 // TreeWriterField configures a Resource field to be included in the tree
@@ -52,10 +64,26 @@ func (p TreeWriter) packageStructure(nodes []*yaml.RNode) error {
 	// create the new tree
 	tree := treeprint.New()
 
+	// p.sort sorts nodes within each package (side-effect) and returns sorted keys.
+	allKeys := p.sort(indexByPackage)
+
+	// Merge keys from NonKRMFiles that aren't already in allKeys.
+	if len(p.NonKRMFiles) > 0 {
+		seen := map[string]bool{}
+		for _, k := range allKeys {
+			seen[k] = true
+		}
+		for k := range p.NonKRMFiles {
+			if !seen[k] {
+				allKeys = append(allKeys, k)
+			}
+		}
+		sort.Strings(allKeys)
+	}
+
 	// add each package to the tree
 	treeIndex := map[string]treeprint.Tree{}
-	keys := p.sort(indexByPackage)
-	for _, pkg := range keys {
+	for _, pkg := range allKeys {
 		// create a branch for this package -- search for the parent package and create
 		// the branch under it -- requires that the keys are sorted
 		branch := tree
@@ -82,6 +110,28 @@ func (p TreeWriter) packageStructure(nodes []*yaml.RNode) error {
 			var err error
 			if _, err = p.doResource(indexByPackage[pkg][i], "", branch); err != nil {
 				return err
+			}
+		}
+
+		// print non-KRM files (skip files already rendered as KRM resources)
+		if len(p.NonKRMFiles[pkg]) > 0 {
+			rendered := map[string]bool{}
+			for _, node := range indexByPackage[pkg] {
+				_ = kioutil.CopyLegacyAnnotations(node)
+				meta, _ := node.GetMeta()
+				if pathAnno := meta.Annotations[kioutil.PathAnnotation]; pathAnno != "" {
+					rendered[filepath.Base(pathAnno)] = true
+				}
+			}
+			names := make([]string, 0, len(p.NonKRMFiles[pkg]))
+			for _, name := range p.NonKRMFiles[pkg] {
+				if !rendered[name] {
+					names = append(names, name)
+				}
+			}
+			sort.Strings(names)
+			for _, name := range names {
+				branch.AddNode(name)
 			}
 		}
 	}

--- a/thirdparty/cmdconfig/commands/cmdtree/tree.go
+++ b/thirdparty/cmdconfig/commands/cmdtree/tree.go
@@ -1,4 +1,5 @@
-// Copyright 2019,2026 The kpt Authors.
+// Copyright 2019 The Kubernetes Authors.
+// Copyright 2026 The kpt Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Summary
Enhances `kpt pkg tree` to show all package files, not just KRM resources. 

### Changes
  - Walk the package tree to discover non-KRM files and render them in the tree output
  - Deduplicate files already rendered as KRM resources (by basename)
  - Skip dotfiles and dot-directories (.git/, .hidden)
  
### Example

Before:
```bash
  Package "my-app"
  ├── [Kptfile]  Kptfile my-app
  ├── [deployment.yaml]  Deployment nginx
  └── Package "subpkg"
      ├── [Kptfile]  Kptfile subpkg
      └── [service.yaml]  Service my-svc
```

After:

```bash
  Package "my-app"
  ├── [Kptfile]  Kptfile my-app
  ├── [deployment.yaml]  Deployment nginx
  ├── README.md
  └── Package "subpkg"
      ├── [Kptfile]  Kptfile subpkg
      ├── [service.yaml]  Service my-svc
      └── NOTES.txt
```

### Testing
- Manually tested with multiple package structures
- Added unit tests

### AI usage disclosure
- AI assistance (Kiro CLI) was used to draft portions of this change, and this PR description.