### PR TITLE
Align kpt version output format with porchctl

### DIFF
--- a/make/info.mk
+++ b/make/info.mk
@@ -21,11 +21,11 @@ GORELEASER_IMAGE  := ghcr.io/goreleaser/goreleaser-cross:v$(GOLANG_VERSION)
 YEAR_GEN          := $(shell date '+%Y')
 
 GOBIN := $(shell go env GOPATH)/bin
-GIT_COMMIT := $(shell git rev-parse --short HEAD)
+KPT_VERSION := $(shell date '+development-%Y-%m-%dT%H:%M:%S')
 
 export KPT_FN_WASM_RUNTIME ?= nodejs
 
-LDFLAGS := -ldflags "-X github.com/kptdev/kpt/run.version=${GIT_COMMIT}
+LDFLAGS := -ldflags "-X github.com/kptdev/kpt/run.version=${KPT_VERSION}
 ifeq ($(OS),Windows_NT)
 	# Do nothing
 else

--- a/run/run.go
+++ b/run/run.go
@@ -105,6 +105,7 @@ func GetMain(ctx context.Context) *cobra.Command {
 
 	replace(cmd)
 
+	versionCmd.Flags().Bool("short", false, "Print only the concise version identifier")
 	cmd.AddCommand(versionCmd)
 	hideFlags(cmd)
 	return cmd
@@ -159,7 +160,7 @@ var version = "unknown"
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of kpt",
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		var hash, dirty string
 		if info, ok := debug.ReadBuildInfo(); ok {
 			for _, setting := range info.Settings {
@@ -173,7 +174,20 @@ var versionCmd = &cobra.Command{
 				}
 			}
 		}
+
+		short, _ := cmd.Flags().GetBool("short")
+		if short {
+			if version == "unknown" && len(hash) >= 7 {
+				fmt.Printf("%s\n", hash[:7])
+			} else {
+				fmt.Printf("%s\n", version)
+			}
+			return
+		}
 		fmt.Printf("Version: %s\n", version)
+		if hash == "" {
+			hash = "unknown"
+		}
 		fmt.Printf("Git commit: %s%s\n", hash, dirty)
 	},
 }

--- a/run/run.go
+++ b/run/run.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The kpt Authors
+// Copyright 2019-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime/debug"
 	"strconv"
 	"strings"
 
@@ -159,7 +160,21 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of kpt",
 	Run: func(_ *cobra.Command, _ []string) {
-		fmt.Printf("%s\n", version)
+		var hash, dirty string
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, setting := range info.Settings {
+				switch setting.Key {
+				case "vcs.revision":
+					hash = setting.Value
+				case "vcs.modified":
+					if strings.ToLower(setting.Value) == "true" {
+						dirty = " (dirty)"
+					}
+				}
+			}
+		}
+		fmt.Printf("Version: %s\n", version)
+		fmt.Printf("Git commit: %s%s\n", hash, dirty)
 	},
 }
 

--- a/run/run.go
+++ b/run/run.go
@@ -1,4 +1,4 @@
-// Copyright 2019-2026 The kpt Authors
+// Copyright 2019,2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updates kpt version to display version information in the same two-line format as porchctl version, using debug.ReadBuildInfo() for git commit details.

It follows the same format/code as `porchctl` .

 ### Before:
```bash
  $ kpt version
  1.0.0-beta.64
```
### After:
```bash
  $ kpt version
  Version: 1.0.0-beta.64
  Git commit: 3d736563e328f8a4ea28f15f9b8d7ae517eb8c19
```
```bash
  $ kpt version --short
  1.0.0-beta.64
```


### For local builds:
```bash
  $ kpt version
  Version: development-2026-05-28T16:00:51
  Git commit: 49df708df... (dirty)
```
```bash
  $ kpt version --short
  49df708dft
```

### AI usage disclosure
- AI assistance (Kiro CLI) was used to draft this PR description.