### PR TITLE
Upgrade KinD to v0.32.0 and Kubernetes e2e test matrix to 1.35/1.36

### DIFF
--- a/.github/workflows/e2eEnvironment.yml
+++ b/.github/workflows/e2eEnvironment.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,10 +33,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["1.33", "1.34"]
+        version: ["1.35", "1.36"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: go/src/github.com/kptdev/kpt
       - name: Set up Go
@@ -49,7 +49,7 @@ jobs:
       - name: Install KinD
         uses: engineerd/setup-kind@v0.6.2
         with:
-          version: "v0.30.0"
+          version: "v0.32.0"
           skipClusterCreation: true
           skipClusterLogsExport: true
       - name: Run Tests

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2", "1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a"]
+        version: ["1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95", "1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"]
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: go/src/github.com/kptdev/kpt
       - name: Set up Go
@@ -49,7 +49,7 @@ jobs:
       - name: Install KinD
         uses: engineerd/setup-kind@v0.6.2
         with:
-          version: "v0.30.0"
+          version: "v0.32.0"
           skipClusterCreation: true
           skipClusterLogsExport: true
 

--- a/e2e/live/end-to-end-test.sh
+++ b/e2e/live/end-to-end-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###########################################################################
-# Copyright 2020 The kpt Authors
+# Copyright 2020, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -62,6 +62,8 @@ OPTIND=1
 
 # Kind/Kubernetes versions.
 
+KIND_1_36_VERSION=1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5
+KIND_1_35_VERSION=1.35.5@sha256:ce977ae6d65918d0b58a5f8b5e940429c2ce42fa3a5619ec2bbc60b949c0ac95
 KIND_1_34_VERSION=1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
 KIND_1_33_VERSION=1.33.4@sha256:25a6018e48dfcaee478f4a59af81157a437f15e6e140bf103f85a2e7cd0cbbf2
 KIND_1_32_VERSION=1.32.8@sha256:abd489f042d2b644e2d033f5c2d900bc707798d075e8186cb65e3f1367a9d5a1
@@ -79,9 +81,9 @@ KIND_1_21_VERSION=1.21.14@sha256:8a4e9bb3f415d2bb81629ce33ef9c76ba514c14d707f979
 
 
 
-NOTE: You must use the @sha256 digest to guarantee an image built for this release, until such a time as we switch to a different tagging scheme. Even then we will highly encourage digest pinning for security and reproducibility reasons.
+# NOTE: You must use the @sha256 digest to guarantee an image built for this release, until such a time as we switch to a different tagging scheme. Even then we will highly encourage digest pinning for security and reproducibility reasons.
 
-DEFAULT_K8S_VERSION=${KIND_1_34_VERSION}
+DEFAULT_K8S_VERSION=${KIND_1_36_VERSION}
 
 # Change from empty string to build the kpt binary from the downloaded
 # repositories at HEAD, including dependencies cli-utils and kustomize.
@@ -126,6 +128,10 @@ while getopts $options opt; do
 		1.33) K8S_VERSION=$KIND_1_33_VERSION
 		      ;;
 		1.34) K8S_VERSION=$KIND_1_34_VERSION
+		      ;;
+		1.35) K8S_VERSION=$KIND_1_35_VERSION
+		      ;;
+		1.36) K8S_VERSION=$KIND_1_36_VERSION
 		      ;;
         *) K8S_VERSION=$short_version
 		      ;;


### PR DESCRIPTION
## Description
  - What changed: Updated KinD version from `v0.30.0` to `v0.32.0` and Kubernetes test matrix from `1.33`/`1.34` to `1.35`/`1.36` in both e2e workflow files. Also upgraded `actions/checkout` from `v5` to `v6`.
  - Why it's needed: The go.mod dependencies target `k8s.io v0.36.1` (Kubernetes 1.36) but CI was only testing against `1.33` and `1.34`, leaving a validation gap.
  - How it works: The e2e workflows now use KinD `v0.32.0` with official node images for Kubernetes `1.35.5` and `1.36.1`, ensuring CI coverage matches the library versions.

  ## Related Issue(s)
  - N/A

  ## Type of Change
  - [ ] Bug fix
  - [ ] New feature
  - [x] Enhancement
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other: ________

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass

  ## Testing Instructions (Optional)
  1. Verify workflows trigger correctly on PR
  2. Confirm KinD `v0.32.0` installs and creates clusters with k8s `1.35.5` and `1.36.1`
  3. Confirm e2e tests pass against both versions

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to identify version gap, look up KinD `v0.32.0` release node image SHAs, and update workflow files.