### PR TITLE
fn doc: remove invalid --stdin flag from docker run args

### DIFF
--- a/commands/fn/doc/cmdfndoc.go
+++ b/commands/fn/doc/cmdfndoc.go
@@ -65,11 +65,10 @@ func (r *Runner) runE(_ *cobra.Command, _ []string) error {
 	resolveFunc := runneroptions.ResolveToImageForCLIFunc(runneroptions.GHCRImagePrefix)
 	image := resolveFunc(r.Image)
 	var out, errout bytes.Buffer
-	dockerRunArgs := []string{
+	runArgs := []string{
 		"run",
-		"--rm",    // delete the container afterward
-		"-i",      // interactive mode to accept stdin
-		"--stdin", // keep stdin open
+		"--rm", // delete the container afterward
+		"-i",   // interactive mode to accept stdin
 		image,
 		"--help",
 	}
@@ -84,7 +83,7 @@ func (r *Runner) runE(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	cmd := exec.Command(runtime.GetBin(), dockerRunArgs...)
+	cmd := exec.Command(runtime.GetBin(), runArgs...)
 	cmd.Stdout = &out
 	cmd.Stderr = &errout
 


### PR DESCRIPTION
Remove `--stdin` from docker run args in `kpt fn doc`.

`--stdin` is a podman-only flag — Docker doesn't recognise it and fails with `unknown flag: --stdin`. The `-i` flag alone keeps stdin open, which is all that's needed to pipe the empty ResourceList for backward compat with older functions.

Introduced in 3998a5db1 as a workaround for functions that read stdin even when `--help` is passed. With SDK v1.0.4 (`AsMain` checks `os.Args` for `--help`/`--doc` before reading stdin) the workaround is unnecessary for migrated functions, but `-i` + the piped empty ResourceList still covers old ones.

AI assisted, author has fully verified all code.
