### PR TITLE
adding porch documentation tab to header

### DIFF
--- a/documentation/config.toml
+++ b/documentation/config.toml
@@ -182,3 +182,9 @@ name = "Functions Catalog"
 url = "https://catalog.kpt.dev/"
 weight = 40
 target = "_self"
+
+[[menu.main]]
+name = "Porch"
+url = "https://kpt-porch.netlify.app/"
+weight = 50
+target = "_self"


### PR DESCRIPTION
Docs: Add Porch documentation link to navbar

## Description

Adds a "Porch" entry to the kpt.dev documentation navbar, linking to the Porch documentation site at https://kpt-porch.netlify.app/.

## Motivation

Porch is being ported from Nephio into the kpt project. The three documentation sites (kpt.dev, catalog.kpt.dev, kpt-porch.netlify.app) should share a consistent navbar.

This is part of a coordinated set of 3 PRs:
- **kptdev/kpt** (this PR) adds "Porch" to kpt.dev navbar
- https://github.com/kptdev/krm-functions-catalog/pull/1255 adds "Porch" to catalog.kpt.dev navbar
- https://github.com/kptdev/porch/pull/1016 adds "Book", "References", "Functions Catalog", "Guides" to porch navbar and ports kpt visual theme

## Changes

- `documentation/config.toml`: Added `[[menu.main]]` entry for Porch (weight 50)
