### PR TITLE
Use latest tag for KRM functions in E2E tests

### DIFF
--- a/e2e/testdata/fn-eval/default-runtime/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/default-runtime/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..b66c419 100644
+index f2eec52..f169ab0 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -10,10 +10,3 @@ index f2eec52..b66c419 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/default-runtime/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/default-runtime/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,4 +22,4 @@ fi
 
 echo "KRM_FN_RUNTIME is ${KRM_FN_RUNTIME}"
 # run eval with KRM_FN_RUNTIME unset.
-kpt fn eval -i ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0 -- namespace=staging
+kpt fn eval -i ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest -- namespace=staging

--- a/e2e/testdata/fn-eval/default-runtime/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/default-runtime/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/error-in-pipe/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/error-in-pipe/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/error-in-pipe/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/error-in-pipe/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,6 @@ set -eo pipefail
 rm -rf out
 
 kpt fn source \
-| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0 \
+| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest \
 | kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/dne -- foo=bar \
 | kpt fn sink out

--- a/e2e/testdata/fn-eval/fn-config-file-in-pkg/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/fn-config-file-in-pkg/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 fnConfig: ../config.yaml

--- a/e2e/testdata/fn-eval/fn-config-file-in-pkg/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/fn-config-file-in-pkg/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/fn-config-file-in-pkg/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/fn-config-file-in-pkg/.expected/diff.patch
@@ -10,7 +10,7 @@ index 003e3fe..7a2ceea 100644
  data:
    namespace: staging
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..b66c419 100644
+index f2eec52..f169ab0 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -21,10 +21,3 @@ index f2eec52..b66c419 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/fn-config-file/pkg/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/fn-config-file/pkg/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 fnConfig: ../../config.yaml

--- a/e2e/testdata/fn-eval/fn-config-file/pkg/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/fn-config-file/pkg/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/fn-config-file/pkg/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/fn-config-file/pkg/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..b66c419 100644
+index f2eec52..f169ab0 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -10,10 +10,3 @@ index f2eec52..b66c419 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/fn-source/include-meta-resource-out-of-place/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/fn-source/include-meta-resource-out-of-place/.expected/diff.patch
@@ -1,17 +1,16 @@
 diff --git a/out/Kptfile b/out/Kptfile
 new file mode 100644
-index 0000000..ede2393
+index 0000000..28956fc
 --- /dev/null
 +++ b/out/Kptfile
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,8 @@
 +apiVersion: kpt.dev/v1
 +kind: Kptfile
 +metadata:
 +  name: app
-+  namespace: staging
 +pipeline:
 +  mutators:
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +      configPath: labelconfig.yaml
 diff --git a/out/labelconfig.yaml b/out/labelconfig.yaml
 new file mode 100644
@@ -41,10 +40,10 @@ index 0000000..37baaa2
 +  tier: app
 diff --git a/out/resources.yaml b/out/resources.yaml
 new file mode 100644
-index 0000000..b66c419
+index 0000000..f169ab0
 --- /dev/null
 +++ b/out/resources.yaml
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,27 @@
 +# Copyright 2021 The kpt Authors
 +#
 +# Licensed under the Apache License, Version 2.0 (the "License");
@@ -70,6 +69,5 @@ index 0000000..b66c419
 +kind: Custom
 +metadata:
 +  name: custom
-+  namespace: staging
 +spec:
 +  image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/fn-source/include-meta-resource-out-of-place/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/fn-source/include-meta-resource-out-of-place/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,5 +18,5 @@ set -eo pipefail
 rm -rf out
 
 kpt fn source \
-| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0 -- namespace=staging \
+| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest -- namespace=staging \
 | kpt fn sink out

--- a/e2e/testdata/fn-eval/fn-source/include-meta-resource-out-of-place/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/fn-source/include-meta-resource-out-of-place/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/fn-source/include-meta-resource-out-of-place/Kptfile
+++ b/e2e/testdata/fn-eval/fn-source/include-meta-resource-out-of-place/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: labelconfig.yaml

--- a/e2e/testdata/fn-eval/fn-source/include-meta-resources/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/fn-source/include-meta-resources/.expected/diff.patch
@@ -1,17 +1,16 @@
 diff --git a/out/Kptfile b/out/Kptfile
 new file mode 100644
-index 0000000..ede2393
+index 0000000..28956fc
 --- /dev/null
 +++ b/out/Kptfile
-@@ -0,0 +1,9 @@
+@@ -0,0 +1,8 @@
 +apiVersion: kpt.dev/v1
 +kind: Kptfile
 +metadata:
 +  name: app
-+  namespace: staging
 +pipeline:
 +  mutators:
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +      configPath: labelconfig.yaml
 diff --git a/out/labelconfig.yaml b/out/labelconfig.yaml
 new file mode 100644
@@ -41,10 +40,10 @@ index 0000000..37baaa2
 +  tier: app
 diff --git a/out/resources.yaml b/out/resources.yaml
 new file mode 100644
-index 0000000..b66c419
+index 0000000..f169ab0
 --- /dev/null
 +++ b/out/resources.yaml
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,27 @@
 +# Copyright 2021 The kpt Authors
 +#
 +# Licensed under the Apache License, Version 2.0 (the "License");
@@ -70,6 +69,5 @@ index 0000000..b66c419
 +kind: Custom
 +metadata:
 +  name: custom
-+  namespace: staging
 +spec:
 +  image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/fn-source/include-meta-resources/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/fn-source/include-meta-resources/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,5 +18,5 @@ set -eo pipefail
 rm -rf out
 
 kpt fn source \
-| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0 -- namespace=staging \
+| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest -- namespace=staging \
 | kpt fn sink out

--- a/e2e/testdata/fn-eval/fn-source/include-meta-resources/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/fn-source/include-meta-resources/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/fn-source/include-meta-resources/Kptfile
+++ b/e2e/testdata/fn-eval/fn-source/include-meta-resources/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: labelconfig.yaml

--- a/e2e/testdata/fn-eval/fnconfig-missing-name/pkg/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/fnconfig-missing-name/pkg/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 fnConfig: ../../config.yaml
 exitCode: 1
 stdErr: "resource must have `metadata.name`"

--- a/e2e/testdata/fn-eval/fnconfig-missing-name/pkg/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/fnconfig-missing-name/pkg/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/function-chain/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/function-chain/.expected/diff.patch
@@ -1,9 +1,9 @@
 diff --git a/out/resources.yaml b/out/resources.yaml
 new file mode 100644
-index 0000000..94ced72
+index 0000000..840637b
 --- /dev/null
 +++ b/out/resources.yaml
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,34 @@
 +# Copyright 2021 The kpt Authors
 +#
 +# Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,16 +29,11 @@ index 0000000..94ced72
 +  selector:
 +    matchLabels:
 +      foo: bar
-+  template:
-+    metadata:
-+      labels:
-+        foo: bar
 +---
 +apiVersion: custom.io/v1
 +kind: Custom
 +metadata:
 +  name: custom
-+  namespace: staging
 +  labels:
 +    foo: bar
 +spec:

--- a/e2e/testdata/fn-eval/function-chain/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/function-chain/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/function-chain/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/function-chain/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,6 @@ set -eo pipefail
 rm -rf out
 
 kpt fn source \
-| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0 -- namespace=staging \
-| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5 -- foo=bar \
+| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest -- namespace=staging \
+| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-labels:latest -- foo=bar \
 | kpt fn sink out

--- a/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 runCount: 2
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 includeMetaResources: true
 exitCode: 1
 args:

--- a/e2e/testdata/fn-eval/include-meta-resources-v1alpha2/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/include-meta-resources-v1alpha2/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/include-meta-resources-v1alpha2/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/include-meta-resources-v1alpha2/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 runCount: 2
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 includeMetaResources: true
 exitCode: 1
 args:

--- a/e2e/testdata/fn-eval/include-meta-resources-v1alpha2/Kptfile
+++ b/e2e/testdata/fn-eval/include-meta-resources-v1alpha2/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: labelconfig.yaml

--- a/e2e/testdata/fn-eval/include-meta-resources/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/include-meta-resources/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/include-meta-resources/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/include-meta-resources/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 runCount: 2
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 includeMetaResources: true
 exitCode: 1
 args:

--- a/e2e/testdata/fn-eval/include-meta-resources/Kptfile
+++ b/e2e/testdata/fn-eval/include-meta-resources/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: labelconfig.yaml

--- a/e2e/testdata/fn-eval/invalid-fn-config-file/pkg/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/invalid-fn-config-file/pkg/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/invalid-fn-config-file/pkg/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/invalid-fn-config-file/pkg/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
 
 testType: eval
 exitCode: 1
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 fnConfig: ../../config.yaml
 stdErr: "wrong node kind: expected MappingNode but got ScalarNode: node contents:\nI am not a valid config file\n"

--- a/e2e/testdata/fn-eval/krm-check-exclude-kustomize/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/krm-check-exclude-kustomize/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/krm-check-exclude-kustomize/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/krm-check-exclude-kustomize/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 args:
   tier: backend

--- a/e2e/testdata/fn-eval/krm-check-exclude-kustomize/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/krm-check-exclude-kustomize/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/Kptfile b/Kptfile
-index 2985a1a..3dfdcf6 100644
+index 4948ed1..712fea8 100644
 --- a/Kptfile
 +++ b/Kptfile
 @@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
@@ -10,12 +10,12 @@ index 2985a1a..3dfdcf6 100644
 +    tier: backend
  pipeline:
    mutators:
-     - image: set-labels:v0.1.5
+     - image: set-labels:latest
 diff --git a/kustomization.yaml b/kustomization.yaml
-index f3f0207..6c517af 100644
+index f3f0207..0452667 100644
 --- a/kustomization.yaml
 +++ b/kustomization.yaml
-@@ -11,7 +11,9 @@
+@@ -11,7 +11,14 @@
  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  # See the License for the specific language governing permissions and
  # limitations under the License.
@@ -26,11 +26,16 @@ index f3f0207..6c517af 100644
 +metadata:
 +  labels:
 +    tier: backend
++spec:
++  selector:
++    tier: backend
++    matchLabels:
++      tier: backend
 diff --git a/resources.yaml b/resources.yaml
-index 40a033d..eb585ba 100644
+index 40a033d..dc478d6 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,23 @@ apiVersion: apps/v1
+@@ -15,12 +15,19 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -41,10 +46,6 @@ index 40a033d..eb585ba 100644
 +  selector:
 +    matchLabels:
 +      tier: backend
-+  template:
-+    metadata:
-+      labels:
-+        tier: backend
  ---
  apiVersion: custom.io/v1
  kind: Custom

--- a/e2e/testdata/fn-eval/krm-check-exclude-kustomize/Kptfile
+++ b/e2e/testdata/fn-eval/krm-check-exclude-kustomize/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: set-labels:v0.1.5
+    - image: set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-eval/missing-fn-config/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/missing-fn-config/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 testType: eval
-exitCode: 1
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-stdErr: "failed to configure function: input namespace cannot be empty"
+exitCode: 0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+stdErr: |
+ [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+ [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+ [Results]: [error] v1/ConfigMap/function-input: `data.namespace` should not be empty

--- a/e2e/testdata/fn-eval/missing-fn-config/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/missing-fn-config/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 testType: eval
-exitCode: 0
+exitCode: 1
 image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 stdErr: |
  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
- [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+ [FAIL] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
  [Results]: [error] v1/ConfigMap/function-input: `data.namespace` should not be empty
+  Stderr: failed to evaluate function: error: function failure  Exit code: 1

--- a/e2e/testdata/fn-eval/multiple-fn-config-one-file/pkg/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/multiple-fn-config-one-file/pkg/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/multiple-fn-config-one-file/pkg/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/multiple-fn-config-one-file/pkg/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 fnConfig: ../../config.yaml
 exitCode: 1
 stdErr: "must not contain more than one config, got 2"

--- a/e2e/testdata/fn-eval/non-krm-resource/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/non-krm-resource/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/non-krm-resource/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/non-krm-resource/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 args:
   namespace: staging
 exitCode: 1
 stdErr: |
-  [FAIL] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
+  [FAIL] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
   error: input resource list must contain only KRM resources: nonkrm.yaml: resource must have `apiVersion`

--- a/e2e/testdata/fn-eval/out-of-place-dir-exists-error/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/out-of-place-dir-exists-error/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,4 +17,4 @@ set -eo pipefail
 
 rm -rf out; mkdir out
 
-kpt fn eval --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0 -o out -- namespace=staging
+kpt fn eval --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest -o out -- namespace=staging

--- a/e2e/testdata/fn-eval/out-of-place-dir-exists-error/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/out-of-place-dir-exists-error/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/out-of-place-dir/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/out-of-place-dir/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s

--- a/e2e/testdata/fn-eval/out-of-place-dir/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/out-of-place-dir/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/out-of-place-dir/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/out-of-place-dir/.expected/diff.patch
@@ -1,9 +1,9 @@
 diff --git a/out/resources.yaml b/out/resources.yaml
 new file mode 100644
-index 0000000..b66c419
+index 0000000..f169ab0
 --- /dev/null
 +++ b/out/resources.yaml
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,27 @@
 +# Copyright 2021 The kpt Authors
 +#
 +# Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,6 +29,5 @@ index 0000000..b66c419
 +kind: Custom
 +metadata:
 +  name: custom
-+  namespace: staging
 +spec:
 +  image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/out-of-place-dir/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/out-of-place-dir/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/out-of-place-dir/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/out-of-place-dir/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,4 +17,4 @@ set -eo pipefail
 
 rm -rf out
 
-kpt fn eval --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0 -o out -- namespace=staging
+kpt fn eval --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest -o out -- namespace=staging

--- a/e2e/testdata/fn-eval/out-of-place-fnchain-stdout/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/out-of-place-fnchain-stdout/.expected/config.yaml
@@ -6,13 +6,15 @@ stdErrStripLines:
   - "    \"WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\""
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" in 0s
   [Results]: [info] metadata.annotations: set annotations: {"foo":"bar"}, [info] spec.template.metadata.annotations: set annotations: {"foo":"bar"}, [info] metadata.annotations: set annotations: {"foo":"bar"}
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
+  [Results]: [info]: set 4 labels in total
 
 stdOut: |
   apiVersion: config.kubernetes.io/v1
@@ -36,11 +38,11 @@ stdOut: |
     metadata:
       name: nginx-deployment
       annotations:
-        config.kubernetes.io/index: "0"
-        config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/index: "0"
-        internal.config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/seqindent: compact
+        config.kubernetes.io/index: '0'
+        config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/index: '0'
+        internal.config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/seqindent: 'compact'
         foo: bar
       namespace: staging
       labels:
@@ -61,13 +63,12 @@ stdOut: |
     metadata:
       name: custom
       annotations:
-        config.kubernetes.io/index: "1"
-        config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/index: "1"
-        internal.config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/seqindent: compact
+        config.kubernetes.io/index: '1'
+        config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/index: '1'
+        internal.config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/seqindent: 'compact'
         foo: bar
-      namespace: staging
       labels:
         tier: backend
     spec:

--- a/e2e/testdata/fn-eval/out-of-place-fnchain-stdout/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/out-of-place-fnchain-stdout/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/out-of-place-fnchain-stdout/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/out-of-place-fnchain-stdout/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,6 @@
 
 set -eo pipefail
 
-kpt fn eval --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0 -o stdout -- namespace=staging \
+kpt fn eval --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest -o stdout -- namespace=staging \
 | kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest -- foo=bar \
-| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5 -- tier=backend
+| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-labels:latest -- tier=backend

--- a/e2e/testdata/fn-eval/out-of-place-fnchain-unwrap/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/out-of-place-fnchain-unwrap/.expected/config.yaml
@@ -20,13 +20,15 @@ stdErrStripLines:
   - "    \"WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\""
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" in 0s
   [Results]: [info] metadata.annotations: set annotations: {"foo":"bar"}, [info] metadata.annotations: set annotations: {"foo":"bar"}, [info] spec.template.metadata.annotations: set annotations: {"foo":"bar"}, [info] metadata.annotations: set annotations: {"foo":"bar"}
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
+  [Results]: [info]: set 5 labels in total
 
 stdOut: |
   # Copyright 2021 The kpt Authors
@@ -69,8 +71,21 @@ stdOut: |
     name: custom
     annotations:
       foo: bar
-    namespace: staging
     labels:
       tier: backend
   spec:
     image: nginx:1.2.3
+  ---
+  apiVersion: kpt.dev/v1
+  kind: Kptfile
+  metadata:
+    name: app
+    annotations:
+      foo: bar
+    labels:
+      tier: backend
+  pipeline:
+    mutators:
+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+        configMap:
+          namespace: staging

--- a/e2e/testdata/fn-eval/out-of-place-fnchain-unwrap/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/out-of-place-fnchain-unwrap/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/out-of-place-fnchain-unwrap/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/out-of-place-fnchain-unwrap/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,6 @@
 
 set -eo pipefail
 
-kpt fn eval --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0 -o stdout -- namespace=staging \
+kpt fn eval --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest -o stdout -- namespace=staging \
 | kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest -- foo=bar \
-| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5 -o unwrap -- tier=backend
+| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-labels:latest -o unwrap -- tier=backend

--- a/e2e/testdata/fn-eval/out-of-place-fnchain-unwrap/Kptfile
+++ b/e2e/testdata/fn-eval/out-of-place-fnchain-unwrap/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging

--- a/e2e/testdata/fn-eval/output-to-stdout/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/output-to-stdout/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/output-to-stdout/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/output-to-stdout/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,11 +34,11 @@ stdOut: |
     metadata:
       name: nginx-deployment
       annotations:
-        config.kubernetes.io/index: "0"
-        config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/index: "0"
-        internal.config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/seqindent: compact
+        config.kubernetes.io/index: '0'
+        config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/index: '0'
+        internal.config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/seqindent: 'compact'
       namespace: staging
     spec:
       replicas: 3
@@ -47,11 +47,10 @@ stdOut: |
     metadata:
       name: custom
       annotations:
-        config.kubernetes.io/index: "1"
-        config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/index: "1"
-        internal.config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/seqindent: compact
-      namespace: staging
+        config.kubernetes.io/index: '1'
+        config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/index: '1'
+        internal.config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/seqindent: 'compact'
     spec:
       image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/output-to-stdout/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/output-to-stdout/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/output-to-stdout/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/output-to-stdout/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 set -eo pipefail
 
 kpt fn source |\
-kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0 -- namespace=staging
+kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest -- namespace=staging

--- a/e2e/testdata/fn-eval/preserve-order-include-meta-resources/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/preserve-order-include-meta-resources/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/preserve-order-include-meta-resources/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/preserve-order-include-meta-resources/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 includeMetaResources: true
 exitCode: 1
 args:

--- a/e2e/testdata/fn-eval/preserve-order-include-meta-resources/Kptfile
+++ b/e2e/testdata/fn-eval/preserve-order-include-meta-resources/Kptfile
@@ -28,14 +28,14 @@ upstreamLock:
     commit: 4d2aa98b45ddee4b5fa45fbca16f2ff887de9efb
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: some-space
     - image: ghcr.io/kptdev/krm-functions-catalog/apply-setters:latest
       configMap:
         image: nginx
         tag: 1.14.1
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: ./fn-config.yaml
     - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
       configPath: path/to/foo-star.yaml

--- a/e2e/testdata/fn-eval/preserve-order-null-values/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/preserve-order-null-values/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 args:
   namespace: staging

--- a/e2e/testdata/fn-eval/preserve-order-null-values/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/preserve-order-null-values/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/preserve-order-null-values/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/preserve-order-null-values/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/resources.yaml b/resources.yaml
-index f410b70..13bc056 100644
+index f410b70..6d94d47 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -16,6 +16,7 @@ kind: Deployment
@@ -10,10 +10,3 @@ index f410b70..13bc056 100644
  spec:
    replicas: 3
  ---
-@@ -23,5 +24,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/custom-pkg-path/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/custom-pkg-path/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 The kpt Authors
+# Copyright 2022-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,12 +18,13 @@ stdErrStripLines:
 
 testType: eval
 
-image: set-namespace:v0.2.0
+image: set-namespace:latest
 
 args:
   namespace: staging
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
-  Added "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" as mutator in the Kptfile.
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 2 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+  Added "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" as mutator in the Kptfile.

--- a/e2e/testdata/fn-eval/save-fn/custom-pkg-path/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/custom-pkg-path/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022-2026 The kpt Authors
+# Copyright 2022, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/save-fn/custom-pkg-path/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/custom-pkg-path/.expected/diff.patch
@@ -1,15 +1,14 @@
 diff --git a/sub-pkg/Kptfile b/sub-pkg/Kptfile
-index d9e2f05..82455d5 100644
+index d9e2f05..e699ad9 100644
 --- a/sub-pkg/Kptfile
 +++ b/sub-pkg/Kptfile
-@@ -2,3 +2,8 @@ apiVersion: kpt.dev/v1
+@@ -2,3 +2,7 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
-+  namespace: staging
 +pipeline:
 +  mutators:
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +      configPath: fn-config.yaml
 diff --git a/sub-pkg/fn-config.yaml b/sub-pkg/fn-config.yaml
 index 21135f9..1000dd9 100644
@@ -23,7 +22,7 @@ index 21135f9..1000dd9 100644
  data:
    namespace: staging
 diff --git a/sub-pkg/resources.yaml b/sub-pkg/resources.yaml
-index eed43d6..81473ca 100644
+index eed43d6..4593a1b 100644
 --- a/sub-pkg/resources.yaml
 +++ b/sub-pkg/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -34,10 +33,3 @@ index eed43d6..81473ca 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/custom-pkg-path/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/custom-pkg-path/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,4 +15,4 @@
 
 set -eo pipefail
 
-kpt fn eval ./sub-pkg -s -t mutator -i set-namespace:v0.2.0 --fn-config=./sub-pkg/fn-config.yaml
+kpt fn eval ./sub-pkg -s -t mutator -i set-namespace:latest --fn-config=./sub-pkg/fn-config.yaml

--- a/e2e/testdata/fn-eval/save-fn/custom-pkg-path/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/custom-pkg-path/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/save-fn/image/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/image/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 The kpt Authors
+# Copyright 2022-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,12 +18,13 @@ stdErrStripLines:
 
 testType: eval
 
-image: set-namespace:v0.2.0
+image: set-namespace:latest
 
 args:
   namespace: staging
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
-  Added "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" as mutator in the Kptfile.
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+  Added "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" as mutator in the Kptfile.

--- a/e2e/testdata/fn-eval/save-fn/image/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/image/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022-2026 The kpt Authors
+# Copyright 2022, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/save-fn/image/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/image/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index d9e2f05..d0d3425 100644
+index d9e2f05..710f44a 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,3 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,3 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
-+  namespace: staging
 +pipeline:
 +  mutators:
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +      configMap:
 +        namespace: staging
 diff --git a/resources.yaml b/resources.yaml
-index eed43d6..81473ca 100644
+index eed43d6..4593a1b 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -24,10 +23,3 @@ index eed43d6..81473ca 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/image/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/image/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/save-fn/image/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/image/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,4 +15,4 @@
 
 set -eo pipefail
 
-kpt fn eval -s -t mutator -i set-namespace:v0.2.0 -- namespace=staging
+kpt fn eval -s -t mutator -i set-namespace:latest -- namespace=staging

--- a/e2e/testdata/fn-eval/save-fn/match-selector/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/match-selector/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 The kpt Authors
+# Copyright 2022-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ stdErrStripLines:
   - "    \"WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\""
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" on 1 resource(s)
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
-  Added "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" as mutator in the Kptfile.
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+  Added "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" as mutator in the Kptfile.

--- a/e2e/testdata/fn-eval/save-fn/match-selector/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/match-selector/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022-2026 The kpt Authors
+# Copyright 2022, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/save-fn/match-selector/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/match-selector/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/Kptfile b/Kptfile
-index d9e2f05..3456414 100644
+index d9e2f05..2468e50 100644
 --- a/Kptfile
 +++ b/Kptfile
 @@ -2,3 +2,10 @@ apiVersion: kpt.dev/v1
@@ -8,7 +8,7 @@ index d9e2f05..3456414 100644
    name: app
 +pipeline:
 +  mutators:
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +      configMap:
 +        namespace: staging
 +      selectors:

--- a/e2e/testdata/fn-eval/save-fn/match-selector/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/match-selector/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/save-fn/match-selector/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/match-selector/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,4 +16,4 @@
 
 set -eo pipefail
 
-kpt fn eval -s -t mutator -i set-namespace:v0.2.0 --match-kind Deployment -- namespace=staging
+kpt fn eval -s -t mutator -i set-namespace:latest --match-kind Deployment -- namespace=staging

--- a/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 The kpt Authors
+# Copyright 2022-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,12 +18,13 @@ stdErrStripLines:
 
 testType: eval
 
-image: set-namespace:v0.2.0
+image: set-namespace:latest
 
 args:
   namespace: staging
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   function not added: Kptfile not exists

--- a/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022-2026 The kpt Authors
+# Copyright 2022, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/resources.yaml b/resources.yaml
-index eed43d6..81473ca 100644
+index eed43d6..4593a1b 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -10,10 +10,3 @@ index eed43d6..81473ca 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,4 +15,4 @@
 
 set -eo pipefail
 
-kpt fn eval -s -t mutator -i set-namespace:v0.2.0 -- namespace=staging
+kpt fn eval -s -t mutator -i set-namespace:latest -- namespace=staging

--- a/e2e/testdata/fn-eval/save-fn/override-fn/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 The kpt Authors
+# Copyright 2022-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,12 +18,13 @@ stdErrStripLines:
 
 testType: eval
 
-image: set-namespace:v0.2.0
+image: set-namespace:latest
 
 args:
   namespace: staging
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
-  Updated "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" as mutator in the Kptfile.
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "newNs", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+  Updated "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" as mutator in the Kptfile.

--- a/e2e/testdata/fn-eval/save-fn/override-fn/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022-2026 The kpt Authors
+# Copyright 2022, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/save-fn/override-fn/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/.expected/diff.patch
@@ -1,23 +1,20 @@
 diff --git a/Kptfile b/Kptfile
-index c093436..6dd6980 100644
+index d479080..8b44906 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,9 +2,9 @@ apiVersion: kpt.dev/v1
- kind: Kptfile
- metadata:
+@@ -4,7 +4,6 @@ metadata:
    name: app
-+  namespace: newNs
  pipeline:
    mutators:
--  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+-  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 -    configMap:
 -      namespace: oldNs
--    name: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+-    name: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +      configMap:
 +        namespace: newNs
 diff --git a/resources.yaml b/resources.yaml
-index eed43d6..0b0d2ce 100644
+index eed43d6..88187d0 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -28,10 +25,3 @@ index eed43d6..0b0d2ce 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: newNs
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/override-fn/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/save-fn/override-fn/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,4 +15,4 @@
 
 set -eo pipefail
 
-kpt fn eval -s -t mutator -i set-namespace:v0.2.0 -- namespace=newNs
+kpt fn eval -s -t mutator -i set-namespace:latest -- namespace=newNs

--- a/e2e/testdata/fn-eval/save-fn/override-fn/Kptfile
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/Kptfile
@@ -4,7 +4,7 @@ metadata:
   name: app
 pipeline:
   mutators:
-  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
     configMap:
       namespace: oldNs
-    name: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    name: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest

--- a/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 The kpt Authors
+# Copyright 2022-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,12 +18,13 @@ stdErrStripLines:
 
 testType: eval
 
-image: set-namespace:v0.2.0
+image: set-namespace:latest
 
 args:
   namespace: staging
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
-  Added "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" as mutator in the Kptfile.
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+  Added "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" as mutator in the Kptfile.

--- a/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022-2026 The kpt Authors
+# Copyright 2022, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index 08afd4c..941eb7f 100644
+index 08afd4c..6c24463 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -4,3 +4,9 @@ kind: Kptfile # comment 1
+@@ -4,3 +4,8 @@ kind: Kptfile # comment 1
  metadata:
    # comment 2
    name: app # comment 3
-+  namespace: staging
 +pipeline:
 +  mutators:
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +      configMap:
 +        namespace: staging
 diff --git a/resources.yaml b/resources.yaml
-index eed43d6..81473ca 100644
+index eed43d6..4593a1b 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -24,10 +23,3 @@ index eed43d6..81473ca 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,4 +15,4 @@
 
 set -eo pipefail
 
-kpt fn eval -s -t mutator -i set-namespace:v0.2.0 -- namespace=staging
+kpt fn eval -s -t mutator -i set-namespace:latest -- namespace=staging

--- a/e2e/testdata/fn-eval/save-fn/validator-type/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/validator-type/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 The kpt Authors
+# Copyright 2022-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,12 +18,13 @@ stdErrStripLines:
 
 testType: eval
 
-image: set-namespace:v0.2.0
+image: set-namespace:latest
 
 args:
   namespace: staging
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
-  Added "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" as validator in the Kptfile.
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+  Added "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" as validator in the Kptfile.

--- a/e2e/testdata/fn-eval/save-fn/validator-type/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/validator-type/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022-2026 The kpt Authors
+# Copyright 2022, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/save-fn/validator-type/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/validator-type/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index d9e2f05..72c9469 100644
+index d9e2f05..cdddc3c 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,3 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,3 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
-+  namespace: staging
 +pipeline:
 +  validators:
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +      configMap:
 +        namespace: staging
 diff --git a/resources.yaml b/resources.yaml
-index eed43d6..81473ca 100644
+index eed43d6..4593a1b 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -24,10 +23,3 @@ index eed43d6..81473ca 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/validator-type/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/validator-type/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,4 +15,4 @@
 
 set -eo pipefail
 
-kpt fn eval -s -t validator -i set-namespace:v0.2.0 -- namespace=staging
+kpt fn eval -s -t validator -i set-namespace:latest -- namespace=staging

--- a/e2e/testdata/fn-eval/save-fn/validator-type/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/validator-type/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/selectors/basicpipeline/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/selectors/basicpipeline/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/selectors/basicpipeline/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/selectors/basicpipeline/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" on 1 resource(s)
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s

--- a/e2e/testdata/fn-eval/selectors/basicpipeline/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/selectors/basicpipeline/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/selectors/basicpipeline/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/selectors/basicpipeline/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,4 +15,4 @@
 
 set -eo pipefail
 
-kpt fn eval -i set-namespace:v0.2.0 --match-name nginx-deployment --match-kind Deployment -- namespace=staging
+kpt fn eval -i set-namespace:latest --match-name nginx-deployment --match-kind Deployment -- namespace=staging

--- a/e2e/testdata/fn-eval/selectors/exclude/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/selectors/exclude/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/selectors/exclude/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/selectors/exclude/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" on 1 resource(s)
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s

--- a/e2e/testdata/fn-eval/selectors/exclude/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/selectors/exclude/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,4 +15,4 @@
 
 set -eo pipefail
 
-kpt fn eval -i set-namespace:v0.2.0 --exclude-kind Custom -- namespace=staging
+kpt fn eval -i set-namespace:latest --exclude-kind Custom -- namespace=staging

--- a/e2e/testdata/fn-eval/selectors/exclude/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/selectors/exclude/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/selectors/out-of-place-fnchain-unwrap/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/selectors/out-of-place-fnchain-unwrap/.expected/config.yaml
@@ -17,13 +17,15 @@ stdErrStripLines:
   - "    \"WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\""
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" on 1 resource(s)
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" on 1 resource(s)
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" in 0s
   [Results]: [info] metadata.annotations: set annotations: {"foo":"bar"}
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
+  [Results]: [info]: set 3 labels in total
 
 stdOut: |
   apiVersion: apps/v1
@@ -38,10 +40,6 @@ stdOut: |
     selector:
       matchLabels:
         tier: backend
-    template:
-      metadata:
-        labels:
-          tier: backend
   ---
   apiVersion: custom.io/v1
   kind: Custom

--- a/e2e/testdata/fn-eval/selectors/out-of-place-fnchain-unwrap/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/selectors/out-of-place-fnchain-unwrap/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/selectors/out-of-place-fnchain-unwrap/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/selectors/out-of-place-fnchain-unwrap/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,6 @@
 set -eo pipefail
 
 kpt fn source \
-| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0 --match-kind Deployment -o stdout -- namespace=staging \
+| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest --match-kind Deployment -o stdout -- namespace=staging \
 | kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest --match-name custom -- foo=bar \
-| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5 -o unwrap -- tier=backend
+| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-labels:latest -o unwrap -- tier=backend

--- a/e2e/testdata/fn-eval/selectors/selectors-with-exclude/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/selectors/selectors-with-exclude/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/selectors/selectors-with-exclude/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/selectors/selectors-with-exclude/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" on 1 resource(s)
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s

--- a/e2e/testdata/fn-eval/selectors/selectors-with-exclude/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/selectors/selectors-with-exclude/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,4 +15,4 @@
 
 set -eo pipefail
 
-kpt fn eval -i set-namespace:v0.2.0 --match-labels foo=bar --match-labels foo-1=bar --exclude-annotations foo=bar -- namespace=staging
+kpt fn eval -i set-namespace:latest --match-labels foo=bar --match-labels foo-1=bar --exclude-annotations foo=bar -- namespace=staging

--- a/e2e/testdata/fn-eval/selectors/selectors-with-exclude/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/selectors/selectors-with-exclude/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/short-image-path/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/short-image-path/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/short-image-path/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/short-image-path/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,11 +17,11 @@ actualStripLines:
 
 testType: eval
 
-image: set-namespace:v0.2.0
+image: set-namespace:latest
 
 args:
   namespace: staging
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s

--- a/e2e/testdata/fn-eval/short-image-path/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/short-image-path/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..b66c419 100644
+index f2eec52..f169ab0 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -10,10 +10,3 @@ index f2eec52..b66c419 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/short-image-path/.expected/results.yaml
+++ b/e2e/testdata/fn-eval/short-image-path/.expected/results.yaml
@@ -4,5 +4,10 @@ metadata:
   name: fnresults
 exitCode: 0
 items:
-  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
     exitCode: 0
+    results:
+      - message: namespace [default] updated to "staging", 1 value(s) changed
+        severity: info
+      - message: all `depends-on` annotations are up-to-date. no `namespace` changed
+        severity: info

--- a/e2e/testdata/fn-eval/simple-function-symlink/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/simple-function-symlink/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/simple-function-symlink/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/simple-function-symlink/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,5 +14,5 @@
 
 stdErr: |-
   [WARN] resolved symlink "new-link" to ".", please note that the symlinks within the package are ignored
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"

--- a/e2e/testdata/fn-eval/simple-function-symlink/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/simple-function-symlink/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..b66c419 100644
+index f2eec52..f169ab0 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -10,10 +10,3 @@ index f2eec52..b66c419 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/simple-function-symlink/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/simple-function-symlink/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,6 @@ set -eo pipefail
 
 ln -s ./ new-link
 
-kpt fn eval new-link --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0 -- namespace=staging
+kpt fn eval new-link --image ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest -- namespace=staging
 
 rm -rf new-link

--- a/e2e/testdata/fn-eval/simple-function-symlink/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/simple-function-symlink/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/simple-function/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/simple-function/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 args:
   namespace: staging

--- a/e2e/testdata/fn-eval/simple-function/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/simple-function/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/simple-function/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/simple-function/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..b66c419 100644
+index f2eec52..f169ab0 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -10,10 +10,3 @@ index f2eec52..b66c419 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/subpkg-exclude-fn-config-by-default/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/subpkg-exclude-fn-config-by-default/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 args:
   namespace: staging

--- a/e2e/testdata/fn-eval/subpkg-exclude-fn-config-by-default/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/subpkg-exclude-fn-config-by-default/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/subpkg-exclude-fn-config-by-default/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/subpkg-exclude-fn-config-by-default/.expected/diff.patch
@@ -1,27 +1,3 @@
-diff --git a/Kptfile b/Kptfile
-index 92a643d..ede2393 100644
---- a/Kptfile
-+++ b/Kptfile
-@@ -2,6 +2,7 @@ apiVersion: kpt.dev/v1
- kind: Kptfile
- metadata:
-   name: app
-+  namespace: staging
- pipeline:
-   mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
-diff --git a/db/Kptfile b/db/Kptfile
-index 093e789..a085eed 100644
---- a/db/Kptfile
-+++ b/db/Kptfile
-@@ -2,6 +2,7 @@ apiVersion: kpt.dev/v1
- kind: Kptfile
- metadata:
-   name: db
-+  namespace: staging
- pipeline:
-   mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
 diff --git a/db/labelconfig.yaml b/db/labelconfig.yaml
 index 6db7671..0de2122 100644
 --- a/db/labelconfig.yaml
@@ -44,19 +20,8 @@ index dabe43c..b44084a 100644
 +  namespace: staging
  spec:
    replicas: 3
-diff --git a/labelconfig.yaml b/labelconfig.yaml
-index 9c360e2..420c97c 100644
---- a/labelconfig.yaml
-+++ b/labelconfig.yaml
-@@ -17,5 +17,6 @@ metadata:
-   name: label-config
-   annotations:
-     config.kubernetes.io/local-config: "true"
-+  namespace: staging
- data:
-   tier: app
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..b66c419 100644
+index f2eec52..f169ab0 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -67,10 +32,3 @@ index f2eec52..b66c419 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/subpkg-exclude-fn-config-by-default/Kptfile
+++ b/e2e/testdata/fn-eval/subpkg-exclude-fn-config-by-default/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: labelconfig.yaml

--- a/e2e/testdata/fn-eval/subpkg-exclude-fn-config-by-default/db/Kptfile
+++ b/e2e/testdata/fn-eval/subpkg-exclude-fn-config-by-default/db/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: labelconfig.yaml

--- a/e2e/testdata/fn-eval/subpkg-has-samename-subdir/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/subpkg-has-samename-subdir/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/subpkg-has-samename-subdir/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/subpkg-has-samename-subdir/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 args:
   namespace: dev

--- a/e2e/testdata/fn-eval/subpkg-has-samename-subdir/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/subpkg-has-samename-subdir/.expected/diff.patch
@@ -1,27 +1,5 @@
-diff --git a/Kptfile b/Kptfile
-index 701e0a1..f9b5995 100644
---- a/Kptfile
-+++ b/Kptfile
-@@ -2,5 +2,6 @@ apiVersion: kpt.dev/v1
- kind: Kptfile
- metadata:
-   name: root-pkg
-+  namespace: dev
- info:
-   description: sample description
-diff --git a/pkg-a/Kptfile b/pkg-a/Kptfile
-index 1c0e1cc..e278c20 100644
---- a/pkg-a/Kptfile
-+++ b/pkg-a/Kptfile
-@@ -2,5 +2,6 @@ apiVersion: kpt.dev/v1
- kind: Kptfile
- metadata:
-   name: pkg-a
-+  namespace: dev
- info:
-   description: sample description
 diff --git a/pkg-a/pkg-a/resources.yaml b/pkg-a/pkg-a/resources.yaml
-index f2eec52..c4e4abb 100644
+index f2eec52..1934a8f 100644
 --- a/pkg-a/pkg-a/resources.yaml
 +++ b/pkg-a/pkg-a/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -32,10 +10,3 @@ index f2eec52..c4e4abb 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: dev
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/subpkg-include-meta-resources/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/subpkg-include-meta-resources/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/subpkg-include-meta-resources/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/subpkg-include-meta-resources/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 runCount: 2
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 includeMetaResources: true
 exitCode: 1
 args:

--- a/e2e/testdata/fn-eval/subpkg-include-meta-resources/Kptfile
+++ b/e2e/testdata/fn-eval/subpkg-include-meta-resources/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: labelconfig.yaml

--- a/e2e/testdata/fn-eval/subpkg-include-meta-resources/db/Kptfile
+++ b/e2e/testdata/fn-eval/subpkg-include-meta-resources/db/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: labelconfig.yaml

--- a/e2e/testdata/fn-eval/subpkgs-with-krmignore/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/subpkgs-with-krmignore/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 args:
   namespace: staging

--- a/e2e/testdata/fn-eval/subpkgs-with-krmignore/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/subpkgs-with-krmignore/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/subpkgs-with-krmignore/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/subpkgs-with-krmignore/.expected/diff.patch
@@ -10,7 +10,7 @@ index dabe43c..b44084a 100644
  spec:
    replicas: 3
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..b66c419 100644
+index f2eec52..f169ab0 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -21,10 +21,3 @@ index f2eec52..b66c419 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/subpkgs/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/subpkgs/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 args:
   namespace: staging

--- a/e2e/testdata/fn-eval/subpkgs/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/subpkgs/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-eval/subpkgs/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/subpkgs/.expected/diff.patch
@@ -10,7 +10,7 @@ index dabe43c..b44084a 100644
  spec:
    replicas: 3
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..b66c419 100644
+index f2eec52..f169ab0 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -21,10 +21,3 @@ index f2eec52..b66c419 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-render/all-resource-deletion/.expected/diff.patch
+++ b/e2e/testdata/fn-render/all-resource-deletion/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index 3c93e9e..5404a5a 100644
+index 473349f..1f6381e 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
-+  namespace: staging
 +  labels:
 +    tier: backend
  pipeline:
    mutators:
      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
-@@ -12,3 +15,16 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+@@ -12,3 +14,24 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: backend
 +status:
@@ -25,24 +24,18 @@ index 3c93e9e..5404a5a 100644
 +    mutationSteps:
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: all matching namespaces are already "staging". no value changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
-diff --git a/delete-all.yaml b/delete-all.yaml
-index 3c86d8b..6754b0a 100644
---- a/delete-all.yaml
-+++ b/delete-all.yaml
-@@ -17,6 +17,9 @@ metadata:
-   name: delete-all
-   annotations:
-     config.kubernetes.io/local-config: "true"
-+  namespace: staging
-+  labels:
-+    tier: backend
- source: |-
-   # delete all resources
-   ctx.resource_list["items"] = [x for x in ctx.resource_list["items"] if x["kind"] in ["Kptfile", "StarlarkRun"]]
++        results:
++          - message: set 1 labels in total
++            severity: info
 diff --git a/deployment.yaml b/deployment.yaml
 deleted file mode 100644
 index 990ca9b..0000000

--- a/e2e/testdata/fn-render/all-resource-deletion/Kptfile
+++ b/e2e/testdata/fn-render/all-resource-deletion/Kptfile
@@ -6,9 +6,9 @@ pipeline:
   mutators:
     - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
       configPath: delete-all.yaml
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/basicpipeline-out-of-place/.expected/diff.patch
+++ b/e2e/testdata/fn-render/basicpipeline-out-of-place/.expected/diff.patch
@@ -1,30 +1,29 @@
 diff --git a/out/Kptfile b/out/Kptfile
 new file mode 100644
-index 0000000..3a2c718
+index 0000000..04af51a
 --- /dev/null
 +++ b/out/Kptfile
-@@ -0,0 +1,15 @@
+@@ -0,0 +1,14 @@
 +apiVersion: kpt.dev/v1
 +kind: Kptfile
 +metadata:
 +  name: app
-+  namespace: staging
 +  labels:
 +    tier: backend
 +pipeline:
 +  mutators:
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +      configMap:
 +        namespace: staging
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +      configMap:
 +        tier: backend
 diff --git a/out/resources.yaml b/out/resources.yaml
 new file mode 100644
-index 0000000..84cfb26
+index 0000000..12338f5
 --- /dev/null
 +++ b/out/resources.yaml
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,34 @@
 +# Copyright 2021 The kpt Authors
 +#
 +# Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,16 +49,11 @@ index 0000000..84cfb26
 +  selector:
 +    matchLabels:
 +      tier: backend
-+  template:
-+    metadata:
-+      labels:
-+        tier: backend
 +---
 +apiVersion: custom.io/v1
 +kind: Custom
 +metadata:
 +  name: custom
-+  namespace: staging
 +  labels:
 +    tier: backend
 +spec:

--- a/e2e/testdata/fn-render/basicpipeline-out-of-place/Kptfile
+++ b/e2e/testdata/fn-render/basicpipeline-out-of-place/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/basicpipeline-symlink/.expected/config.yaml
+++ b/e2e/testdata/fn-render/basicpipeline-symlink/.expected/config.yaml
@@ -22,8 +22,10 @@ stdErrStripLines:
 stdErr: |-
   [WARN] resolved symlink "new-link" to ".", please note that the symlinks within the package are ignored
   Package: "basicpipeline-symlink"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
+  [Results]: [info]: set 4 labels in total
   Successfully executed 2 function(s) in 1 package(s).

--- a/e2e/testdata/fn-render/basicpipeline-symlink/.expected/diff.patch
+++ b/e2e/testdata/fn-render/basicpipeline-symlink/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index 1307fb5..fee64dc 100644
+index ae603c9..13a6cbf 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
-+  namespace: staging
 +  labels:
 +    tier: backend
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-@@ -10,3 +13,14 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+@@ -10,3 +12,22 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: backend
 +status:
@@ -23,15 +22,23 @@ index 1307fb5..fee64dc 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 4 labels in total
++            severity: info
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..84cfb26 100644
+index f2eec52..12338f5 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,25 @@ apiVersion: apps/v1
+@@ -15,12 +15,20 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -43,16 +50,11 @@ index f2eec52..84cfb26 100644
 +  selector:
 +    matchLabels:
 +      tier: backend
-+  template:
-+    metadata:
-+      labels:
-+        tier: backend
  ---
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
    name: custom
-+  namespace: staging
 +  labels:
 +    tier: backend
  spec:

--- a/e2e/testdata/fn-render/basicpipeline-symlink/Kptfile
+++ b/e2e/testdata/fn-render/basicpipeline-symlink/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/basicpipeline-v1alpha2/Kptfile
+++ b/e2e/testdata/fn-render/basicpipeline-v1alpha2/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/basicpipeline/.expected/diff.patch
+++ b/e2e/testdata/fn-render/basicpipeline/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index 1307fb5..fee64dc 100644
+index ae603c9..13a6cbf 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
-+  namespace: staging
 +  labels:
 +    tier: backend
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-@@ -10,3 +13,14 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+@@ -10,3 +12,22 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: backend
 +status:
@@ -23,15 +22,23 @@ index 1307fb5..fee64dc 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 4 labels in total
++            severity: info
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..84cfb26 100644
+index f2eec52..12338f5 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,25 @@ apiVersion: apps/v1
+@@ -15,12 +15,20 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -43,16 +50,11 @@ index f2eec52..84cfb26 100644
 +  selector:
 +    matchLabels:
 +      tier: backend
-+  template:
-+    metadata:
-+      labels:
-+        tier: backend
  ---
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
    name: custom
-+  namespace: staging
 +  labels:
 +    tier: backend
  spec:

--- a/e2e/testdata/fn-render/basicpipeline/Kptfile
+++ b/e2e/testdata/fn-render/basicpipeline/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/default-runtime/.expected/diff.patch
+++ b/e2e/testdata/fn-render/default-runtime/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index 1307fb5..fee64dc 100644
+index ae603c9..13a6cbf 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
-+  namespace: staging
 +  labels:
 +    tier: backend
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-@@ -10,3 +13,14 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+@@ -10,3 +12,22 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: backend
 +status:
@@ -23,15 +22,23 @@ index 1307fb5..fee64dc 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 4 labels in total
++            severity: info
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..84cfb26 100644
+index f2eec52..12338f5 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,25 @@ apiVersion: apps/v1
+@@ -15,12 +15,20 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -43,16 +50,11 @@ index f2eec52..84cfb26 100644
 +  selector:
 +    matchLabels:
 +      tier: backend
-+  template:
-+    metadata:
-+      labels:
-+        tier: backend
  ---
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
    name: custom
-+  namespace: staging
 +  labels:
 +    tier: backend
  spec:

--- a/e2e/testdata/fn-render/default-runtime/Kptfile
+++ b/e2e/testdata/fn-render/default-runtime/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/fn-failure/.expected/diff.patch
+++ b/e2e/testdata/fn-render/fn-failure/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/Kptfile b/Kptfile
-index 3447ba3..9127985 100644
+index 9a9c8a8..6c13438 100644
 --- a/Kptfile
 +++ b/Kptfile
 @@ -4,12 +4,31 @@ metadata:
@@ -9,18 +9,18 @@ index 3447ba3..9127985 100644
 -# invalid starlark input results in failure of first fn
 -  - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 -    configPath: starlark-failure-fn.yaml
--  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+-  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 -    configMap:
 -      namespace: staging
--  - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+-  - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 -    configMap:
 -      tier: backend
 +    - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +      configPath: starlark-failure-fn.yaml
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +      configMap:
 +        namespace: staging
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +      configMap:
 +        tier: backend
 +status:

--- a/e2e/testdata/fn-render/fn-failure/Kptfile
+++ b/e2e/testdata/fn-render/fn-failure/Kptfile
@@ -7,9 +7,9 @@ pipeline:
 # invalid starlark input results in failure of first fn
   - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
     configPath: starlark-failure-fn.yaml
-  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
     configMap:
       namespace: staging
-  - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+  - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
     configMap:
       tier: backend

--- a/e2e/testdata/fn-render/fnconfig-ancestorfn-not-mutate-subpkg-config/.expected/diff.patch
+++ b/e2e/testdata/fn-render/fnconfig-ancestorfn-not-mutate-subpkg-config/.expected/diff.patch
@@ -1,15 +1,9 @@
 diff --git a/Kptfile b/Kptfile
-index dbab15c..3eab648 100644
+index 8d8916e..67d2002 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,8 +2,20 @@ apiVersion: kpt.dev/v1
- kind: Kptfile
- metadata:
-   name: app-with-db
-+  namespace: staging
- pipeline:
-   mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+@@ -7,3 +7,22 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
        configMap:
          namespace: staging
 +status:
@@ -19,24 +13,31 @@ index dbab15c..3eab648 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++        results:
++          - message: set 4 labels in total
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
++        results:
++          - message: namespace [default] updated to "staging", 3 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
 diff --git a/db/Kptfile b/db/Kptfile
-index 093e789..dfe7f20 100644
+index f4f3c67..456cee5 100644
 --- a/db/Kptfile
 +++ b/db/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: db
 +  labels:
 +    tier: db
-+  namespace: staging
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 diff --git a/db/labelconfig.yaml b/db/labelconfig.yaml
 index 22d2de2..f4d597f 100644
 --- a/db/labelconfig.yaml
@@ -51,10 +52,10 @@ index 22d2de2..f4d597f 100644
  data:
    tier: db
 diff --git a/db/resources.yaml b/db/resources.yaml
-index dabe43c..7ced034 100644
+index dabe43c..30d3155 100644
 --- a/db/resources.yaml
 +++ b/db/resources.yaml
-@@ -15,5 +15,15 @@ apiVersion: apps/v1
+@@ -15,5 +15,11 @@ apiVersion: apps/v1
  kind: StatefulSet
  metadata:
    name: db
@@ -66,12 +67,8 @@ index dabe43c..7ced034 100644
 +  selector:
 +    matchLabels:
 +      tier: db
-+  template:
-+    metadata:
-+      labels:
-+        tier: db
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..b66c419 100644
+index f2eec52..f169ab0 100644
 --- a/resources.yaml
 +++ b/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -82,10 +79,3 @@ index f2eec52..b66c419 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: staging
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-render/fnconfig-ancestorfn-not-mutate-subpkg-config/Kptfile
+++ b/e2e/testdata/fn-render/fnconfig-ancestorfn-not-mutate-subpkg-config/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: app-with-db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging

--- a/e2e/testdata/fn-render/fnconfig-ancestorfn-not-mutate-subpkg-config/db/Kptfile
+++ b/e2e/testdata/fn-render/fnconfig-ancestorfn-not-mutate-subpkg-config/db/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: labelconfig.yaml

--- a/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/.expected/diff.patch
+++ b/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/.expected/diff.patch
@@ -1,10 +1,10 @@
 diff --git a/Kptfile b/Kptfile
-index 0bfdbb0..b4a6160 100644
+index f244e01..dad7306 100644
 --- a/Kptfile
 +++ b/Kptfile
 @@ -6,3 +6,13 @@ pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configPath: db/labelconfig.yaml
 +status:
 +  conditions:

--- a/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/Kptfile
+++ b/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: app-with-db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: db/labelconfig.yaml

--- a/e2e/testdata/fn-render/fnconfig-in-subdir/.expected/diff.patch
+++ b/e2e/testdata/fn-render/fnconfig-in-subdir/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index 0bfdbb0..f4fdf26 100644
+index f244e01..9f79949 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,7 +2,18 @@ apiVersion: kpt.dev/v1
+@@ -2,7 +2,21 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app-with-db
@@ -10,7 +10,7 @@ index 0bfdbb0..f4fdf26 100644
 +    tier: db
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configPath: db/labelconfig.yaml
 +status:
 +  conditions:
@@ -19,8 +19,11 @@ index 0bfdbb0..f4fdf26 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 5 labels in total
++            severity: info
 diff --git a/db/labelconfig.yaml b/db/labelconfig.yaml
 index 22d2de2..19e0746 100644
 --- a/db/labelconfig.yaml
@@ -34,10 +37,10 @@ index 22d2de2..19e0746 100644
  data:
    tier: db
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..022e175 100644
+index f2eec52..8ea86f0 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,23 @@ apiVersion: apps/v1
+@@ -15,12 +15,19 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -48,10 +51,6 @@ index f2eec52..022e175 100644
 +  selector:
 +    matchLabels:
 +      tier: db
-+  template:
-+    metadata:
-+      labels:
-+        tier: db
  ---
  apiVersion: custom.io/v1
  kind: Custom

--- a/e2e/testdata/fn-render/fnconfig-in-subdir/Kptfile
+++ b/e2e/testdata/fn-render/fnconfig-in-subdir/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: app-with-db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: db/labelconfig.yaml

--- a/e2e/testdata/fn-render/fnconfig-missing-name/Kptfile
+++ b/e2e/testdata/fn-render/fnconfig-missing-name/Kptfile
@@ -4,8 +4,8 @@ metadata:
   name: app-with-db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: labelconfig.yaml

--- a/e2e/testdata/fn-render/fnconfig-multiple-config-one-file/Kptfile
+++ b/e2e/testdata/fn-render/fnconfig-multiple-config-one-file/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: app-with-db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: labelconfig.yaml

--- a/e2e/testdata/fn-render/fnconfig-not-relative/Kptfile
+++ b/e2e/testdata/fn-render/fnconfig-not-relative/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: app-with-db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: /some/root/labelconfig.yaml

--- a/e2e/testdata/fn-render/fnconfig-outside-package/Kptfile
+++ b/e2e/testdata/fn-render/fnconfig-outside-package/Kptfile
@@ -4,7 +4,7 @@ metadata:
   name: app-with-db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: labelconfig.yaml
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: some/../../home/.kube/config # config pointing outside the package

--- a/e2e/testdata/fn-render/fnconfig-pkgfn-refers-subdir/.expected/diff.patch
+++ b/e2e/testdata/fn-render/fnconfig-pkgfn-refers-subdir/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index c2cf3ba..d0bbc91 100644
+index 34f24da..f5bcf7c 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,7 +2,18 @@ apiVersion: kpt.dev/v1
+@@ -2,7 +2,21 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app-with-db
@@ -10,7 +10,7 @@ index c2cf3ba..d0bbc91 100644
 +    tier: db
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configPath: confs/labelconfig.yaml
 +status:
 +  conditions:
@@ -19,8 +19,11 @@ index c2cf3ba..d0bbc91 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 5 labels in total
++            severity: info
 diff --git a/confs/labelconfig.yaml b/confs/labelconfig.yaml
 index 22d2de2..19e0746 100644
 --- a/confs/labelconfig.yaml
@@ -34,10 +37,10 @@ index 22d2de2..19e0746 100644
  data:
    tier: db
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..022e175 100644
+index f2eec52..8ea86f0 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,23 @@ apiVersion: apps/v1
+@@ -15,12 +15,19 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -48,10 +51,6 @@ index f2eec52..022e175 100644
 +  selector:
 +    matchLabels:
 +      tier: db
-+  template:
-+    metadata:
-+      labels:
-+        tier: db
  ---
  apiVersion: custom.io/v1
  kind: Custom

--- a/e2e/testdata/fn-render/fnconfig-pkgfn-refers-subdir/Kptfile
+++ b/e2e/testdata/fn-render/fnconfig-pkgfn-refers-subdir/Kptfile
@@ -4,5 +4,5 @@ metadata:
   name: app-with-db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: confs/labelconfig.yaml

--- a/e2e/testdata/fn-render/fnconfig-updated-in-render/.expected/diff.patch
+++ b/e2e/testdata/fn-render/fnconfig-updated-in-render/.expected/diff.patch
@@ -1,19 +1,10 @@
 diff --git a/Kptfile b/Kptfile
-index 950565f..d9be19c 100644
+index bec7e37..7116d33 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -3,7 +3,7 @@ kind: Kptfile
- metadata:
-   name: frontend
-   labels:
--    app.kubernetes.io/app: example
-+    app.kubernetes.io/app: frontend
-   annotations:
-     config.kubernetes.io/local-config: "true"
- info:
-@@ -16,3 +16,19 @@ pipeline:
+@@ -16,3 +16,24 @@ pipeline:
        configPath: update-labels.yaml
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configPath: label-input.yaml
 +status:
 +  conditions:
@@ -22,15 +13,20 @@ index 950565f..d9be19c 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
 +        results:
-+          - message: namespace "example" updated to "frontend", 2 value(s) changed
++          - message: namespace [example] updated to "frontend", 2 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
 +            severity: info
 +      - image: ghcr.io/kptdev/krm-functions-catalog/apply-replacements:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 4 labels in total
++            severity: info
 diff --git a/app.yaml b/app.yaml
 index 3361e5b..33f2627 100644
 --- a/app.yaml
@@ -58,15 +54,12 @@ index 3361e5b..33f2627 100644
 -      app.kubernetes.io/app: example
 +      app.kubernetes.io/app: frontend
 diff --git a/label-input.yaml b/label-input.yaml
-index 26dab6c..cdff6e0 100644
+index 26dab6c..2a28d6b 100644
 --- a/label-input.yaml
 +++ b/label-input.yaml
-@@ -5,6 +5,6 @@ metadata: # kpt-merge: /label-input
-   annotations:
-     config.kubernetes.io/local-config: "true"
+@@ -7,4 +7,4 @@ metadata: # kpt-merge: /label-input
    labels:
--    app.kubernetes.io/app: example
-+    app.kubernetes.io/app: frontend
+     app.kubernetes.io/app: example
  data:
 -  app.kubernetes.io/app: example
 +  app.kubernetes.io/app: frontend
@@ -84,28 +77,3 @@ index 9db1da3..e112378 100644
 -    app.kubernetes.io/app: example
 +    app.kubernetes.io/app: frontend
  spec: {}
-diff --git a/package-context.yaml b/package-context.yaml
-index 2340959..bbf7167 100644
---- a/package-context.yaml
-+++ b/package-context.yaml
-@@ -4,5 +4,7 @@ metadata:
-   name: kptfile.kpt.dev
-   annotations:
-     config.kubernetes.io/local-config: "true"
-+  labels:
-+    app.kubernetes.io/app: frontend
- data:
-   name: frontend
-diff --git a/update-labels.yaml b/update-labels.yaml
-index 7aae6c7..cabf787 100644
---- a/update-labels.yaml
-+++ b/update-labels.yaml
-@@ -5,7 +5,7 @@ metadata: # kpt-merge: /update-labels
-   annotations:
-     config.kubernetes.io/local-config: "true"
-   labels:
--    app.kubernetes.io/app: example
-+    app.kubernetes.io/app: frontend
- replacements:
- - source:
-     kind: ConfigMap

--- a/e2e/testdata/fn-render/fnconfig-updated-in-render/Kptfile
+++ b/e2e/testdata/fn-render/fnconfig-updated-in-render/Kptfile
@@ -10,9 +10,9 @@ info:
   description: sample description
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configPath: package-context.yaml
     - image: ghcr.io/kptdev/krm-functions-catalog/apply-replacements:latest
       configPath: update-labels.yaml
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: label-input.yaml

--- a/e2e/testdata/fn-render/fnconfig/.expected/diff.patch
+++ b/e2e/testdata/fn-render/fnconfig/.expected/diff.patch
@@ -1,20 +1,19 @@
 diff --git a/Kptfile b/Kptfile
-index 043dcac..58ddc42 100644
+index cd1b1e5..a14e2ce 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app-with-db
-+  namespace: staging
 +  labels:
 +    tier: db
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-@@ -9,3 +12,18 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+@@ -9,3 +11,34 @@ pipeline:
          namespace: staging
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configPath: labelconfig.yaml
 +status:
 +  conditions:
@@ -23,34 +22,49 @@ index 043dcac..58ddc42 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "db", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++        results:
++          - message: set 3 labels in total
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [db default] updated to "staging", 3 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 8 labels in total
++            severity: info
 diff --git a/db/Kptfile b/db/Kptfile
-index 264dd2e..8dd7c37 100644
+index a0e6f2d..5e0e30a 100644
 --- a/db/Kptfile
 +++ b/db/Kptfile
-@@ -2,6 +2,10 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: db
-+  namespace: staging
 +  labels:
 +    app: backend
 +    tier: db
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 diff --git a/db/resources.yaml b/db/resources.yaml
-index dabe43c..e9be40c 100644
+index dabe43c..25f77c1 100644
 --- a/db/resources.yaml
 +++ b/db/resources.yaml
-@@ -15,5 +15,18 @@ apiVersion: apps/v1
+@@ -15,5 +15,13 @@ apiVersion: apps/v1
  kind: StatefulSet
  metadata:
    name: db
@@ -64,11 +78,6 @@ index dabe43c..e9be40c 100644
 +    matchLabels:
 +      app: backend
 +      tier: db
-+  template:
-+    metadata:
-+      labels:
-+        app: backend
-+        tier: db
 diff --git a/labelconfig.yaml b/labelconfig.yaml
 index 22d2de2..8712cbf 100644
 --- a/labelconfig.yaml
@@ -83,10 +92,10 @@ index 22d2de2..8712cbf 100644
  data:
    tier: db
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..8b2113d 100644
+index f2eec52..dcf72b1 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,25 @@ apiVersion: apps/v1
+@@ -15,12 +15,20 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -98,16 +107,11 @@ index f2eec52..8b2113d 100644
 +  selector:
 +    matchLabels:
 +      tier: db
-+  template:
-+    metadata:
-+      labels:
-+        tier: db
  ---
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
    name: custom
-+  namespace: staging
 +  labels:
 +    tier: db
  spec:

--- a/e2e/testdata/fn-render/fnconfig/Kptfile
+++ b/e2e/testdata/fn-render/fnconfig/Kptfile
@@ -4,8 +4,8 @@ metadata:
   name: app-with-db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: labelconfig.yaml

--- a/e2e/testdata/fn-render/fnconfig/db/Kptfile
+++ b/e2e/testdata/fn-render/fnconfig/db/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: db
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         app: backend

--- a/e2e/testdata/fn-render/format-on-success/.expected/diff.patch
+++ b/e2e/testdata/fn-render/format-on-success/.expected/diff.patch
@@ -1,15 +1,9 @@
 diff --git a/Kptfile b/Kptfile
-index dbab15c..3ab935c 100644
+index 8d8916e..edb2aa5 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,8 +2,20 @@ apiVersion: kpt.dev/v1
- kind: Kptfile
- metadata:
-   name: app-with-db
-+  namespace: staging
- pipeline:
-   mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+@@ -7,3 +7,24 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
        configMap:
          namespace: staging
 +status:
@@ -19,22 +13,20 @@ index dbab15c..3ab935c 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++        results:
++          - message: namespace [default] updated to "db", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-diff --git a/db/Kptfile b/db/Kptfile
-index 92bb0fc..31aafaa 100644
---- a/db/Kptfile
-+++ b/db/Kptfile
-@@ -2,6 +2,7 @@ apiVersion: kpt.dev/v1
- kind: Kptfile
- metadata:
-   name: db
-+  namespace: staging
- pipeline:
-   mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++        results:
++          - message: namespace [db default] updated to "staging", 2 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
 diff --git a/db/resources.yaml b/db/resources.yaml
 index dabe43c..b44084a 100644
 --- a/db/resources.yaml

--- a/e2e/testdata/fn-render/format-on-success/Kptfile
+++ b/e2e/testdata/fn-render/format-on-success/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: app-with-db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging

--- a/e2e/testdata/fn-render/format-on-success/db/Kptfile
+++ b/e2e/testdata/fn-render/format-on-success/db/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: db

--- a/e2e/testdata/fn-render/generator/.expected/diff.patch
+++ b/e2e/testdata/fn-render/generator/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index 8050168..a201e2b 100644
+index 26aa62c..5589489 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app-with-generator
-+  namespace: staging
 +  labels:
 +    tier: db
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-@@ -10,3 +13,20 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+@@ -10,3 +12,36 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: db
 +status:
@@ -25,23 +24,38 @@ index 8050168..a201e2b 100644
 +    mutationSteps:
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "db", 2 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++        results:
++          - message: set 7 labels in total
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [db default] updated to "staging", 3 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 11 labels in total
++            severity: info
 diff --git a/db/Kptfile b/db/Kptfile
-index 3091f75..b290407 100644
+index 4538e5e..95ee6cd 100644
 --- a/db/Kptfile
 +++ b/db/Kptfile
-@@ -2,6 +2,10 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: db
-+  namespace: staging
 +  labels:
 +    app: backend
 +    tier: db
@@ -80,10 +94,10 @@ index 0000000..ffdf484
 +      app: backend
 +      tier: db
 diff --git a/db/resources.yaml b/db/resources.yaml
-index dabe43c..e9be40c 100644
+index dabe43c..25f77c1 100644
 --- a/db/resources.yaml
 +++ b/db/resources.yaml
-@@ -15,5 +15,18 @@ apiVersion: apps/v1
+@@ -15,5 +15,13 @@ apiVersion: apps/v1
  kind: StatefulSet
  metadata:
    name: db
@@ -97,20 +111,14 @@ index dabe43c..e9be40c 100644
 +    matchLabels:
 +      app: backend
 +      tier: db
-+  template:
-+    metadata:
-+      labels:
-+        app: backend
-+        tier: db
 diff --git a/db/starlark-httpbin.yaml b/db/starlark-httpbin.yaml
-index e52e48f..d21601e 100644
+index e52e48f..7aad15e 100644
 --- a/db/starlark-httpbin.yaml
 +++ b/db/starlark-httpbin.yaml
-@@ -15,6 +15,10 @@ apiVersion: fn.kpt.dev/v1alpha1
+@@ -15,6 +15,9 @@ apiVersion: fn.kpt.dev/v1alpha1
  kind: StarlarkRun
  metadata:
    name: httpbin-gen
-+  namespace: staging
 +  labels:
 +    app: backend
 +    tier: db
@@ -118,10 +126,10 @@ index e52e48f..d21601e 100644
    httpbin_deployment = {
       "apiVersion": "apps/v1",
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..8b2113d 100644
+index f2eec52..dcf72b1 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,25 @@ apiVersion: apps/v1
+@@ -15,12 +15,20 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -133,16 +141,11 @@ index f2eec52..8b2113d 100644
 +  selector:
 +    matchLabels:
 +      tier: db
-+  template:
-+    metadata:
-+      labels:
-+        tier: db
  ---
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
    name: custom
-+  namespace: staging
 +  labels:
 +    tier: db
  spec:

--- a/e2e/testdata/fn-render/generator/Kptfile
+++ b/e2e/testdata/fn-render/generator/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: app-with-generator
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: db

--- a/e2e/testdata/fn-render/generator/db/Kptfile
+++ b/e2e/testdata/fn-render/generator/db/Kptfile
@@ -6,9 +6,9 @@ pipeline:
   mutators:
     - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
       configPath: starlark-httpbin.yaml
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: db
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         app: backend

--- a/e2e/testdata/fn-render/invalid-configmap-fnconfig/Kptfile
+++ b/e2e/testdata/fn-render/invalid-configmap-fnconfig/Kptfile
@@ -4,10 +4,10 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap: # invalid config
         tier: backend
         envs: # lists are not allowed in configmap

--- a/e2e/testdata/fn-render/invalid-inline-fnconfig/Kptfile
+++ b/e2e/testdata/fn-render/invalid-inline-fnconfig/Kptfile
@@ -4,10 +4,10 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       config: # invalid inline config, missing apiVersion/kind
         envs:
           - dev

--- a/e2e/testdata/fn-render/kptfile-unknown-fields/Kptfile
+++ b/e2e/testdata/fn-render/kptfile-unknown-fields/Kptfile
@@ -4,10 +4,10 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend
       targetResources: # unknown field

--- a/e2e/testdata/fn-render/krm-check-exclude-kustomize/.expected/diff.patch
+++ b/e2e/testdata/fn-render/krm-check-exclude-kustomize/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index 2985a1a..30b4376 100644
+index 4948ed1..49d57fb 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,8 +2,19 @@ apiVersion: kpt.dev/v1
+@@ -2,8 +2,22 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
@@ -10,7 +10,7 @@ index 2985a1a..30b4376 100644
 +    tier: backend
  pipeline:
    mutators:
-     - image: set-labels:v0.1.5
+     - image: set-labels:latest
        configMap:
          tier: backend
 +status:
@@ -20,13 +20,16 @@ index 2985a1a..30b4376 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 8 labels in total
++            severity: info
 diff --git a/kustomization.yaml b/kustomization.yaml
-index f3f0207..6c517af 100644
+index f3f0207..0452667 100644
 --- a/kustomization.yaml
 +++ b/kustomization.yaml
-@@ -11,7 +11,9 @@
+@@ -11,7 +11,14 @@
  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  # See the License for the specific language governing permissions and
  # limitations under the License.
@@ -37,11 +40,16 @@ index f3f0207..6c517af 100644
 +metadata:
 +  labels:
 +    tier: backend
++spec:
++  selector:
++    tier: backend
++    matchLabels:
++      tier: backend
 diff --git a/resources.yaml b/resources.yaml
-index 40a033d..eb585ba 100644
+index 40a033d..dc478d6 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,23 @@ apiVersion: apps/v1
+@@ -15,12 +15,19 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -52,10 +60,6 @@ index 40a033d..eb585ba 100644
 +  selector:
 +    matchLabels:
 +      tier: backend
-+  template:
-+    metadata:
-+      labels:
-+        tier: backend
  ---
  apiVersion: custom.io/v1
  kind: Custom

--- a/e2e/testdata/fn-render/krm-check-exclude-kustomize/Kptfile
+++ b/e2e/testdata/fn-render/krm-check-exclude-kustomize/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: set-labels:v0.1.5
+    - image: set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/krmignore/Kptfile
+++ b/e2e/testdata/fn-render/krmignore/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging

--- a/e2e/testdata/fn-render/missing-fn-image/.expected/diff.patch
+++ b/e2e/testdata/fn-render/missing-fn-image/.expected/diff.patch
@@ -1,9 +1,9 @@
 diff --git a/Kptfile b/Kptfile
-index 11012de..a0f4634 100644
+index e60b7a4..064d8e6 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -7,6 +7,26 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+@@ -7,6 +7,31 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
        configMap:
          namespace: staging
 -    - image: ghcr.io/kptdev/krm-functions-catalog/dne # non-existing image
@@ -20,8 +20,13 @@ index 11012de..a0f4634 100644
 +        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
 +      - image: ghcr.io/kptdev/krm-functions-catalog/dne:latest
 +        stderr: |-
 +          docker: Error response from daemon: error from registry: denied

--- a/e2e/testdata/fn-render/missing-fn-image/Kptfile
+++ b/e2e/testdata/fn-render/missing-fn-image/Kptfile
@@ -4,7 +4,7 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
     - image: ghcr.io/kptdev/krm-functions-catalog/dne # non-existing image

--- a/e2e/testdata/fn-render/missing-fnconfig/Kptfile
+++ b/e2e/testdata/fn-render/missing-fnconfig/Kptfile
@@ -4,8 +4,8 @@ metadata:
   name: app-with-db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configPath: labelconfig1.yaml

--- a/e2e/testdata/fn-render/missing-fnconfig/db/Kptfile
+++ b/e2e/testdata/fn-render/missing-fnconfig/db/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: db
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         app: backend

--- a/e2e/testdata/fn-render/multiple-fnconfig/Kptfile
+++ b/e2e/testdata/fn-render/multiple-fnconfig/Kptfile
@@ -4,7 +4,7 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
       configPath: configmap.yaml

--- a/e2e/testdata/fn-render/no-fnconfig/.expected/config.yaml
+++ b/e2e/testdata/fn-render/no-fnconfig/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,4 +21,12 @@ stdErrStripLines:
 
 exitCode: 1
 
-stdErr: "[error]: failed to configure function: `functionConfig` must be either a `ConfigMap` or `SetLabels`"
+stdErr: |
+  Package: "no-fnconfig"
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+  [FAIL] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
+  [Results]: [info]: `FunctionConfig` is not given
+   Stderr: failed to evaluate function: error: function failure  Exit code: 1

--- a/e2e/testdata/fn-render/no-fnconfig/.expected/config.yaml
+++ b/e2e/testdata/fn-render/no-fnconfig/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-render/no-fnconfig/.expected/diff.patch
+++ b/e2e/testdata/fn-render/no-fnconfig/.expected/diff.patch
@@ -1,11 +1,11 @@
 diff --git a/Kptfile b/Kptfile
-index f2d1249..6772376 100644
+index f2fdc9a..c6b117b 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -8,3 +8,25 @@ pipeline:
+@@ -8,3 +8,27 @@ pipeline:
        configMap:
          namespace: staging
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +status:
 +  conditions:
 +    - type: Rendered
@@ -16,15 +16,17 @@ index f2d1249..6772376 100644
 +        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
-+        stderr: '[error] : failed to configure function: `functionConfig` must be either a `ConfigMap` or `SetLabels`'
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
++        stderr: 'failed to evaluate function: error: function failure'
 +        exitCode: 1
 +        results:
-+          - message: 'failed to configure function: `functionConfig` must be either a `ConfigMap` or `SetLabels`'
-+            severity: error
-+        errorResults:
-+          - message: 'failed to configure function: `functionConfig` must be either a `ConfigMap` or `SetLabels`'
-+            severity: error
-+    errorSummary: 'ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5: exit code 1'
++          - message: '`FunctionConfig` is not given'
++            severity: info
++    errorSummary: 'ghcr.io/kptdev/krm-functions-catalog/set-labels:latest: exit code 1'

--- a/e2e/testdata/fn-render/no-fnconfig/Kptfile
+++ b/e2e/testdata/fn-render/no-fnconfig/Kptfile
@@ -4,7 +4,7 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest

--- a/e2e/testdata/fn-render/no-format-on-failure/Kptfile
+++ b/e2e/testdata/fn-render/no-format-on-failure/Kptfile
@@ -4,7 +4,7 @@ metadata:
   name: app-with-db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace:
           hello: world

--- a/e2e/testdata/fn-render/no-format-on-failure/db/Kptfile
+++ b/e2e/testdata/fn-render/no-format-on-failure/db/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: db

--- a/e2e/testdata/fn-render/no-pipeline-in-subpackage/.expected/diff.patch
+++ b/e2e/testdata/fn-render/no-pipeline-in-subpackage/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index 1307fb5..fee64dc 100644
+index ae603c9..6e5cd46 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
-+  namespace: staging
 +  labels:
 +    tier: backend
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-@@ -10,3 +13,14 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+@@ -10,3 +12,22 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: backend
 +status:
@@ -23,26 +22,33 @@ index 1307fb5..fee64dc 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 5 labels in total
++            severity: info
 diff --git a/db/Kptfile b/db/Kptfile
-index 79b7a5a..15f086b 100644
+index 79b7a5a..c1f496c 100644
 --- a/db/Kptfile
 +++ b/db/Kptfile
-@@ -2,3 +2,6 @@ apiVersion: kpt.dev/v1
+@@ -2,3 +2,5 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: db
-+  namespace: staging
 +  labels:
 +    tier: backend
 diff --git a/db/resources.yaml b/db/resources.yaml
-index f2eec52..84cfb26 100644
+index f2eec52..12338f5 100644
 --- a/db/resources.yaml
 +++ b/db/resources.yaml
-@@ -15,12 +15,25 @@ apiVersion: apps/v1
+@@ -15,12 +15,20 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -54,16 +60,11 @@ index f2eec52..84cfb26 100644
 +  selector:
 +    matchLabels:
 +      tier: backend
-+  template:
-+    metadata:
-+      labels:
-+        tier: backend
  ---
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
    name: custom
-+  namespace: staging
 +  labels:
 +    tier: backend
  spec:

--- a/e2e/testdata/fn-render/no-pipeline-in-subpackage/Kptfile
+++ b/e2e/testdata/fn-render/no-pipeline-in-subpackage/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/non-krm-resource/.expected/diff.patch
+++ b/e2e/testdata/fn-render/non-krm-resource/.expected/diff.patch
@@ -1,9 +1,9 @@
 diff --git a/Kptfile b/Kptfile
-index 1307fb5..a5c31bf 100644
+index ae603c9..38d3a2a 100644
 --- a/Kptfile
 +++ b/Kptfile
 @@ -10,3 +10,17 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: backend
 +status:
@@ -16,7 +16,7 @@ index 1307fb5..a5c31bf 100644
 +        	pipeline.run: input resource list must contain only KRM resources: non-krm.yaml: resource must have `apiVersion`
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        executionError: 'input resource list must contain only KRM resources: non-krm.yaml: resource must have `apiVersion`'
 +        exitCode: 1
-+    errorSummary: 'ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0: input resource list must contain only KRM resources: non-krm.yaml: resource must have `apiVersion`'
++    errorSummary: 'ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest: input resource list must contain only KRM resources: non-krm.yaml: resource must have `apiVersion`'

--- a/e2e/testdata/fn-render/non-krm-resource/Kptfile
+++ b/e2e/testdata/fn-render/non-krm-resource/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/out-of-place-dir-exists-error/Kptfile
+++ b/e2e/testdata/fn-render/out-of-place-dir-exists-error/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging

--- a/e2e/testdata/fn-render/out-of-place-dir/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-dir/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s

--- a/e2e/testdata/fn-render/out-of-place-dir/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-dir/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-render/out-of-place-dir/.expected/diff.patch
+++ b/e2e/testdata/fn-render/out-of-place-dir/.expected/diff.patch
@@ -1,25 +1,24 @@
 diff --git a/out/Kptfile b/out/Kptfile
 new file mode 100644
-index 0000000..d0d3425
+index 0000000..710f44a
 --- /dev/null
 +++ b/out/Kptfile
-@@ -0,0 +1,10 @@
+@@ -0,0 +1,9 @@
 +apiVersion: kpt.dev/v1
 +kind: Kptfile
 +metadata:
 +  name: app
-+  namespace: staging
 +pipeline:
 +  mutators:
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +      configMap:
 +        namespace: staging
 diff --git a/out/resources.yaml b/out/resources.yaml
 new file mode 100644
-index 0000000..b66c419
+index 0000000..f169ab0
 --- /dev/null
 +++ b/out/resources.yaml
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,27 @@
 +# Copyright 2021 The kpt Authors
 +#
 +# Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,6 +44,5 @@ index 0000000..b66c419
 +kind: Custom
 +metadata:
 +  name: custom
-+  namespace: staging
 +spec:
 +  image: nginx:1.2.3

--- a/e2e/testdata/fn-render/out-of-place-dir/Kptfile
+++ b/e2e/testdata/fn-render/out-of-place-dir/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging

--- a/e2e/testdata/fn-render/out-of-place-fnchain-stdout-results/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-stdout-results/.expected/config.yaml
@@ -6,25 +6,6 @@ stdOut: |
   apiVersion: config.kubernetes.io/v1
   kind: ResourceList
   items:
-  - apiVersion: kpt.dev/v1
-    kind: Kptfile
-    metadata:
-      name: app
-      annotations:
-        config.kubernetes.io/index: "0"
-        config.kubernetes.io/path: Kptfile
-        internal.config.kubernetes.io/index: "0"
-        internal.config.kubernetes.io/path: Kptfile
-        internal.config.kubernetes.io/seqindent: wide
-        foo: bar
-      namespace: staging
-      labels:
-        tier: backend
-    pipeline:
-      mutators:
-      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-        configMap:
-          namespace: staging
   # Copyright 2021 The kpt Authors
   #
   # Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,11 +24,11 @@ stdOut: |
     metadata:
       name: nginx-deployment
       annotations:
-        config.kubernetes.io/index: "0"
-        config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/index: "0"
-        internal.config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/seqindent: compact
+        config.kubernetes.io/index: '0'
+        config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/index: '0'
+        internal.config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/seqindent: 'compact'
         foo: bar
       namespace: staging
       labels:
@@ -68,17 +49,34 @@ stdOut: |
     metadata:
       name: custom
       annotations:
-        config.kubernetes.io/index: "1"
-        config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/index: "1"
-        internal.config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/seqindent: compact
+        config.kubernetes.io/index: '1'
+        config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/index: '1'
+        internal.config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/seqindent: 'compact'
         foo: bar
-      namespace: staging
       labels:
         tier: backend
     spec:
       image: nginx:1.2.3
+  - apiVersion: kpt.dev/v1
+    kind: Kptfile
+    metadata:
+      name: app
+      annotations:
+        config.kubernetes.io/index: '0'
+        config.kubernetes.io/path: 'Kptfile'
+        internal.config.kubernetes.io/index: '0'
+        internal.config.kubernetes.io/path: 'Kptfile'
+        internal.config.kubernetes.io/seqindent: 'wide'
+        foo: bar
+      labels:
+        tier: backend
+    pipeline:
+      mutators:
+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+        configMap:
+          namespace: staging
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s

--- a/e2e/testdata/fn-render/out-of-place-fnchain-stdout-results/.expected/exec.sh
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-stdout-results/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-render/out-of-place-fnchain-stdout-results/.expected/exec.sh
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-stdout-results/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ results=$(mktemp -d)
 
 kpt fn render -o stdout --results-dir $results \
 | kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest --results-dir $results -- foo=bar \
-| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5 --results-dir $results -- tier=backend
+| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-labels:latest --results-dir $results -- tier=backend
 
 # remove temporary directory
 rm -r $results

--- a/e2e/testdata/fn-render/out-of-place-fnchain-stdout-results/Kptfile
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-stdout-results/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging

--- a/e2e/testdata/fn-render/out-of-place-fnchain-stdout/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-stdout/.expected/config.yaml
@@ -4,37 +4,20 @@ stdErrStripLines:
 
 stdErr: |
   Package: "out-of-place-fnchain-stdout"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" in 0s
   [Results]: [info] metadata.annotations: set annotations: {"foo":"bar"}, [info] metadata.annotations: set annotations: {"foo":"bar"}, [info] spec.template.metadata.annotations: set annotations: {"foo":"bar"}, [info] metadata.annotations: set annotations: {"foo":"bar"}
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
+  [Results]: [info]: set 5 labels in total
 
 stdOut: |
   apiVersion: config.kubernetes.io/v1
   kind: ResourceList
   items:
-  - apiVersion: kpt.dev/v1
-    kind: Kptfile
-    metadata:
-      name: app
-      annotations:
-        config.kubernetes.io/index: "0"
-        config.kubernetes.io/path: Kptfile
-        internal.config.kubernetes.io/index: "0"
-        internal.config.kubernetes.io/path: Kptfile
-        internal.config.kubernetes.io/seqindent: wide
-        foo: bar
-      namespace: staging
-      labels:
-        tier: backend
-    pipeline:
-      mutators:
-      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-        configMap:
-          namespace: staging
   # Copyright 2021 The kpt Authors
   #
   # Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,11 +36,11 @@ stdOut: |
     metadata:
       name: nginx-deployment
       annotations:
-        config.kubernetes.io/index: "0"
-        config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/index: "0"
-        internal.config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/seqindent: compact
+        config.kubernetes.io/index: '0'
+        config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/index: '0'
+        internal.config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/seqindent: 'compact'
         foo: bar
       namespace: staging
       labels:
@@ -78,14 +61,31 @@ stdOut: |
     metadata:
       name: custom
       annotations:
-        config.kubernetes.io/index: "1"
-        config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/index: "1"
-        internal.config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/seqindent: compact
+        config.kubernetes.io/index: '1'
+        config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/index: '1'
+        internal.config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/seqindent: 'compact'
         foo: bar
-      namespace: staging
       labels:
         tier: backend
     spec:
       image: nginx:1.2.3
+  - apiVersion: kpt.dev/v1
+    kind: Kptfile
+    metadata:
+      name: app
+      annotations:
+        config.kubernetes.io/index: '0'
+        config.kubernetes.io/path: 'Kptfile'
+        internal.config.kubernetes.io/index: '0'
+        internal.config.kubernetes.io/path: 'Kptfile'
+        internal.config.kubernetes.io/seqindent: 'wide'
+        foo: bar
+      labels:
+        tier: backend
+    pipeline:
+      mutators:
+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+        configMap:
+          namespace: staging

--- a/e2e/testdata/fn-render/out-of-place-fnchain-stdout/.expected/exec.sh
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-stdout/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-render/out-of-place-fnchain-stdout/.expected/exec.sh
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-stdout/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,4 +18,4 @@ set -eo pipefail
 
 kpt fn render -o stdout \
 | kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest -- foo=bar \
-| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5 -- tier=backend
+| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-labels:latest -- tier=backend

--- a/e2e/testdata/fn-render/out-of-place-fnchain-stdout/Kptfile
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-stdout/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging

--- a/e2e/testdata/fn-render/out-of-place-fnchain-unwrap/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-unwrap/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,8 +53,21 @@ stdOut: |
     name: custom
     annotations:
       foo: bar
-    namespace: staging
     labels:
       tier: backend
   spec:
     image: nginx:1.2.3
+  ---
+  apiVersion: kpt.dev/v1
+  kind: Kptfile
+  metadata:
+    name: app
+    annotations:
+      foo: bar
+    labels:
+      tier: backend
+  pipeline:
+    mutators:
+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+        configMap:
+          namespace: staging

--- a/e2e/testdata/fn-render/out-of-place-fnchain-unwrap/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-unwrap/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-render/out-of-place-fnchain-unwrap/.expected/exec.sh
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-unwrap/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-render/out-of-place-fnchain-unwrap/.expected/exec.sh
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-unwrap/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,4 +18,4 @@ set -eo pipefail
 
 kpt fn render -o stdout \
 | kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest -- foo=bar \
-| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5 -o unwrap -- tier=backend
+| kpt fn eval - --image ghcr.io/kptdev/krm-functions-catalog/set-labels:latest -o unwrap -- tier=backend

--- a/e2e/testdata/fn-render/out-of-place-fnchain-unwrap/Kptfile
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-unwrap/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging

--- a/e2e/testdata/fn-render/out-of-place-stdout/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-stdout/.expected/config.yaml
@@ -3,29 +3,13 @@ stdErrStripLines:
   - "    \"WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\""
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
 
 stdOut: |
   apiVersion: config.kubernetes.io/v1
   kind: ResourceList
   items:
-  - apiVersion: kpt.dev/v1
-    kind: Kptfile
-    metadata:
-      name: app
-      annotations:
-        config.kubernetes.io/index: "0"
-        config.kubernetes.io/path: Kptfile
-        internal.config.kubernetes.io/index: "0"
-        internal.config.kubernetes.io/path: Kptfile
-        internal.config.kubernetes.io/seqindent: wide
-      namespace: staging
-    pipeline:
-      mutators:
-      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-        configMap:
-          namespace: staging
   # Copyright 2021 The kpt Authors
   #
   # Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,11 +28,11 @@ stdOut: |
     metadata:
       name: nginx-deployment
       annotations:
-        config.kubernetes.io/index: "0"
-        config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/index: "0"
-        internal.config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/seqindent: compact
+        config.kubernetes.io/index: '0'
+        config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/index: '0'
+        internal.config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/seqindent: 'compact'
       namespace: staging
     spec:
       replicas: 3
@@ -57,11 +41,25 @@ stdOut: |
     metadata:
       name: custom
       annotations:
-        config.kubernetes.io/index: "1"
-        config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/index: "1"
-        internal.config.kubernetes.io/path: resources.yaml
-        internal.config.kubernetes.io/seqindent: compact
-      namespace: staging
+        config.kubernetes.io/index: '1'
+        config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/index: '1'
+        internal.config.kubernetes.io/path: 'resources.yaml'
+        internal.config.kubernetes.io/seqindent: 'compact'
     spec:
       image: nginx:1.2.3
+  - apiVersion: kpt.dev/v1
+    kind: Kptfile
+    metadata:
+      name: app
+      annotations:
+        config.kubernetes.io/index: '0'
+        config.kubernetes.io/path: 'Kptfile'
+        internal.config.kubernetes.io/index: '0'
+        internal.config.kubernetes.io/path: 'Kptfile'
+        internal.config.kubernetes.io/seqindent: 'wide'
+    pipeline:
+      mutators:
+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+        configMap:
+          namespace: staging

--- a/e2e/testdata/fn-render/out-of-place-stdout/Kptfile
+++ b/e2e/testdata/fn-render/out-of-place-stdout/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging

--- a/e2e/testdata/fn-render/out-of-place-unwrap/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-unwrap/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-render/out-of-place-unwrap/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-unwrap/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,10 +13,23 @@
 # limitations under the License.
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
 
 stdOut: |
+  # Copyright 2021 The kpt Authors
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #      http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
   apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -29,6 +42,15 @@ stdOut: |
   kind: Custom
   metadata:
     name: custom
-    namespace: staging
   spec:
     image: nginx:1.2.3
+  ---
+  apiVersion: kpt.dev/v1
+  kind: Kptfile
+  metadata:
+    name: app
+  pipeline:
+    mutators:
+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+        configMap:
+          namespace: staging

--- a/e2e/testdata/fn-render/out-of-place-unwrap/Kptfile
+++ b/e2e/testdata/fn-render/out-of-place-unwrap/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging

--- a/e2e/testdata/fn-render/preserve-order-null-values/.expected/diff.patch
+++ b/e2e/testdata/fn-render/preserve-order-null-values/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index 1307fb5..fee64dc 100644
+index ae603c9..13a6cbf 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
-+  namespace: staging
 +  labels:
 +    tier: backend
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-@@ -10,3 +13,14 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+@@ -10,3 +12,22 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: backend
 +status:
@@ -23,15 +22,23 @@ index 1307fb5..fee64dc 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 4 labels in total
++            severity: info
 diff --git a/resources.yaml b/resources.yaml
-index f410b70..b58c04c 100644
+index f410b70..ce12ace 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -16,12 +16,25 @@ kind: Deployment
+@@ -16,12 +16,20 @@ kind: Deployment
  metadata:
    name: nginx-deployment
    createTimestamp: null
@@ -43,16 +50,11 @@ index f410b70..b58c04c 100644
 +  selector:
 +    matchLabels:
 +      tier: backend
-+  template:
-+    metadata:
-+      labels:
-+        tier: backend
  ---
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
    name: custom
-+  namespace: staging
 +  labels:
 +    tier: backend
  spec:

--- a/e2e/testdata/fn-render/preserve-order-null-values/Kptfile
+++ b/e2e/testdata/fn-render/preserve-order-null-values/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/resource-deletion/.expected/diff.patch
+++ b/e2e/testdata/fn-render/resource-deletion/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index 364e274..f17e769 100644
+index 01b45db..d9e79d9 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
-+  namespace: staging
 +  labels:
 +    tier: backend
  pipeline:
    mutators:
      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
-@@ -12,3 +15,16 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+@@ -12,3 +14,24 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: backend
 +status:
@@ -25,10 +24,18 @@ index 364e274..f17e769 100644
 +    mutationSteps:
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 5 labels in total
++            severity: info
 diff --git a/deployment_httpbin.yaml b/deployment_httpbin.yaml
 deleted file mode 100644
 index 49d4f6e..0000000
@@ -72,10 +79,10 @@ index 49d4f6e..0000000
 -        - name: httpbin
 -          image: kennethreitz/httpbin
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..84cfb26 100644
+index f2eec52..12338f5 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,25 @@ apiVersion: apps/v1
+@@ -15,12 +15,20 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -87,29 +94,23 @@ index f2eec52..84cfb26 100644
 +  selector:
 +    matchLabels:
 +      tier: backend
-+  template:
-+    metadata:
-+      labels:
-+        tier: backend
  ---
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
    name: custom
-+  namespace: staging
 +  labels:
 +    tier: backend
  spec:
    image: nginx:1.2.3
 diff --git a/starlark-httpbin.yaml b/starlark-httpbin.yaml
-index fd90109..e437ba7 100644
+index fd90109..f9174fb 100644
 --- a/starlark-httpbin.yaml
 +++ b/starlark-httpbin.yaml
-@@ -15,6 +15,9 @@ apiVersion: fn.kpt.dev/v1alpha1
+@@ -15,6 +15,8 @@ apiVersion: fn.kpt.dev/v1alpha1
  kind: StarlarkRun
  metadata:
    name: httpbin-gen
-+  namespace: staging
 +  labels:
 +    tier: backend
  source: |

--- a/e2e/testdata/fn-render/resource-deletion/Kptfile
+++ b/e2e/testdata/fn-render/resource-deletion/Kptfile
@@ -6,9 +6,9 @@ pipeline:
   mutators:
     - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
       configPath: starlark-httpbin.yaml
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-basicpipeline/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-basicpipeline/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index 674ce18..e2f7a4d 100644
+index 3ef95be..9d77a98 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,18 +1,47 @@
+@@ -1,18 +1,68 @@
  apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
@@ -17,7 +17,7 @@ index 674ce18..e2f7a4d 100644
 -  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 -    configMap:
 -      namespace: staging
--  - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
+-  - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest
 -    configMap:
 -      app: myapp
 -  - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
@@ -26,7 +26,7 @@ index 674ce18..e2f7a4d 100644
 +    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +      configMap:
 +        namespace: staging
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest
 +      configMap:
 +        app: myapp
 +    - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
@@ -48,8 +48,29 @@ index 674ce18..e2f7a4d 100644
 +            severity: info
 +          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
 +            severity: info
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest
 +        exitCode: 0
++        results:
++          - message: 'set annotations: {"app":"myapp"}'
++            field:
++              path: metadata.annotations
++            file:
++              path: Kptfile
++          - message: 'set annotations: {"app":"myapp"}'
++            field:
++              path: metadata.annotations
++            file:
++              path: resources.yaml
++          - message: 'set annotations: {"app":"myapp"}'
++            field:
++              path: spec.template.metadata.annotations
++            file:
++              path: resources.yaml
++          - message: 'set annotations: {"app":"myapp"}'
++            field:
++              path: metadata.annotations
++            file:
++              path: starlark-fn-failure.yaml
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
 +        exitCode: 1

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-basicpipeline/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-basicpipeline/.expected/diff.patch
@@ -1,13 +1,12 @@
 diff --git a/Kptfile b/Kptfile
-index 8e0454e..f230a89 100644
+index 674ce18..e2f7a4d 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,18 +1,43 @@
+@@ -1,18 +1,47 @@
  apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
 +  name: save-on-render-failure
-+  namespace: staging
    annotations:
 +    app: myapp
      kpt.dev/bfs-rendering: "true"
@@ -15,7 +14,7 @@ index 8e0454e..f230a89 100644
 -  name: save-on-render-failure
  pipeline:
    mutators:
--  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+-  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 -    configMap:
 -      namespace: staging
 -  - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
@@ -24,7 +23,7 @@ index 8e0454e..f230a89 100644
 -  - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 -    configPath: starlark-fn-failure.yaml
 -
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +      configMap:
 +        namespace: staging
 +    - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
@@ -42,8 +41,13 @@ index 8e0454e..f230a89 100644
 +        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
 +      - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
 +        exitCode: 0
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
@@ -74,16 +78,15 @@ index 0848ba0..7eece9b 100644
 +      annotations:
 +        app: myapp
 diff --git a/starlark-fn-failure.yaml b/starlark-fn-failure.yaml
-index 55ceaae..d2841c7 100644
+index 55ceaae..85d3786 100644
 --- a/starlark-fn-failure.yaml
 +++ b/starlark-fn-failure.yaml
-@@ -2,6 +2,9 @@ apiVersion: fn.kpt.dev/v1alpha1
+@@ -2,6 +2,8 @@ apiVersion: fn.kpt.dev/v1alpha1
  kind: StarlarkRun
  metadata:
    name: always-fail
 +  annotations:
 +    app: myapp
-+  namespace: staging
  source: |
    def fail_fn(items):
      fail("intentional failure for testing")

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-basicpipeline/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-basicpipeline/Kptfile
@@ -7,7 +7,7 @@ metadata:
   name: save-on-render-failure
 pipeline:
   mutators:
-  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
     configMap:
       namespace: staging
   - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-basicpipeline/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-basicpipeline/Kptfile
@@ -10,7 +10,7 @@ pipeline:
   - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
     configMap:
       namespace: staging
-  - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
+  - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest
     configMap:
       app: myapp
   - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-deep-nested-middle-fails/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-deep-nested-middle-fails/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index dbd6541..ad87335 100644
+index 7d1bb00..365f002 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,14 +1,41 @@
+@@ -1,14 +1,47 @@
  apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
@@ -17,7 +17,7 @@ index dbd6541..ad87335 100644
    description: BFS - Deep nested, middle level fails
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
 -        level: "root"
 +        level: root
@@ -31,10 +31,16 @@ index dbd6541..ad87335 100644
 +        	pipeline.run: pkg ./level1: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: set 7 labels in total
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 5 labels in total
++            severity: info
 +    validationSteps:
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
@@ -59,7 +65,7 @@ index 59bb817..19a7ead 100644
  data:
    level: root
 diff --git a/level1/Kptfile b/level1/Kptfile
-index 2bc48be..ec5f5a7 100644
+index 1b41eb9..0a73b3c 100644
 --- a/level1/Kptfile
 +++ b/level1/Kptfile
 @@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
@@ -84,10 +90,10 @@ index 57d3b69..10a2e13 100644
  data:
    level: level1
 diff --git a/level1/level2/Kptfile b/level1/level2/Kptfile
-index 314d402..29e69db 100644
+index d3d138b..4e0d160 100644
 --- a/level1/level2/Kptfile
 +++ b/level1/level2/Kptfile
-@@ -2,10 +2,12 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: level2
@@ -96,11 +102,6 @@ index 314d402..29e69db 100644
  info:
    description: Level2 that succeeds
  pipeline:
-   mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
-       configMap:
--        level: "level2"
-+        level: level2
 diff --git a/level1/level2/configmap.yaml b/level1/level2/configmap.yaml
 index ab7d3fa..1eeeaed 100644
 --- a/level1/level2/configmap.yaml

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-deep-nested-middle-fails/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-deep-nested-middle-fails/Kptfile
@@ -9,6 +9,6 @@ info:
   description: BFS - Deep nested, middle level fails
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         level: "root"

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-deep-nested-middle-fails/level1/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-deep-nested-middle-fails/level1/Kptfile
@@ -6,7 +6,7 @@ info:
   description: Level1 with failing validator
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         level: level1
   validators:

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-deep-nested-middle-fails/level1/level2/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-deep-nested-middle-fails/level1/level2/Kptfile
@@ -6,6 +6,6 @@ info:
   description: Level2 that succeeds
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         level: "level2"

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-multiple-subpkgs-one-fails/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-multiple-subpkgs-one-fails/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/Kptfile b/Kptfile
-index e9fad85..b0d2fb6 100644
+index 05639fc..6a1a626 100644
 --- a/Kptfile
 +++ b/Kptfile
 @@ -1,10 +1,12 @@
@@ -16,8 +16,8 @@ index e9fad85..b0d2fb6 100644
  info:
    description: BFS - Multiple subpackages, sub2 fails
  pipeline:
-@@ -12,3 +14,30 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+@@ -12,3 +14,39 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          pkg: root
 +status:
@@ -30,12 +30,21 @@ index e9fad85..b0d2fb6 100644
 +        	pipeline.run: pkg ./sub2: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: set 13 labels in total
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: set 3 labels in total
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 4 labels in total
++            severity: info
 +    validationSteps:
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
@@ -63,7 +72,7 @@ index 9148b9b..2e551c8 100644
 +  selector:
 +    pkg: root
 diff --git a/sub1/Kptfile b/sub1/Kptfile
-index 2d62077..0f03268 100644
+index 28acfc9..a54a9d7 100644
 --- a/sub1/Kptfile
 +++ b/sub1/Kptfile
 @@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
@@ -74,12 +83,12 @@ index 2d62077..0f03268 100644
 +    pkg: sub1
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 diff --git a/sub1/deployment.yaml b/sub1/deployment.yaml
-index 2f649ba..c2245a9 100644
+index 2f649ba..a7eb295 100644
 --- a/sub1/deployment.yaml
 +++ b/sub1/deployment.yaml
-@@ -2,5 +2,14 @@ apiVersion: apps/v1
+@@ -2,5 +2,10 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: sub1-deployment
@@ -90,12 +99,8 @@ index 2f649ba..c2245a9 100644
 +  selector:
 +    matchLabels:
 +      pkg: sub1
-+  template:
-+    metadata:
-+      labels:
-+        pkg: sub1
 diff --git a/sub2/Kptfile b/sub2/Kptfile
-index 853d3f0..89cfa33 100644
+index fc295bc..4a009b4 100644
 --- a/sub2/Kptfile
 +++ b/sub2/Kptfile
 @@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
@@ -106,12 +111,12 @@ index 853d3f0..89cfa33 100644
 +    pkg: sub2
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 diff --git a/sub2/deployment.yaml b/sub2/deployment.yaml
-index 20375ea..7290360 100644
+index 20375ea..df23fde 100644
 --- a/sub2/deployment.yaml
 +++ b/sub2/deployment.yaml
-@@ -2,5 +2,14 @@ apiVersion: apps/v1
+@@ -2,5 +2,10 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: sub2-deployment
@@ -122,10 +127,6 @@ index 20375ea..7290360 100644
 +  selector:
 +    matchLabels:
 +      pkg: sub2
-+  template:
-+    metadata:
-+      labels:
-+        pkg: sub2
 diff --git a/sub2/starlark-fn-failure.yaml b/sub2/starlark-fn-failure.yaml
 index 55ceaae..5b9cf38 100644
 --- a/sub2/starlark-fn-failure.yaml
@@ -140,7 +141,7 @@ index 55ceaae..5b9cf38 100644
    def fail_fn(items):
      fail("intentional failure for testing")
 diff --git a/sub3/Kptfile b/sub3/Kptfile
-index ff35b98..958a351 100644
+index e5736ef..399199d 100644
 --- a/sub3/Kptfile
 +++ b/sub3/Kptfile
 @@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
@@ -151,12 +152,12 @@ index ff35b98..958a351 100644
 +    pkg: root
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 diff --git a/sub3/deployment.yaml b/sub3/deployment.yaml
-index dc257b3..3a13d11 100644
+index dc257b3..87649ef 100644
 --- a/sub3/deployment.yaml
 +++ b/sub3/deployment.yaml
-@@ -2,5 +2,14 @@ apiVersion: apps/v1
+@@ -2,5 +2,10 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: sub3-deployment
@@ -167,7 +168,3 @@ index dc257b3..3a13d11 100644
 +  selector:
 +    matchLabels:
 +      pkg: root
-+  template:
-+    metadata:
-+      labels:
-+        pkg: root

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-multiple-subpkgs-one-fails/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-multiple-subpkgs-one-fails/Kptfile
@@ -9,6 +9,6 @@ info:
   description: BFS - Multiple subpackages, sub2 fails
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         pkg: root

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-multiple-subpkgs-one-fails/sub1/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-multiple-subpkgs-one-fails/sub1/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: sub1
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         pkg: sub1

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-multiple-subpkgs-one-fails/sub2/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-multiple-subpkgs-one-fails/sub2/Kptfile
@@ -4,7 +4,7 @@ metadata:
   name: sub2
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         pkg: sub2
   validators:

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-multiple-subpkgs-one-fails/sub3/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-multiple-subpkgs-one-fails/sub3/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: sub3
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         pkg: sub3

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-and-subpkg-both-fail/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-and-subpkg-both-fail/.expected/diff.patch
@@ -1,12 +1,14 @@
 diff --git a/Kptfile b/Kptfile
-index 867a54b..6ccc3b8 100644
+index 05b0b75..c39c740 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,10 +1,10 @@
+@@ -1,10 +1,12 @@
  apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
 +  name: bfs-parent-and-subpkg-both-fail
++  labels:
++    pkg: root
    annotations:
      kpt.dev/bfs-rendering: "true"
      kpt.dev/save-on-render-failure: "true"
@@ -14,7 +16,7 @@ index 867a54b..6ccc3b8 100644
  info:
    description: BFS - Both parent and subpackage fail
  pipeline:
-@@ -15,3 +15,23 @@ pipeline:
+@@ -15,3 +17,29 @@ pipeline:
    validators:
      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
        configPath: starlark-fn-failure.yaml
@@ -28,13 +30,85 @@ index 867a54b..6ccc3b8 100644
 +        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
-+        stderr: '[error] : failed to run function: may not add resource with an already registered id: fn.kpt.dev_v1alpha1_StarlarkRun|~X|always-fail'
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
++        exitCode: 0
++        results:
++          - message: set 7 labels in total
++            severity: info
++    validationSteps:
++      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
++        stderr: 'failed to evaluate function: error: function failure'
 +        exitCode: 1
 +        results:
-+          - message: 'failed to run function: may not add resource with an already registered id: fn.kpt.dev_v1alpha1_StarlarkRun|~X|always-fail'
++          - message: 'fail: intentional failure for testing'
 +            severity: error
 +        errorResults:
-+          - message: 'failed to run function: may not add resource with an already registered id: fn.kpt.dev_v1alpha1_StarlarkRun|~X|always-fail'
++          - message: 'fail: intentional failure for testing'
 +            severity: error
-+    errorSummary: 'ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5: exit code 1'
++    errorSummary: 'ghcr.io/kptdev/krm-functions-catalog/starlark:latest: exit code 1'
+diff --git a/configmap.yaml b/configmap.yaml
+index 8594873..a591ceb 100644
+--- a/configmap.yaml
++++ b/configmap.yaml
+@@ -2,5 +2,7 @@ apiVersion: v1
+ kind: ConfigMap
+ metadata:
+   name: root-config
++  labels:
++    pkg: root
+ data:
+   pkg: root
+diff --git a/starlark-fn-failure.yaml b/starlark-fn-failure.yaml
+index 55ceaae..4d0a95c 100644
+--- a/starlark-fn-failure.yaml
++++ b/starlark-fn-failure.yaml
+@@ -2,6 +2,8 @@ apiVersion: fn.kpt.dev/v1alpha1
+ kind: StarlarkRun
+ metadata:
+   name: always-fail
++  labels:
++    pkg: root
+ source: |
+   def fail_fn(items):
+     fail("intentional failure for testing")
+diff --git a/subpkg/Kptfile b/subpkg/Kptfile
+index 4c71101..09b6550 100644
+--- a/subpkg/Kptfile
++++ b/subpkg/Kptfile
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
+ kind: Kptfile
+ metadata:
+   name: subpkg
++  labels:
++    pkg: root
+ info:
+   description: Subpackage that also fails
+ pipeline:
+diff --git a/subpkg/service.yaml b/subpkg/service.yaml
+index 276bf9e..d6424da 100644
+--- a/subpkg/service.yaml
++++ b/subpkg/service.yaml
+@@ -2,6 +2,10 @@ apiVersion: v1
+ kind: Service
+ metadata:
+   name: sub-service
++  labels:
++    pkg: root
+ spec:
+   ports:
+   - port: 80
++  selector:
++    pkg: root
+diff --git a/subpkg/starlark-fn-failure.yaml b/subpkg/starlark-fn-failure.yaml
+index 55ceaae..4d0a95c 100644
+--- a/subpkg/starlark-fn-failure.yaml
++++ b/subpkg/starlark-fn-failure.yaml
+@@ -2,6 +2,8 @@ apiVersion: fn.kpt.dev/v1alpha1
+ kind: StarlarkRun
+ metadata:
+   name: always-fail
++  labels:
++    pkg: root
+ source: |
+   def fail_fn(items):
+     fail("intentional failure for testing")

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-and-subpkg-both-fail/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-and-subpkg-both-fail/Kptfile
@@ -9,7 +9,7 @@ info:
   description: BFS - Both parent and subpackage fail
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         pkg: root
   validators:

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-and-subpkg-both-fail/subpkg/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-and-subpkg-both-fail/subpkg/Kptfile
@@ -6,7 +6,7 @@ info:
   description: Subpackage that also fails
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         pkg: subpkg
   validators:

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-mutator-fails/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-mutator-fails/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index 2c67980..0e92246 100644
+index daf587a..1e27ec7 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,16 +1,40 @@
+@@ -1,16 +1,43 @@
  apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
@@ -17,7 +17,7 @@ index 2c67980..0e92246 100644
    description: BFS - Parent mutator fails
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
 -        test: "parent-mutator-fail"
 +        test: parent-mutator-fail
@@ -33,8 +33,11 @@ index 2c67980..0e92246 100644
 +        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 6 labels in total
++            severity: info
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
 +        exitCode: 1
@@ -71,7 +74,7 @@ index 55ceaae..f589633 100644
    def fail_fn(items):
      fail("intentional failure for testing")
 diff --git a/subpkg/Kptfile b/subpkg/Kptfile
-index e940ae8..e6e678c 100644
+index fd277c8..ed7a995 100644
 --- a/subpkg/Kptfile
 +++ b/subpkg/Kptfile
 @@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-mutator-fails/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-mutator-fails/Kptfile
@@ -9,7 +9,7 @@ info:
   description: BFS - Parent mutator fails
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         test: "parent-mutator-fail"
     - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-mutator-fails/subpkg/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-mutator-fails/subpkg/Kptfile
@@ -6,6 +6,6 @@ info:
   description: Subpackage that succeeds
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: subpkg-ns

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-validator-fails/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-validator-fails/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index 17ef3d8..93810be 100644
+index ab26c4e..9d3cdaf 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,17 +1,42 @@
+@@ -1,17 +1,45 @@
  apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
@@ -17,7 +17,7 @@ index 17ef3d8..93810be 100644
    description: BFS - Parent validator fails
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
 -        test: "parent-fail"
 +        test: parent-fail
@@ -34,8 +34,11 @@ index 17ef3d8..93810be 100644
 +        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 6 labels in total
++            severity: info
 +    validationSteps:
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
@@ -73,7 +76,7 @@ index 55ceaae..eb4b975 100644
    def fail_fn(items):
      fail("intentional failure for testing")
 diff --git a/subpkg/Kptfile b/subpkg/Kptfile
-index e940ae8..88a8d4e 100644
+index fd277c8..ecbfb69 100644
 --- a/subpkg/Kptfile
 +++ b/subpkg/Kptfile
 @@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-validator-fails/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-validator-fails/Kptfile
@@ -9,7 +9,7 @@ info:
   description: BFS - Parent validator fails
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         test: "parent-fail"
   validators:

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-validator-fails/subpkg/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-parent-validator-fails/subpkg/Kptfile
@@ -6,6 +6,6 @@ info:
   description: Subpackage that succeeds
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: subpkg-ns

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-subpkg-mutator-fails/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-subpkg-mutator-fails/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index 84b93a6..f9f5122 100644
+index 9e3fa88..8523c39 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,14 +1,40 @@
+@@ -1,14 +1,48 @@
  apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
@@ -17,7 +17,7 @@ index 84b93a6..f9f5122 100644
    description: BFS - Subpackage mutator fails
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
 -        test: "mutator-fail"
 +        test: mutator-fail
@@ -31,10 +31,18 @@ index 84b93a6..f9f5122 100644
 +        	pipeline.run: pkg ./subpkg: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++        results:
++          - message: set 7 labels in total
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
++        results:
++          - message: namespace [default] updated to "subpkg-ns", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
 +        exitCode: 1
@@ -46,10 +54,10 @@ index 84b93a6..f9f5122 100644
 +            severity: error
 +    errorSummary: 'ghcr.io/kptdev/krm-functions-catalog/starlark:latest: exit code 1'
 diff --git a/deployment.yaml b/deployment.yaml
-index cc866f6..6ed4201 100644
+index cc866f6..694641e 100644
 --- a/deployment.yaml
 +++ b/deployment.yaml
-@@ -2,5 +2,14 @@ apiVersion: apps/v1
+@@ -2,5 +2,10 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: root-deployment
@@ -60,29 +68,24 @@ index cc866f6..6ed4201 100644
 +  selector:
 +    matchLabels:
 +      test: mutator-fail
-+  template:
-+    metadata:
-+      labels:
-+        test: mutator-fail
 diff --git a/subpkg/Kptfile b/subpkg/Kptfile
-index 7b4318a..5b35311 100644
+index 672ec0a..3385016 100644
 --- a/subpkg/Kptfile
 +++ b/subpkg/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: subpkg
 +  labels:
 +    test: mutator-fail
-+  namespace: subpkg-ns
  info:
    description: Subpackage with failing mutator
  pipeline:
 diff --git a/subpkg/deployment.yaml b/subpkg/deployment.yaml
-index 302322e..546fe5c 100644
+index 302322e..d964609 100644
 --- a/subpkg/deployment.yaml
 +++ b/subpkg/deployment.yaml
-@@ -2,5 +2,15 @@ apiVersion: apps/v1
+@@ -2,5 +2,11 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: sub-deployment
@@ -94,21 +97,16 @@ index 302322e..546fe5c 100644
 +  selector:
 +    matchLabels:
 +      test: mutator-fail
-+  template:
-+    metadata:
-+      labels:
-+        test: mutator-fail
 diff --git a/subpkg/starlark-fn-failure.yaml b/subpkg/starlark-fn-failure.yaml
-index 55ceaae..026f2e5 100644
+index 55ceaae..6e4dbaa 100644
 --- a/subpkg/starlark-fn-failure.yaml
 +++ b/subpkg/starlark-fn-failure.yaml
-@@ -2,6 +2,9 @@ apiVersion: fn.kpt.dev/v1alpha1
+@@ -2,6 +2,8 @@ apiVersion: fn.kpt.dev/v1alpha1
  kind: StarlarkRun
  metadata:
    name: always-fail
 +  labels:
 +    test: mutator-fail
-+  namespace: subpkg-ns
  source: |
    def fail_fn(items):
      fail("intentional failure for testing")

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-subpkg-mutator-fails/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-subpkg-mutator-fails/Kptfile
@@ -9,6 +9,6 @@ info:
   description: BFS - Subpackage mutator fails
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         test: "mutator-fail"

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-subpkg-mutator-fails/subpkg/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-subpkg-mutator-fails/subpkg/Kptfile
@@ -6,7 +6,7 @@ info:
   description: Subpackage with failing mutator
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: subpkg-ns
     - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-subpkg-validator-fails/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-subpkg-validator-fails/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index 86dbe13..755cbd3 100644
+index ba48e7c..487d026 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,15 +1,43 @@
+@@ -1,15 +1,51 @@
  apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
@@ -18,7 +18,7 @@ index 86dbe13..755cbd3 100644
    description: BFS - Subpackage validator fails
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
 -        test: "subpkg-fail"
 -        level: "root"
@@ -34,10 +34,18 @@ index 86dbe13..755cbd3 100644
 +        	pipeline.run: pkg ./subpkg: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++        results:
++          - message: set 14 labels in total
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
++        results:
++          - message: namespace [default] updated to "subpkg-ns", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
 +    validationSteps:
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
@@ -50,10 +58,10 @@ index 86dbe13..755cbd3 100644
 +            severity: error
 +    errorSummary: 'ghcr.io/kptdev/krm-functions-catalog/starlark:latest: exit code 1'
 diff --git a/deployment.yaml b/deployment.yaml
-index 7123634..4db6211 100644
+index 7123634..6d1e0fb 100644
 --- a/deployment.yaml
 +++ b/deployment.yaml
-@@ -3,5 +3,17 @@ kind: Deployment
+@@ -3,5 +3,12 @@ kind: Deployment
  metadata:
    name: root-deployment
    namespace: default
@@ -66,31 +74,25 @@ index 7123634..4db6211 100644
 +    matchLabels:
 +      level: root
 +      test: subpkg-fail
-+  template:
-+    metadata:
-+      labels:
-+        level: root
-+        test: subpkg-fail
 diff --git a/subpkg/Kptfile b/subpkg/Kptfile
-index 271c9a5..445ddf4 100644
+index cd67e16..2ba1858 100644
 --- a/subpkg/Kptfile
 +++ b/subpkg/Kptfile
-@@ -2,6 +2,10 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: subpkg
 +  labels:
 +    level: root
 +    test: subpkg-fail
-+  namespace: subpkg-ns
  info:
    description: Subpackage with failing validator
  pipeline:
 diff --git a/subpkg/deployment.yaml b/subpkg/deployment.yaml
-index 302322e..dfe3056 100644
+index 302322e..0645d38 100644
 --- a/subpkg/deployment.yaml
 +++ b/subpkg/deployment.yaml
-@@ -2,5 +2,18 @@ apiVersion: apps/v1
+@@ -2,5 +2,13 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: sub-deployment
@@ -104,23 +106,17 @@ index 302322e..dfe3056 100644
 +    matchLabels:
 +      level: root
 +      test: subpkg-fail
-+  template:
-+    metadata:
-+      labels:
-+        level: root
-+        test: subpkg-fail
 diff --git a/subpkg/starlark-fn-failure.yaml b/subpkg/starlark-fn-failure.yaml
-index 55ceaae..4d01f35 100644
+index 55ceaae..50f0edf 100644
 --- a/subpkg/starlark-fn-failure.yaml
 +++ b/subpkg/starlark-fn-failure.yaml
-@@ -2,6 +2,10 @@ apiVersion: fn.kpt.dev/v1alpha1
+@@ -2,6 +2,9 @@ apiVersion: fn.kpt.dev/v1alpha1
  kind: StarlarkRun
  metadata:
    name: always-fail
 +  labels:
 +    level: root
 +    test: subpkg-fail
-+  namespace: subpkg-ns
  source: |
    def fail_fn(items):
      fail("intentional failure for testing")

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-subpkg-validator-fails/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-subpkg-validator-fails/Kptfile
@@ -9,7 +9,7 @@ info:
   description: BFS - Subpackage validator fails
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         test: "subpkg-fail"
         level: "root"

--- a/e2e/testdata/fn-render/save-on-render-failure/bfs-subpkg-validator-fails/subpkg/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/bfs-subpkg-validator-fails/subpkg/Kptfile
@@ -6,7 +6,7 @@ info:
   description: Subpackage with failing validator
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: subpkg-ns
   validators:

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-basicpipeline/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-basicpipeline/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index a41ae45..cd29499 100644
+index b705bdb..15a1b9e 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,16 +1,46 @@
+@@ -1,16 +1,67 @@
  apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
@@ -16,7 +16,7 @@ index a41ae45..cd29499 100644
 -  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 -    configMap:
 -      namespace: staging
--  - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
+-  - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest
 -    configMap:
 -      app: myapp
 -  - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
@@ -24,7 +24,7 @@ index a41ae45..cd29499 100644
 +    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +      configMap:
 +        namespace: staging
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest
 +      configMap:
 +        app: myapp
 +    - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
@@ -46,8 +46,29 @@ index a41ae45..cd29499 100644
 +            severity: info
 +          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
 +            severity: info
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest
 +        exitCode: 0
++        results:
++          - message: 'set annotations: {"app":"myapp"}'
++            field:
++              path: metadata.annotations
++            file:
++              path: Kptfile
++          - message: 'set annotations: {"app":"myapp"}'
++            field:
++              path: metadata.annotations
++            file:
++              path: resources.yaml
++          - message: 'set annotations: {"app":"myapp"}'
++            field:
++              path: spec.template.metadata.annotations
++            file:
++              path: resources.yaml
++          - message: 'set annotations: {"app":"myapp"}'
++            field:
++              path: metadata.annotations
++            file:
++              path: starlark-fn-failure.yaml
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
 +        exitCode: 1

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-basicpipeline/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-basicpipeline/.expected/diff.patch
@@ -1,20 +1,19 @@
 diff --git a/Kptfile b/Kptfile
-index ed88ddf..a1d57f0 100644
+index a41ae45..cd29499 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,16 +1,42 @@
+@@ -1,16 +1,46 @@
  apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
 +  name: save-on-render-failure
-+  namespace: staging
    annotations:
 +    app: myapp
      kpt.dev/save-on-render-failure: "true"
 -  name: save-on-render-failure
  pipeline:
    mutators:
--  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+-  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 -    configMap:
 -      namespace: staging
 -  - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
@@ -22,7 +21,7 @@ index ed88ddf..a1d57f0 100644
 -      app: myapp
 -  - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 -    configPath: starlark-fn-failure.yaml
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +      configMap:
 +        namespace: staging
 +    - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
@@ -40,8 +39,13 @@ index ed88ddf..a1d57f0 100644
 +        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
 +      - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
 +        exitCode: 0
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
@@ -72,16 +76,15 @@ index 0848ba0..7eece9b 100644
 +      annotations:
 +        app: myapp
 diff --git a/starlark-fn-failure.yaml b/starlark-fn-failure.yaml
-index 55ceaae..d2841c7 100644
+index 55ceaae..85d3786 100644
 --- a/starlark-fn-failure.yaml
 +++ b/starlark-fn-failure.yaml
-@@ -2,6 +2,9 @@ apiVersion: fn.kpt.dev/v1alpha1
+@@ -2,6 +2,8 @@ apiVersion: fn.kpt.dev/v1alpha1
  kind: StarlarkRun
  metadata:
    name: always-fail
 +  annotations:
 +    app: myapp
-+  namespace: staging
  source: |
    def fail_fn(items):
      fail("intentional failure for testing")

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-basicpipeline/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-basicpipeline/Kptfile
@@ -6,7 +6,7 @@ metadata:
   name: save-on-render-failure
 pipeline:
   mutators:
-  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
     configMap:
       namespace: staging
   - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-basicpipeline/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-basicpipeline/Kptfile
@@ -9,7 +9,7 @@ pipeline:
   - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
     configMap:
       namespace: staging
-  - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
+  - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest
     configMap:
       app: myapp
   - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-deep-nested-middle-fails/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-deep-nested-middle-fails/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index 4047d27..02908a2 100644
+index 7f1c8b4..255b9e1 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,13 +1,38 @@
+@@ -1,13 +1,44 @@
  apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
@@ -14,7 +14,7 @@ index 4047d27..02908a2 100644
    description: DFS - Deep nested, middle level fails
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
 -        level: "root"
 +        level: root
@@ -28,10 +28,16 @@ index 4047d27..02908a2 100644
 +        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: set 2 labels in total
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 5 labels in total
++            severity: info
 +    validationSteps:
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
@@ -44,7 +50,7 @@ index 4047d27..02908a2 100644
 +            severity: error
 +    errorSummary: 'ghcr.io/kptdev/krm-functions-catalog/starlark:latest: exit code 1'
 diff --git a/level1/Kptfile b/level1/Kptfile
-index 2bc48be..ec5f5a7 100644
+index 1b41eb9..0a73b3c 100644
 --- a/level1/Kptfile
 +++ b/level1/Kptfile
 @@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
@@ -69,10 +75,10 @@ index 57d3b69..10a2e13 100644
  data:
    level: level1
 diff --git a/level1/level2/Kptfile b/level1/level2/Kptfile
-index 314d402..29e69db 100644
+index d3d138b..4e0d160 100644
 --- a/level1/level2/Kptfile
 +++ b/level1/level2/Kptfile
-@@ -2,10 +2,12 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: level2
@@ -81,11 +87,6 @@ index 314d402..29e69db 100644
  info:
    description: Level2 that succeeds
  pipeline:
-   mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
-       configMap:
--        level: "level2"
-+        level: level2
 diff --git a/level1/level2/configmap.yaml b/level1/level2/configmap.yaml
 index ab7d3fa..1eeeaed 100644
 --- a/level1/level2/configmap.yaml

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-deep-nested-middle-fails/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-deep-nested-middle-fails/Kptfile
@@ -8,6 +8,6 @@ info:
   description: DFS - Deep nested, middle level fails
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         level: "root"

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-deep-nested-middle-fails/level1/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-deep-nested-middle-fails/level1/Kptfile
@@ -6,7 +6,7 @@ info:
   description: Level1 with failing validator
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         level: level1
   validators:

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-deep-nested-middle-fails/level1/level2/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-deep-nested-middle-fails/level1/level2/Kptfile
@@ -6,6 +6,6 @@ info:
   description: Level2 that succeeds
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         level: "level2"

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-multiple-subpkgs-one-fails/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-multiple-subpkgs-one-fails/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/Kptfile b/Kptfile
-index c47c90d..0ad6086 100644
+index 3410f0a..94e41fa 100644
 --- a/Kptfile
 +++ b/Kptfile
 @@ -1,9 +1,9 @@
@@ -13,8 +13,8 @@ index c47c90d..0ad6086 100644
  info:
    description: DFS - Multiple subpackages, sub2 fails
  pipeline:
-@@ -11,3 +11,28 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+@@ -11,3 +11,34 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          pkg: root
 +status:
@@ -27,10 +27,16 @@ index c47c90d..0ad6086 100644
 +        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: set 3 labels in total
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 4 labels in total
++            severity: info
 +    validationSteps:
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
@@ -43,7 +49,7 @@ index c47c90d..0ad6086 100644
 +            severity: error
 +    errorSummary: 'ghcr.io/kptdev/krm-functions-catalog/starlark:latest: exit code 1'
 diff --git a/sub1/Kptfile b/sub1/Kptfile
-index 2d62077..0f03268 100644
+index 28acfc9..a54a9d7 100644
 --- a/sub1/Kptfile
 +++ b/sub1/Kptfile
 @@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
@@ -54,12 +60,12 @@ index 2d62077..0f03268 100644
 +    pkg: sub1
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 diff --git a/sub1/deployment.yaml b/sub1/deployment.yaml
-index 2f649ba..c2245a9 100644
+index 2f649ba..a7eb295 100644
 --- a/sub1/deployment.yaml
 +++ b/sub1/deployment.yaml
-@@ -2,5 +2,14 @@ apiVersion: apps/v1
+@@ -2,5 +2,10 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: sub1-deployment
@@ -70,12 +76,8 @@ index 2f649ba..c2245a9 100644
 +  selector:
 +    matchLabels:
 +      pkg: sub1
-+  template:
-+    metadata:
-+      labels:
-+        pkg: sub1
 diff --git a/sub2/Kptfile b/sub2/Kptfile
-index 853d3f0..89cfa33 100644
+index fc295bc..4a009b4 100644
 --- a/sub2/Kptfile
 +++ b/sub2/Kptfile
 @@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
@@ -86,12 +88,12 @@ index 853d3f0..89cfa33 100644
 +    pkg: sub2
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 diff --git a/sub2/deployment.yaml b/sub2/deployment.yaml
-index 20375ea..7290360 100644
+index 20375ea..df23fde 100644
 --- a/sub2/deployment.yaml
 +++ b/sub2/deployment.yaml
-@@ -2,5 +2,14 @@ apiVersion: apps/v1
+@@ -2,5 +2,10 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: sub2-deployment
@@ -102,10 +104,6 @@ index 20375ea..7290360 100644
 +  selector:
 +    matchLabels:
 +      pkg: sub2
-+  template:
-+    metadata:
-+      labels:
-+        pkg: sub2
 diff --git a/sub2/starlark-fn-failure.yaml b/sub2/starlark-fn-failure.yaml
 index 55ceaae..5b9cf38 100644
 --- a/sub2/starlark-fn-failure.yaml

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-multiple-subpkgs-one-fails/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-multiple-subpkgs-one-fails/Kptfile
@@ -8,6 +8,6 @@ info:
   description: DFS - Multiple subpackages, sub2 fails
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         pkg: root

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-multiple-subpkgs-one-fails/sub1/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-multiple-subpkgs-one-fails/sub1/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: sub1
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         pkg: sub1

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-multiple-subpkgs-one-fails/sub2/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-multiple-subpkgs-one-fails/sub2/Kptfile
@@ -4,7 +4,7 @@ metadata:
   name: sub2
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         pkg: sub2
   validators:

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-multiple-subpkgs-one-fails/sub3/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-multiple-subpkgs-one-fails/sub3/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: sub3
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         pkg: sub3

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-and-subpkg-both-fail/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-and-subpkg-both-fail/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/Kptfile b/Kptfile
-index 2e71448..1a82d1e 100644
+index 31eb203..499fd22 100644
 --- a/Kptfile
 +++ b/Kptfile
 @@ -1,9 +1,9 @@
@@ -13,7 +13,7 @@ index 2e71448..1a82d1e 100644
  info:
    description: DFS - Both parent and subpackage fail
  pipeline:
-@@ -14,3 +14,26 @@ pipeline:
+@@ -14,3 +14,29 @@ pipeline:
    validators:
      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
        configPath: starlark-fn-failure.yaml
@@ -27,8 +27,11 @@ index 2e71448..1a82d1e 100644
 +        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 4 labels in total
++            severity: info
 +    validationSteps:
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
@@ -41,7 +44,7 @@ index 2e71448..1a82d1e 100644
 +            severity: error
 +    errorSummary: 'ghcr.io/kptdev/krm-functions-catalog/starlark:latest: exit code 1'
 diff --git a/subpkg/Kptfile b/subpkg/Kptfile
-index 492902c..3cb271d 100644
+index 4c71101..18abcc9 100644
 --- a/subpkg/Kptfile
 +++ b/subpkg/Kptfile
 @@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-and-subpkg-both-fail/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-and-subpkg-both-fail/Kptfile
@@ -8,7 +8,7 @@ info:
   description: DFS - Both parent and subpackage fail
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         pkg: root
   validators:

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-and-subpkg-both-fail/subpkg/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-and-subpkg-both-fail/subpkg/Kptfile
@@ -6,7 +6,7 @@ info:
   description: Subpackage that also fails
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         pkg: subpkg
   validators:

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-mutator-fails/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-mutator-fails/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index 207a7ca..c351a54 100644
+index aa1ee97..1777945 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,15 +1,41 @@
+@@ -1,15 +1,49 @@
  apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
@@ -16,7 +16,7 @@ index 207a7ca..c351a54 100644
    description: DFS - Parent mutator fails
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
 -        test: "parent-mutator-fail"
 +        test: parent-mutator-fail
@@ -32,10 +32,18 @@ index 207a7ca..c351a54 100644
 +        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "subpkg-ns", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 6 labels in total
++            severity: info
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
 +        exitCode: 1
@@ -72,14 +80,13 @@ index 55ceaae..f589633 100644
    def fail_fn(items):
      fail("intentional failure for testing")
 diff --git a/subpkg/Kptfile b/subpkg/Kptfile
-index e940ae8..9b73f07 100644
+index fd277c8..ed7a995 100644
 --- a/subpkg/Kptfile
 +++ b/subpkg/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: subpkg
-+  namespace: subpkg-ns
 +  labels:
 +    test: parent-mutator-fail
  info:

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-mutator-fails/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-mutator-fails/Kptfile
@@ -8,7 +8,7 @@ info:
   description: DFS - Parent mutator fails
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         test: "parent-mutator-fail"
     - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-mutator-fails/subpkg/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-mutator-fails/subpkg/Kptfile
@@ -6,6 +6,6 @@ info:
   description: Subpackage that succeeds
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: subpkg-ns

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-validator-fails/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-validator-fails/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index b402aed..04ef8db 100644
+index f9bc7a2..9a991aa 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,16 +1,43 @@
+@@ -1,16 +1,51 @@
  apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
@@ -16,7 +16,7 @@ index b402aed..04ef8db 100644
    description: DFS - Parent validator fails
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
 -        test: "parent-fail"
 +        test: parent-fail
@@ -33,10 +33,18 @@ index b402aed..04ef8db 100644
 +        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "subpkg-ns", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 6 labels in total
++            severity: info
 +    validationSteps:
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
@@ -74,14 +82,13 @@ index 55ceaae..eb4b975 100644
    def fail_fn(items):
      fail("intentional failure for testing")
 diff --git a/subpkg/Kptfile b/subpkg/Kptfile
-index e940ae8..a2fe9c5 100644
+index fd277c8..ecbfb69 100644
 --- a/subpkg/Kptfile
 +++ b/subpkg/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: subpkg
-+  namespace: subpkg-ns
 +  labels:
 +    test: parent-fail
  info:

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-validator-fails/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-validator-fails/Kptfile
@@ -8,7 +8,7 @@ info:
   description: DFS - Parent validator fails
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         test: "parent-fail"
   validators:

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-validator-fails/subpkg/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-parent-validator-fails/subpkg/Kptfile
@@ -6,6 +6,6 @@ info:
   description: Subpackage that succeeds
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: subpkg-ns

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-subpkg-mutator-fails/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-subpkg-mutator-fails/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index 80aa788..77f5c7b 100644
+index d6232cb..aa17c17 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,13 +1,35 @@
+@@ -1,13 +1,40 @@
  apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
@@ -14,7 +14,7 @@ index 80aa788..77f5c7b 100644
    description: DFS - Subpackage mutator fails
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
 -        test: "mutator-fail"
 +        test: mutator-fail
@@ -28,8 +28,13 @@ index 80aa788..77f5c7b 100644
 +        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
++        results:
++          - message: namespace [default] updated to "subpkg-ns", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
 +        exitCode: 1
@@ -40,18 +45,6 @@ index 80aa788..77f5c7b 100644
 +          - message: 'fail: intentional failure for testing'
 +            severity: error
 +    errorSummary: 'ghcr.io/kptdev/krm-functions-catalog/starlark:latest: exit code 1'
-diff --git a/subpkg/Kptfile b/subpkg/Kptfile
-index 7b4318a..2c39656 100644
---- a/subpkg/Kptfile
-+++ b/subpkg/Kptfile
-@@ -2,6 +2,7 @@ apiVersion: kpt.dev/v1
- kind: Kptfile
- metadata:
-   name: subpkg
-+  namespace: subpkg-ns
- info:
-   description: Subpackage with failing mutator
- pipeline:
 diff --git a/subpkg/deployment.yaml b/subpkg/deployment.yaml
 index 302322e..98ff830 100644
 --- a/subpkg/deployment.yaml
@@ -63,15 +56,3 @@ index 302322e..98ff830 100644
 +  namespace: subpkg-ns
  spec:
    replicas: 2
-diff --git a/subpkg/starlark-fn-failure.yaml b/subpkg/starlark-fn-failure.yaml
-index 55ceaae..3a4003f 100644
---- a/subpkg/starlark-fn-failure.yaml
-+++ b/subpkg/starlark-fn-failure.yaml
-@@ -2,6 +2,7 @@ apiVersion: fn.kpt.dev/v1alpha1
- kind: StarlarkRun
- metadata:
-   name: always-fail
-+  namespace: subpkg-ns
- source: |
-   def fail_fn(items):
-     fail("intentional failure for testing")

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-subpkg-mutator-fails/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-subpkg-mutator-fails/Kptfile
@@ -8,6 +8,6 @@ info:
   description: DFS - Subpackage mutator fails
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         test: "mutator-fail"

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-subpkg-mutator-fails/subpkg/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-subpkg-mutator-fails/subpkg/Kptfile
@@ -6,7 +6,7 @@ info:
   description: Subpackage with failing mutator
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: subpkg-ns
     - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-subpkg-validator-fails/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-subpkg-validator-fails/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index 7c3b09a..2b496da 100644
+index 8795678..85b77a9 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -1,14 +1,37 @@
+@@ -1,14 +1,42 @@
  apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
@@ -14,7 +14,7 @@ index 7c3b09a..2b496da 100644
    description: DFS - Subpackage validator fails
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
 -        test: "subpkg-fail"
 -        level: "root"
@@ -30,8 +30,13 @@ index 7c3b09a..2b496da 100644
 +        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
++        results:
++          - message: namespace [default] updated to "subpkg-ns", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
 +    validationSteps:
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
@@ -43,18 +48,6 @@ index 7c3b09a..2b496da 100644
 +          - message: 'fail: intentional failure for testing'
 +            severity: error
 +    errorSummary: 'ghcr.io/kptdev/krm-functions-catalog/starlark:latest: exit code 1'
-diff --git a/subpkg/Kptfile b/subpkg/Kptfile
-index 271c9a5..cbd2fa4 100644
---- a/subpkg/Kptfile
-+++ b/subpkg/Kptfile
-@@ -2,6 +2,7 @@ apiVersion: kpt.dev/v1
- kind: Kptfile
- metadata:
-   name: subpkg
-+  namespace: subpkg-ns
- info:
-   description: Subpackage with failing validator
- pipeline:
 diff --git a/subpkg/deployment.yaml b/subpkg/deployment.yaml
 index 302322e..98ff830 100644
 --- a/subpkg/deployment.yaml
@@ -66,15 +59,3 @@ index 302322e..98ff830 100644
 +  namespace: subpkg-ns
  spec:
    replicas: 2
-diff --git a/subpkg/starlark-fn-failure.yaml b/subpkg/starlark-fn-failure.yaml
-index 55ceaae..3a4003f 100644
---- a/subpkg/starlark-fn-failure.yaml
-+++ b/subpkg/starlark-fn-failure.yaml
-@@ -2,6 +2,7 @@ apiVersion: fn.kpt.dev/v1alpha1
- kind: StarlarkRun
- metadata:
-   name: always-fail
-+  namespace: subpkg-ns
- source: |
-   def fail_fn(items):
-     fail("intentional failure for testing")

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-subpkg-validator-fails/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-subpkg-validator-fails/Kptfile
@@ -8,7 +8,7 @@ info:
   description: DFS - Subpackage validator fails
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         test: "subpkg-fail"
         level: "root"

--- a/e2e/testdata/fn-render/save-on-render-failure/dfs-subpkg-validator-fails/subpkg/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/dfs-subpkg-validator-fails/subpkg/Kptfile
@@ -6,7 +6,7 @@ info:
   description: Subpackage with failing validator
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: subpkg-ns
   validators:

--- a/e2e/testdata/fn-render/save-on-render-failure/no-save-on-render-failure/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/no-save-on-render-failure/.expected/diff.patch
@@ -1,15 +1,15 @@
 diff --git a/Kptfile b/Kptfile
-index 377ab52..4155d35 100644
+index 1667ca3..1fec05d 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -4,11 +4,40 @@ metadata:
+@@ -4,11 +4,61 @@ metadata:
    name: no-save-on-render-failure
  pipeline:
    mutators:
 -  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 -    configMap:
 -      namespace: staging
--  - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
+-  - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest
 -    configMap:
 -      app: myapp
 -  - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
@@ -17,7 +17,7 @@ index 377ab52..4155d35 100644
 +    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +      configMap:
 +        namespace: staging
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest
 +      configMap:
 +        app: myapp
 +    - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
@@ -39,8 +39,29 @@ index 377ab52..4155d35 100644
 +            severity: info
 +          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
 +            severity: info
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest
 +        exitCode: 0
++        results:
++          - message: 'set annotations: {"app":"myapp"}'
++            field:
++              path: metadata.annotations
++            file:
++              path: Kptfile
++          - message: 'set annotations: {"app":"myapp"}'
++            field:
++              path: metadata.annotations
++            file:
++              path: resources.yaml
++          - message: 'set annotations: {"app":"myapp"}'
++            field:
++              path: spec.template.metadata.annotations
++            file:
++              path: resources.yaml
++          - message: 'set annotations: {"app":"myapp"}'
++            field:
++              path: metadata.annotations
++            file:
++              path: starlark-fn-failure.yaml
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        stderr: 'failed to evaluate function: error: function failure'
 +        exitCode: 1

--- a/e2e/testdata/fn-render/save-on-render-failure/no-save-on-render-failure/.expected/diff.patch
+++ b/e2e/testdata/fn-render/save-on-render-failure/no-save-on-render-failure/.expected/diff.patch
@@ -1,12 +1,12 @@
 diff --git a/Kptfile b/Kptfile
-index 8a2f9e1..49b7fb6 100644
+index 377ab52..4155d35 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -4,11 +4,35 @@ metadata:
+@@ -4,11 +4,40 @@ metadata:
    name: no-save-on-render-failure
  pipeline:
    mutators:
--  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+-  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 -    configMap:
 -      namespace: staging
 -  - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
@@ -14,7 +14,7 @@ index 8a2f9e1..49b7fb6 100644
 -      app: myapp
 -  - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 -    configPath: starlark-fn-failure.yaml
-+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +      configMap:
 +        namespace: staging
 +    - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
@@ -32,8 +32,13 @@ index 8a2f9e1..49b7fb6 100644
 +        	pipeline.run: already handled error
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
 +      - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
 +        exitCode: 0
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest

--- a/e2e/testdata/fn-render/save-on-render-failure/no-save-on-render-failure/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/no-save-on-render-failure/Kptfile
@@ -4,7 +4,7 @@ metadata:
   name: no-save-on-render-failure
 pipeline:
   mutators:
-  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
     configMap:
       namespace: staging
   - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4

--- a/e2e/testdata/fn-render/save-on-render-failure/no-save-on-render-failure/Kptfile
+++ b/e2e/testdata/fn-render/save-on-render-failure/no-save-on-render-failure/Kptfile
@@ -7,7 +7,7 @@ pipeline:
   - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
     configMap:
       namespace: staging
-  - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:v0.1.4
+  - image: ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest
     configMap:
       app: myapp
   - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest

--- a/e2e/testdata/fn-render/selectors/basicpipeline/.expected/config.yaml
+++ b/e2e/testdata/fn-render/selectors/basicpipeline/.expected/config.yaml
@@ -21,9 +21,11 @@ stdErrStripLines:
 
 stdErr: |
   Package: "basicpipeline"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" on 1 resource(s)
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
+  [Results]: [info]: set 4 labels in total
   Successfully executed 2 function(s) in 1 package(s).
 

--- a/e2e/testdata/fn-render/selectors/basicpipeline/.expected/diff.patch
+++ b/e2e/testdata/fn-render/selectors/basicpipeline/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index abc7b97..251ecc4 100644
+index 134a316..8eda99c 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,14 +2,27 @@ apiVersion: kpt.dev/v1
+@@ -2,14 +2,35 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
@@ -10,7 +10,7 @@ index abc7b97..251ecc4 100644
 +    tier: backend
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
        configMap:
          namespace: staging
        selectors:
@@ -18,7 +18,7 @@ index abc7b97..251ecc4 100644
 -          kind: Deployment
 +        - kind: Deployment
 +          name: nginx-deployment
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: backend
 +status:
@@ -28,15 +28,23 @@ index abc7b97..251ecc4 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 4 labels in total
++            severity: info
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..6b5d443 100644
+index f2eec52..12338f5 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,24 @@ apiVersion: apps/v1
+@@ -15,12 +15,20 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -48,10 +56,6 @@ index f2eec52..6b5d443 100644
 +  selector:
 +    matchLabels:
 +      tier: backend
-+  template:
-+    metadata:
-+      labels:
-+        tier: backend
  ---
  apiVersion: custom.io/v1
  kind: Custom

--- a/e2e/testdata/fn-render/selectors/basicpipeline/Kptfile
+++ b/e2e/testdata/fn-render/selectors/basicpipeline/Kptfile
@@ -4,12 +4,12 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
       selectors:
         - name: nginx-deployment
           kind: Deployment
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/selectors/exclude/.expected/config.yaml
+++ b/e2e/testdata/fn-render/selectors/exclude/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,8 +21,10 @@ stdErrStripLines:
 
 stdErr: |
   Package: "exclude"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" on 1 resource(s)
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5" on 2 resource(s)
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on 2 resource(s)
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
+  [Results]: [info]: set 3 labels in total
   Successfully executed 2 function(s) in 1 package(s).

--- a/e2e/testdata/fn-render/selectors/exclude/.expected/config.yaml
+++ b/e2e/testdata/fn-render/selectors/exclude/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-render/selectors/exclude/.expected/diff.patch
+++ b/e2e/testdata/fn-render/selectors/exclude/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index 266b33a..4be3f73 100644
+index 2ccf013..18a1b9e 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -8,10 +8,21 @@ pipeline:
+@@ -8,10 +8,29 @@ pipeline:
        configMap:
          namespace: staging
        selectors:
@@ -10,7 +10,7 @@ index 266b33a..4be3f73 100644
 -          kind: Deployment
 +        - kind: Deployment
 +          name: nginx-deployment
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: backend
        exclude:
@@ -22,15 +22,23 @@ index 266b33a..4be3f73 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 3 labels in total
++            severity: info
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..6b5d443 100644
+index f2eec52..12338f5 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,24 @@ apiVersion: apps/v1
+@@ -15,12 +15,20 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -42,10 +50,6 @@ index f2eec52..6b5d443 100644
 +  selector:
 +    matchLabels:
 +      tier: backend
-+  template:
-+    metadata:
-+      labels:
-+        tier: backend
  ---
  apiVersion: custom.io/v1
  kind: Custom

--- a/e2e/testdata/fn-render/selectors/exclude/Kptfile
+++ b/e2e/testdata/fn-render/selectors/exclude/Kptfile
@@ -4,13 +4,13 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
       selectors:
         - name: nginx-deployment
           kind: Deployment
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend
       exclude:

--- a/e2e/testdata/fn-render/selectors/generator/.expected/config.yaml
+++ b/e2e/testdata/fn-render/selectors/generator/.expected/config.yaml
@@ -23,13 +23,17 @@ stdErr: |
   Package: "generator/db"
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/starlark:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/starlark:latest" in 0s
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" on 1 resource(s)
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5" on 1 resource(s)
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "db", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on 1 resource(s)
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
+  [Results]: [info]: set 3 labels in total
   Package: "generator"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" on 1 resource(s)
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5" on 1 resource(s)
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [db] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on 1 resource(s)
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
+  [Results]: [info]: set 3 labels in total
   Successfully executed 5 function(s) in 2 package(s).

--- a/e2e/testdata/fn-render/selectors/generator/.expected/diff.patch
+++ b/e2e/testdata/fn-render/selectors/generator/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index eb2f084..10441e5 100644
+index 1029c28..df2f733 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -14,3 +14,20 @@ pipeline:
+@@ -14,3 +14,36 @@ pipeline:
          tier: db
        selectors:
          - name: httpbin
@@ -15,14 +15,30 @@ index eb2f084..10441e5 100644
 +    mutationSteps:
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "db", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++        results:
++          - message: set 3 labels in total
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [db] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 3 labels in total
++            severity: info
 diff --git a/db/deployment_httpbin.yaml b/db/deployment_httpbin.yaml
 new file mode 100644
 index 0000000..ffdf484

--- a/e2e/testdata/fn-render/selectors/generator/Kptfile
+++ b/e2e/testdata/fn-render/selectors/generator/Kptfile
@@ -4,12 +4,12 @@ metadata:
   name: app-with-generator
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
       selectors:
         - name: httpbin
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: db
       selectors:

--- a/e2e/testdata/fn-render/selectors/generator/db/Kptfile
+++ b/e2e/testdata/fn-render/selectors/generator/db/Kptfile
@@ -6,12 +6,12 @@ pipeline:
   mutators:
     - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
       configPath: starlark-httpbin.yaml
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: db
       selectors:
         - name: httpbin
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         app: backend
       selectors:

--- a/e2e/testdata/fn-render/selectors/selectors-with-exclude/.expected/config.yaml
+++ b/e2e/testdata/fn-render/selectors/selectors-with-exclude/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-render/selectors/selectors-with-exclude/.expected/config.yaml
+++ b/e2e/testdata/fn-render/selectors/selectors-with-exclude/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,8 +21,10 @@ stdErrStripLines:
 
 stdErr: |
   Package: "selectors-with-exclude"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" on 1 resource(s)
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5" in 0s
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
+  [Results]: [info]: set 4 labels in total
   Successfully executed 2 function(s) in 1 package(s).

--- a/e2e/testdata/fn-render/selectors/selectors-with-exclude/.expected/diff.patch
+++ b/e2e/testdata/fn-render/selectors/selectors-with-exclude/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/Kptfile b/Kptfile
-index c16cdca..1fd5efb 100644
+index 30183f6..431362d 100644
 --- a/Kptfile
 +++ b/Kptfile
 @@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
@@ -10,9 +10,9 @@ index c16cdca..1fd5efb 100644
 +    tier: backend
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-@@ -15,3 +17,14 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+@@ -15,3 +17,22 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: backend
 +status:
@@ -22,15 +22,23 @@ index c16cdca..1fd5efb 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 4 labels in total
++            severity: info
 diff --git a/resources.yaml b/resources.yaml
-index d3ed04c..f66e542 100644
+index d3ed04c..27056e8 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -17,8 +17,17 @@ metadata:
+@@ -17,8 +17,13 @@ metadata:
    name: nginx-deployment
    labels:
      foo: bar
@@ -41,14 +49,10 @@ index d3ed04c..f66e542 100644
 +  selector:
 +    matchLabels:
 +      tier: backend
-+  template:
-+    metadata:
-+      labels:
-+        tier: backend
  ---
  apiVersion: custom.io/v1
  kind: Custom
-@@ -26,5 +35,6 @@ metadata:
+@@ -26,5 +31,6 @@ metadata:
    name: custom
    labels:
      foo: bar

--- a/e2e/testdata/fn-render/selectors/selectors-with-exclude/Kptfile
+++ b/e2e/testdata/fn-render/selectors/selectors-with-exclude/Kptfile
@@ -4,7 +4,7 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
       selectors:
@@ -12,6 +12,6 @@ pipeline:
             foo: bar
       exclude:
         - kind: Custom
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/short-image-path/.expected/config.yaml
+++ b/e2e/testdata/fn-render/short-image-path/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021-2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,10 +16,15 @@ actualStripLines:
   - "    stderr: 'WARNING: The requested image''s platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested'"
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0" in 0s
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5"
-  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5" in 0s
+  Package: "short-image-path"
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+  [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
+  [Results]: [info]: set 4 labels in total
+  Successfully executed 2 function(s) in 1 package(s).
+  For complete results, see results/results.yaml
 
 stdErrStripLines:
   - "  Stderr:"

--- a/e2e/testdata/fn-render/short-image-path/.expected/config.yaml
+++ b/e2e/testdata/fn-render/short-image-path/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021-2026 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/e2e/testdata/fn-render/short-image-path/.expected/diff.patch
+++ b/e2e/testdata/fn-render/short-image-path/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index d4e5935..24022da 100644
+index 9b02c2e..d8b630c 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
-+  namespace: staging
 +  labels:
 +    tier: backend
  pipeline:
    mutators:
-     - image: set-namespace:v0.2.0
-@@ -10,3 +13,14 @@ pipeline:
-     - image: set-labels:v0.1.5
+     - image: set-namespace:latest
+@@ -10,3 +12,22 @@ pipeline:
+     - image: set-labels:latest
        configMap:
          tier: backend
 +status:
@@ -23,15 +22,23 @@ index d4e5935..24022da 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 4 labels in total
++            severity: info
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..84cfb26 100644
+index f2eec52..12338f5 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,25 @@ apiVersion: apps/v1
+@@ -15,12 +15,20 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -43,16 +50,11 @@ index f2eec52..84cfb26 100644
 +  selector:
 +    matchLabels:
 +      tier: backend
-+  template:
-+    metadata:
-+      labels:
-+        tier: backend
  ---
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
    name: custom
-+  namespace: staging
 +  labels:
 +    tier: backend
  spec:

--- a/e2e/testdata/fn-render/short-image-path/.expected/results.yaml
+++ b/e2e/testdata/fn-render/short-image-path/.expected/results.yaml
@@ -4,7 +4,15 @@ metadata:
   name: fnresults
 exitCode: 0
 items:
-  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+  - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
     exitCode: 0
-  - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    results:
+      - message: namespace [default] updated to "staging", 1 value(s) changed
+        severity: info
+      - message: all `depends-on` annotations are up-to-date. no `namespace` changed
+        severity: info
+  - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
     exitCode: 0
+    results:
+      - message: set 4 labels in total
+        severity: info

--- a/e2e/testdata/fn-render/short-image-path/Kptfile
+++ b/e2e/testdata/fn-render/short-image-path/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: set-namespace:v0.2.0
+    - image: set-namespace:latest
       configMap:
         namespace: staging
-    - image: set-labels:v0.1.5
+    - image: set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/subpkg-fn-failure/.expected/diff.patch
+++ b/e2e/testdata/fn-render/subpkg-fn-failure/.expected/diff.patch
@@ -1,9 +1,9 @@
 diff --git a/Kptfile b/Kptfile
-index 364e274..4e01e27 100644
+index 01b45db..600b54c 100644
 --- a/Kptfile
 +++ b/Kptfile
 @@ -12,3 +12,23 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: backend
 +status:

--- a/e2e/testdata/fn-render/subpkg-fn-failure/Kptfile
+++ b/e2e/testdata/fn-render/subpkg-fn-failure/Kptfile
@@ -6,9 +6,9 @@ pipeline:
   mutators:
     - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
       configPath: starlark-httpbin.yaml
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/subpkg-fn-failure/db/Kptfile
+++ b/e2e/testdata/fn-render/subpkg-fn-failure/db/Kptfile
@@ -6,9 +6,9 @@ pipeline:
   mutators:
     - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
       configPath: statefulset-filter.yaml
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: db
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         app: backend

--- a/e2e/testdata/fn-render/subpkg-has-invalid-kptfile/.expected/diff.patch
+++ b/e2e/testdata/fn-render/subpkg-has-invalid-kptfile/.expected/diff.patch
@@ -1,9 +1,9 @@
 diff --git a/Kptfile b/Kptfile
-index 1307fb5..15413d2 100644
+index ae603c9..98eeb85 100644
 --- a/Kptfile
 +++ b/Kptfile
 @@ -10,3 +10,11 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: backend
 +status:

--- a/e2e/testdata/fn-render/subpkg-has-invalid-kptfile/Kptfile
+++ b/e2e/testdata/fn-render/subpkg-has-invalid-kptfile/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/subpkg-has-invalid-kptfile/db/Kptfile
+++ b/e2e/testdata/fn-render/subpkg-has-invalid-kptfile/db/Kptfile
@@ -7,9 +7,9 @@ pipeline:
     - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
     # malformed Kptfile
   configPath: statefulset-filter.yaml
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: db
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         app: backend

--- a/e2e/testdata/fn-render/subpkg-has-samename-subdir/.expected/diff.patch
+++ b/e2e/testdata/fn-render/subpkg-has-samename-subdir/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index 701e0a1..63952e8 100644
+index 701e0a1..b7a3e2d 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -4,3 +4,12 @@ metadata:
+@@ -4,3 +4,17 @@ metadata:
    name: root-pkg
  info:
    description: sample description
@@ -13,22 +13,15 @@ index 701e0a1..63952e8 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-diff --git a/pkg-a/Kptfile b/pkg-a/Kptfile
-index 088bc03..c42f368 100644
---- a/pkg-a/Kptfile
-+++ b/pkg-a/Kptfile
-@@ -2,6 +2,7 @@ apiVersion: kpt.dev/v1
- kind: Kptfile
- metadata:
-   name: pkg-a
-+  namespace: dev
- info:
-   description: sample description
- pipeline:
++        results:
++          - message: namespace [default] updated to "dev", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
 diff --git a/pkg-a/pkg-a/resources.yaml b/pkg-a/pkg-a/resources.yaml
-index f2eec52..c4e4abb 100644
+index f2eec52..1934a8f 100644
 --- a/pkg-a/pkg-a/resources.yaml
 +++ b/pkg-a/pkg-a/resources.yaml
 @@ -15,6 +15,7 @@ apiVersion: apps/v1
@@ -39,10 +32,3 @@ index f2eec52..c4e4abb 100644
  spec:
    replicas: 3
  ---
-@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
- kind: Custom
- metadata:
-   name: custom
-+  namespace: dev
- spec:
-   image: nginx:1.2.3

--- a/e2e/testdata/fn-render/subpkg-has-samename-subdir/pkg-a/Kptfile
+++ b/e2e/testdata/fn-render/subpkg-has-samename-subdir/pkg-a/Kptfile
@@ -6,6 +6,6 @@ info:
   description: sample description
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: dev

--- a/e2e/testdata/fn-render/subpkg-resource-deletion/.expected/diff.patch
+++ b/e2e/testdata/fn-render/subpkg-resource-deletion/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index 364e274..79d669a 100644
+index 01b45db..e69142d 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
-+  namespace: staging
 +  labels:
 +    tier: backend
  pipeline:
    mutators:
      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
-@@ -12,3 +15,22 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+@@ -12,3 +14,38 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: backend
 +status:
@@ -25,25 +24,40 @@ index 364e274..79d669a 100644
 +    mutationSteps:
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: all matching namespaces are already "db". no value changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 3 labels in total
++            severity: info
 +      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 7 labels in total
++            severity: info
 diff --git a/db/Kptfile b/db/Kptfile
-index 6c7674c..11fe9cc 100644
+index 1e34168..16fdcf9 100644
 --- a/db/Kptfile
 +++ b/db/Kptfile
-@@ -2,6 +2,10 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: db
-+  namespace: staging
 +  labels:
 +    app: backend
 +    tier: backend
@@ -51,10 +65,10 @@ index 6c7674c..11fe9cc 100644
    mutators:
      - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
 diff --git a/db/resources.yaml b/db/resources.yaml
-index f983597..9dabb18 100644
+index f983597..e21782c 100644
 --- a/db/resources.yaml
 +++ b/db/resources.yaml
-@@ -1,26 +1,10 @@
+@@ -1,26 +1,9 @@
 -# Copyright 2021 The kpt Authors
 -#
 -# Licensed under the Apache License, Version 2.0 (the "License");
@@ -79,21 +93,19 @@ index f983597..9dabb18 100644
  kind: Custom
  metadata:
    name: custom
-+  namespace: staging
 +  labels:
 +    app: backend
 +    tier: backend
  spec:
    image: nginx:1.2.3
 diff --git a/db/statefulset-filter.yaml b/db/statefulset-filter.yaml
-index e1f7b67..ac69c02 100644
+index e1f7b67..8ab4033 100644
 --- a/db/statefulset-filter.yaml
 +++ b/db/statefulset-filter.yaml
-@@ -15,6 +15,10 @@ apiVersion: fn.kpt.dev/v1alpha1
+@@ -15,6 +15,9 @@ apiVersion: fn.kpt.dev/v1alpha1
  kind: StarlarkRun
  metadata:
    name: statefulset-filter
-+  namespace: staging
 +  labels:
 +    app: backend
 +    tier: backend
@@ -143,10 +155,10 @@ index 49d4f6e..0000000
 -        - name: httpbin
 -          image: kennethreitz/httpbin
 diff --git a/resources.yaml b/resources.yaml
-index 239f0d6..9ca3271 100644
+index 239f0d6..2bfd098 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,5 +15,15 @@ apiVersion: apps/v1
+@@ -15,5 +15,11 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -158,19 +170,14 @@ index 239f0d6..9ca3271 100644
 +  selector:
 +    matchLabels:
 +      tier: backend
-+  template:
-+    metadata:
-+      labels:
-+        tier: backend
 diff --git a/starlark-httpbin.yaml b/starlark-httpbin.yaml
-index fd90109..e437ba7 100644
+index fd90109..f9174fb 100644
 --- a/starlark-httpbin.yaml
 +++ b/starlark-httpbin.yaml
-@@ -15,6 +15,9 @@ apiVersion: fn.kpt.dev/v1alpha1
+@@ -15,6 +15,8 @@ apiVersion: fn.kpt.dev/v1alpha1
  kind: StarlarkRun
  metadata:
    name: httpbin-gen
-+  namespace: staging
 +  labels:
 +    tier: backend
  source: |

--- a/e2e/testdata/fn-render/subpkg-resource-deletion/Kptfile
+++ b/e2e/testdata/fn-render/subpkg-resource-deletion/Kptfile
@@ -6,9 +6,9 @@ pipeline:
   mutators:
     - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
       configPath: starlark-httpbin.yaml
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/subpkg-resource-deletion/db/Kptfile
+++ b/e2e/testdata/fn-render/subpkg-resource-deletion/db/Kptfile
@@ -6,9 +6,9 @@ pipeline:
   mutators:
     - image: ghcr.io/kptdev/krm-functions-catalog/starlark:latest
       configPath: statefulset-filter.yaml
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: db
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         app: backend

--- a/e2e/testdata/fn-render/subpkgs-with-krmignore/.expected/diff.patch
+++ b/e2e/testdata/fn-render/subpkgs-with-krmignore/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index 82686a8..7570107 100644
+index dcf093e..33d9c53 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app-with-db
-+  namespace: staging
 +  labels:
 +    tier: db
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-@@ -10,3 +13,18 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+@@ -10,3 +12,34 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: db
 +status:
@@ -23,34 +22,49 @@ index 82686a8..7570107 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "db", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++        results:
++          - message: set 3 labels in total
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [db default] updated to "staging", 2 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 7 labels in total
++            severity: info
 diff --git a/db/Kptfile b/db/Kptfile
-index 264dd2e..8dd7c37 100644
+index a0e6f2d..5e0e30a 100644
 --- a/db/Kptfile
 +++ b/db/Kptfile
-@@ -2,6 +2,10 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: db
-+  namespace: staging
 +  labels:
 +    app: backend
 +    tier: db
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 diff --git a/db/resources.yaml b/db/resources.yaml
-index dabe43c..e9be40c 100644
+index dabe43c..25f77c1 100644
 --- a/db/resources.yaml
 +++ b/db/resources.yaml
-@@ -15,5 +15,18 @@ apiVersion: apps/v1
+@@ -15,5 +15,13 @@ apiVersion: apps/v1
  kind: StatefulSet
  metadata:
    name: db
@@ -64,16 +78,11 @@ index dabe43c..e9be40c 100644
 +    matchLabels:
 +      app: backend
 +      tier: db
-+  template:
-+    metadata:
-+      labels:
-+        app: backend
-+        tier: db
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..8b2113d 100644
+index f2eec52..dcf72b1 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,25 @@ apiVersion: apps/v1
+@@ -15,12 +15,20 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -85,16 +94,11 @@ index f2eec52..8b2113d 100644
 +  selector:
 +    matchLabels:
 +      tier: db
-+  template:
-+    metadata:
-+      labels:
-+        tier: db
  ---
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
    name: custom
-+  namespace: staging
 +  labels:
 +    tier: db
  spec:

--- a/e2e/testdata/fn-render/subpkgs-with-krmignore/Kptfile
+++ b/e2e/testdata/fn-render/subpkgs-with-krmignore/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: app-with-db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: db

--- a/e2e/testdata/fn-render/subpkgs-with-krmignore/db/Kptfile
+++ b/e2e/testdata/fn-render/subpkgs-with-krmignore/db/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: db
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         app: backend

--- a/e2e/testdata/fn-render/subpkgs/.expected/diff.patch
+++ b/e2e/testdata/fn-render/subpkgs/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index 82686a8..7570107 100644
+index dcf093e..33d9c53 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app-with-db
-+  namespace: staging
 +  labels:
 +    tier: db
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-@@ -10,3 +13,18 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+@@ -10,3 +12,34 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: db
 +status:
@@ -23,34 +22,49 @@ index 82686a8..7570107 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "db", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++        results:
++          - message: set 3 labels in total
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [db default] updated to "staging", 2 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 7 labels in total
++            severity: info
 diff --git a/db/Kptfile b/db/Kptfile
-index 264dd2e..8dd7c37 100644
+index a0e6f2d..5e0e30a 100644
 --- a/db/Kptfile
 +++ b/db/Kptfile
-@@ -2,6 +2,10 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: db
-+  namespace: staging
 +  labels:
 +    app: backend
 +    tier: db
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 diff --git a/db/resources.yaml b/db/resources.yaml
-index dabe43c..e9be40c 100644
+index dabe43c..25f77c1 100644
 --- a/db/resources.yaml
 +++ b/db/resources.yaml
-@@ -15,5 +15,18 @@ apiVersion: apps/v1
+@@ -15,5 +15,13 @@ apiVersion: apps/v1
  kind: StatefulSet
  metadata:
    name: db
@@ -64,16 +78,11 @@ index dabe43c..e9be40c 100644
 +    matchLabels:
 +      app: backend
 +      tier: db
-+  template:
-+    metadata:
-+      labels:
-+        app: backend
-+        tier: db
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..8b2113d 100644
+index f2eec52..dcf72b1 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,25 @@ apiVersion: apps/v1
+@@ -15,12 +15,20 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -85,16 +94,11 @@ index f2eec52..8b2113d 100644
 +  selector:
 +    matchLabels:
 +      tier: db
-+  template:
-+    metadata:
-+      labels:
-+        tier: db
  ---
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
    name: custom
-+  namespace: staging
 +  labels:
 +    tier: db
  spec:

--- a/e2e/testdata/fn-render/subpkgs/Kptfile
+++ b/e2e/testdata/fn-render/subpkgs/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: app-with-db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: db

--- a/e2e/testdata/fn-render/subpkgs/db/Kptfile
+++ b/e2e/testdata/fn-render/subpkgs/db/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: db
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         app: backend

--- a/e2e/testdata/fn-render/success-stdout/.expected/diff.patch
+++ b/e2e/testdata/fn-render/success-stdout/.expected/diff.patch
@@ -1,19 +1,18 @@
 diff --git a/Kptfile b/Kptfile
-index 1307fb5..fee64dc 100644
+index ae603c9..13a6cbf 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,9 @@ apiVersion: kpt.dev/v1
+@@ -2,6 +2,8 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
-+  namespace: staging
 +  labels:
 +    tier: backend
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
-@@ -10,3 +13,14 @@ pipeline:
-     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
+@@ -10,3 +12,22 @@ pipeline:
+     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
        configMap:
          tier: backend
 +status:
@@ -23,15 +22,23 @@ index 1307fb5..fee64dc 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 +        exitCode: 0
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
++        results:
++          - message: namespace [default] updated to "staging", 1 value(s) changed
++            severity: info
++          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
++            severity: info
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
 +        exitCode: 0
++        results:
++          - message: set 4 labels in total
++            severity: info
 diff --git a/resources.yaml b/resources.yaml
-index f2eec52..84cfb26 100644
+index f2eec52..12338f5 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -15,12 +15,25 @@ apiVersion: apps/v1
+@@ -15,12 +15,20 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: nginx-deployment
@@ -43,16 +50,11 @@ index f2eec52..84cfb26 100644
 +  selector:
 +    matchLabels:
 +      tier: backend
-+  template:
-+    metadata:
-+      labels:
-+        tier: backend
  ---
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
    name: custom
-+  namespace: staging
 +  labels:
 +    tier: backend
  spec:

--- a/e2e/testdata/fn-render/success-stdout/Kptfile
+++ b/e2e/testdata/fn-render/success-stdout/Kptfile
@@ -4,9 +4,9 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/validator-mutates-resources/Kptfile
+++ b/e2e/testdata/fn-render/validator-mutates-resources/Kptfile
@@ -4,6 +4,6 @@ metadata:
   name: app
 pipeline:
   validators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend

--- a/pkg/lib/kptops/fs_test.go
+++ b/pkg/lib/kptops/fs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt Authors
+// Copyright 2022-2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -62,10 +62,10 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend`
 
@@ -140,10 +140,10 @@ metadata:
   name: app-with-db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: staging
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: db`
 
@@ -159,10 +159,10 @@ metadata:
   name: db
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
       configMap:
         namespace: db
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         app: backend`
 

--- a/pkg/lib/kptops/fs_test.go
+++ b/pkg/lib/kptops/fs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2026 The kpt Authors
+// Copyright 2022, 2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/lib/kptops/helpers_test.go
+++ b/pkg/lib/kptops/helpers_test.go
@@ -35,8 +35,8 @@ import (
 // testFunctions maps image references to in-process function implementations.
 // Test Kptfiles must use these exact image strings for the runtime to resolve them.
 var testFunctions = map[string]framework.ResourceListProcessorFunc{
-	"ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5":    setLabels,
-	"ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1": setNamespace,
+	"ghcr.io/kptdev/krm-functions-catalog/set-labels:latest":    setLabels,
+	"ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest": setNamespace,
 }
 
 // runtime is a test-only FunctionRuntime that resolves functions from testFunctions.


### PR DESCRIPTION
### Description 

Switch `set-namespace`, `set-annotations` and `set-labels` KRM function images from pinned versions (`v0.2.0/v0.4.1`, `v0.1.` and `v0.1.5`) to `:latest` across E2E tests and unit test fixtures.

Updated expected test outputs to reflect behavioural changes in the latest image versions:
  - set-namespace no longer applies to non-namespaced resources
  - Both functions now emit structured result messages

### Issues
- Part of #4297

### Testing
- Unit and E2E tests are passing