### PR TITLE
Fix import on cmdcat command.go

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v29.4.0+incompatible h1:+IjXULMetlvWJiuSI0Nbor36lcJ5BTcVpUmB21KBoVM=
 github.com/docker/cli v29.4.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
-github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker-credential-helpers v0.9.4 h1:76ItO69/AP/V4yT9V4uuuItG0B1N8hvt0T0c0NN/DzI=
 github.com/docker/docker-credential-helpers v0.9.4/go.mod h1:v1S+hepowrQXITkEfw6o4+BMbGot02wiKpzWhGUZK6c=
 github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 h1:UhxFibDNY/bfvqU5CAUmr9zpesgbU6SWc8/B4mflAE4=

--- a/thirdparty/cmdconfig/commands/cmdcat/cmdcat.go
+++ b/thirdparty/cmdconfig/commands/cmdcat/cmdcat.go
@@ -26,8 +26,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/kptdev/kpt/internal/docs/generated/pkgdocs"
-	"github.com/kptdev/kpt/internal/util/argutil"
 	kptfilev1 "github.com/kptdev/kpt/pkg/api/kptfile/v1"
+	argsutil "github.com/kptdev/kpt/pkg/lib/util/args"
 	"github.com/kptdev/kpt/thirdparty/cmdconfig/commands/runner"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/kyaml/kio"
@@ -92,7 +92,7 @@ func (r *CatRunner) runE(c *cobra.Command, args []string) error {
 		return runner.HandleError(r.Ctx, err)
 	}
 
-	resolvedPath, err := argutil.ResolveSymlink(r.Ctx, args[0])
+	resolvedPath, err := argsutil.ResolveSymlink(r.Ctx, args[0])
 	if err != nil {
 		return runner.HandleError(r.Ctx, err)
 	}

--- a/thirdparty/cmdconfig/commands/cmdcat/cmdcat_test.go
+++ b/thirdparty/cmdconfig/commands/cmdcat/cmdcat_test.go
@@ -777,7 +777,7 @@ kind: Kptfile
 metadata:
   name: root
 `)
-	for i := 0; i < 500; i++ {
+	for i := range 500 {
 		writeFile(t, filepath.Join(d, fmt.Sprintf("f%03d.yaml", i)),
 			fmt.Sprintf("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cm-%d\n", i))
 	}


### PR DESCRIPTION
This PR fixes an incorrect import that breaks the kpt build.
