### PR TITLE
allow image references combining a tag and a digest

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -3,6 +3,7 @@ module github.com/kptdev/kpt/api
 go 1.24.0
 
 require (
+	github.com/distribution/reference v0.6.0
 	github.com/stretchr/testify v1.11.1
 	k8s.io/apimachinery v0.34.8 // intentionally outdated to have a lower go version
 	sigs.k8s.io/kustomize/kyaml v0.21.1
@@ -19,6 +20,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-openapi/jsonpointer v0.19.6/go.mod h1:osyAmYz/mB/C3I+WsTTSgw1ONzaLJoLCyoi6/zppojs=
@@ -38,6 +40,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/api/kptfile/v1/validation.go
+++ b/api/kptfile/v1/validation.go
@@ -17,10 +17,10 @@ package v1
 import (
 	"fmt"
 	"path/filepath"
-	"regexp"
 	"slices"
 	"strings"
 
+	"github.com/distribution/reference"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
@@ -116,35 +116,21 @@ func (f *Function) validate(fsys filesys.FileSystem, fnType string, idx int, pkg
 	return nil
 }
 
-// ValidateFunctionImageURL validates the function name.
-// According to Docker implementation
-// https://github.com/docker/distribution/blob/master/reference/reference.go. A valid
-// name definition is:
+// ValidateFunctionImageURL validates the function image reference.
 //
-//	name                            := [domain '/'] path-component ['/' path-component]*
-//	domain                          := domain-component ['.' domain-component]* [':' port-number]
-//	domain-component                := /([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])/
-//	port-number                     := /[0-9]+/
-//	path-component                  := alpha-numeric [separator alpha-numeric]*
-//	alpha-numeric                   := /[a-z0-9]+/
-//	separator                       := /[_.]|__|[-]*/
+// The reference must conform to the standard OCI/Docker reference grammar
+// implemented by github.com/distribution/reference:
+//
+//	reference := name [ ":" tag ] [ "@" digest ]
+//
+// This means an image may carry a tag
+// (e.g. ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.5),
+// a digest (e.g. ghcr.io/kptdev/krm-functions-catalog/set-namespace@sha256:...),
+// or both at the same time
+// (e.g. ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.5@sha256:...).
 func ValidateFunctionImageURL(name string) error {
-	pathComponentRegexp := `(?:[a-z0-9](?:(?:[_.]|__|[-]*)[a-z0-9]+)*)`
-	domainComponentRegexp := `(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`
-	domainRegexp := fmt.Sprintf(`%s(?:\.%s)*(?:\:[0-9]+)?`, domainComponentRegexp, domainComponentRegexp)
-	nameRegexp := fmt.Sprintf(`(?:%s\/)?%s(?:\/%s)*`, domainRegexp,
-		pathComponentRegexp, pathComponentRegexp)
-	tagRegexp := `(?:[\w][\w.-]{0,127})`
-	shaRegexp := `(sha256:[a-zA-Z0-9]{64})`
-	versionRegexp := fmt.Sprintf(`(%s|%s)`, tagRegexp, shaRegexp)
-	r := fmt.Sprintf(`^(?:%s(?:(\:|@)%s)?)$`, nameRegexp, versionRegexp)
-
-	matched, err := regexp.MatchString(r, name)
-	if err != nil {
-		return err
-	}
-	if !matched {
-		return fmt.Errorf("function name %q is invalid", name)
+	if _, err := reference.Parse(name); err != nil {
+		return fmt.Errorf("function image reference %q is invalid: %w", name, err)
 	}
 	return nil
 }

--- a/api/kptfile/v1/validation_test.go
+++ b/api/kptfile/v1/validation_test.go
@@ -233,6 +233,18 @@ func TestValidateFunctionName(t *testing.T) {
 			"example.com/foo/generate-folders@sha256:3434a5299f8fcb2c2ade9975e56ca5a622427b9d5a9a971640765e830fb90a0e",
 			true,
 		},
+		{
+			"example.com/foo/generate-folders:v0.1.0@sha256:3434a5299f8fcb2c2ade9975e56ca5a622427b9d5a9a971640765e830fb90a0e",
+			true,
+		},
+		{
+			"example:v0.1.0@sha256:a2672547b418a57a2b2b41940f96ab4fe78f19851f15c74017ff074bba70c9d9",
+			true,
+		},
+		{
+			"generate-folders@v0.1.0",
+			false,
+		},
 	}
 
 	for _, n := range inputs {


### PR DESCRIPTION
## Description

fix #4578 

## Motivation

The `name:tag@digest` form is valid per the OCI/Docker reference grammar.
