### PR TITLE
Upgrade Go version to 1.26.3

### DIFF
--- a/documentation/go.mod
+++ b/documentation/go.mod
@@ -1,3 +1,3 @@
 module github.com/kptdev/docs
 
-go 1.25.10
+go 1.26.3

--- a/documentation/go.mod
+++ b/documentation/go.mod
@@ -1,3 +1,3 @@
 module github.com/kptdev/docs
 
-go 1.26.3
+go 1.25.10

--- a/documentation/go.mod
+++ b/documentation/go.mod
@@ -1,5 +1,3 @@
 module github.com/kptdev/docs
 
-go 1.25.9
-
-require github.com/google/docsy v0.12.0 // indirect
+go 1.26.3

--- a/documentation/go.mod
+++ b/documentation/go.mod
@@ -1,3 +1,5 @@
 module github.com/kptdev/docs
 
-go 1.26.3
+go 1.25.9
+
+require github.com/google/docsy v0.12.0 // indirect

--- a/documentation/go.mod
+++ b/documentation/go.mod
@@ -1,5 +1,5 @@
 module github.com/kptdev/docs
 
-go 1.25.9
+go 1.26.3
 
 require github.com/google/docsy v0.12.0 // indirect

--- a/documentation/go.sum
+++ b/documentation/go.sum
@@ -1,0 +1,4 @@
+github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/google/docsy v0.12.0 h1:CddZKL39YyJzawr8GTVaakvcUTCJRAAYdz7W0qfZ2P4=
+github.com/google/docsy v0.12.0/go.mod h1:1bioDqA493neyFesaTvQ9reV0V2vYy+xUAnlnz7+miM=
+github.com/twbs/bootstrap v5.3.6+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/documentation/go.sum
+++ b/documentation/go.sum
@@ -1,4 +1,0 @@
-github.com/FortAwesome/Font-Awesome v0.0.0-20241216213156-af620534bfc3/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
-github.com/google/docsy v0.12.0 h1:CddZKL39YyJzawr8GTVaakvcUTCJRAAYdz7W0qfZ2P4=
-github.com/google/docsy v0.12.0/go.mod h1:1bioDqA493neyFesaTvQ9reV0V2vYy+xUAnlnz7+miM=
-github.com/twbs/bootstrap v5.3.6+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/documentation/netlify.toml
+++ b/documentation/netlify.toml
@@ -7,7 +7,6 @@ ignore = "exit 1"
 NODE_VERSION = "18.16.1"
 HUGO_VERSION = "0.147.8"
 HUGO_ENABLEGITINFO = "true"
-GO_VERSION = "1.26.3"
 
 [context.production.environment]
 HUGO_ENV = "production"

--- a/documentation/netlify.toml
+++ b/documentation/netlify.toml
@@ -7,6 +7,7 @@ ignore = "exit 1"
 NODE_VERSION = "18.16.1"
 HUGO_VERSION = "0.147.8"
 HUGO_ENABLEGITINFO = "true"
+GO_VERSION = "1.26.3"
 
 [context.production.environment]
 HUGO_ENV = "production"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/kpt
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/healthcheck/go.mod
+++ b/healthcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/kptdev/kpt/healthcheck
 
-go 1.26.2
+go 1.26.3
 
 require (
 	k8s.io/apimachinery v0.36.0


### PR DESCRIPTION
Upgrade Go version to 1.26.3 to address security vulnerabilities in the Go standard library.

I have used AI in the creation of this PR.

I have used the following AI tools:
- Antigravity to automate the analysis, fork, clone, and upgrade process.