### PR TITLE
ci: verify documentation/go.sum integrity

### DIFF
--- a/.github/workflows/verifyDocumentation.yml
+++ b/.github/workflows/verifyDocumentation.yml
@@ -1,0 +1,52 @@
+# Copyright 2026 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: VerifyDocumentation
+on:
+  pull_request:
+    paths:
+      - "documentation/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "documentation/**"
+
+jobs:
+  verify-docs-module:
+    name: Verify documentation module
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: documentation/go.mod
+          cache: false
+
+      - name: Verify go.sum is not empty
+        working-directory: documentation
+        run: |
+          if [ ! -s go.sum ]; then
+            echo "::error::documentation/go.sum is empty. This file must contain checksums for module dependencies."
+            echo "This is a Hugo module — do NOT use 'go mod tidy' as it strips Hugo-only entries."
+            echo "Restore go.sum from the main branch or run 'hugo mod tidy' instead."
+            exit 1
+          fi
+
+      - name: Verify module integrity
+        working-directory: documentation
+        run: go mod verify


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that checks documentation/go.sum on PRs touching `documentation/`:

1. **Fails if go.sum is empty** — prevents accidental stripping during Go version bumps
2. **Runs `go mod verify`** — ensures checksums match downloaded modules

## Motivation

PR #4519 accidentally emptied `documentation/go.sum` when upgrading Go versions. This happened because `go mod tidy` with newer Go can strip entries for Hugo-only modules. This CI check catches that before merge.

## What was tested

- Verified the workflow YAML is valid
- Confirmed `go mod verify` passes against the current `documentation/` module