### PR TITLE
Fix CI: replace broken setup-kind action and bump checkout to v6

### DIFF
--- a/.github/workflows/e2eEnvironment.yml
+++ b/.github/workflows/e2eEnvironment.yml
@@ -45,14 +45,11 @@ jobs:
           go-version-file: go/src/github.com/kptdev/kpt/go.mod
           cache: true
           cache-dependency-path: go/src/github.com/kptdev/kpt/go.sum
-      # Pinned to Commit to ensure action is consistent: https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
-      # If you upgrade this version confirm the changes match your expectations
-      - name: Install KinD
-        uses: engineerd/setup-kind@v0.6.2
+      - name: Install Kind
+        uses: helm/kind-action@v1
         with:
-          version: "v0.32.0"
-          skipClusterCreation: true
-          skipClusterLogsExport: true
+          version: v0.32.0
+          install_only: true
       - name: Run Tests
         working-directory: go/src/github.com/kptdev/kpt
         env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,7 +50,7 @@ jobs:
           which podman
           podman version
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: ${{ env.GOPATH }}/src/github.com/kptdev/kpt
       - name: Set up Go
@@ -73,7 +73,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: ${{ env.GOPATH }}/src/github.com/kptdev/kpt
       - name: Set up Go

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -44,14 +44,11 @@ jobs:
           go-version-file: go/src/github.com/kptdev/kpt/go.mod
           cache: true
           cache-dependency-path: go/src/github.com/kptdev/kpt/go.sum
-      # Pinned to Commit to ensure action is consistent: https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
-      # If you upgrade this version confirm the changes match your expectations
-      - name: Install KinD
-        uses: engineerd/setup-kind@v0.6.2
+      - name: Install Kind
+        uses: helm/kind-action@v1
         with:
-          version: "v0.32.0"
-          skipClusterCreation: true
-          skipClusterLogsExport: true
+          version: v0.32.0
+          install_only: true
 
       - name: Run Tests
         working-directory: go/src/github.com/kptdev/kpt

--- a/.github/workflows/release-api.yml
+++ b/.github/workflows/release-api.yml
@@ -24,7 +24,7 @@ jobs:
     name: kpt-api-release
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           path: go/src/github.com/kptdev/kpt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           path: go/src/github.com/kptdev/kpt

--- a/.github/workflows/verifyContent.yml
+++ b/.github/workflows/verifyContent.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: go/src/github.com/kptdev/kpt
       - name: Set up Go

--- a/.github/workflows/verifyDocumentation.yml
+++ b/.github/workflows/verifyDocumentation.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
## Description
Replace the defunct `engineerd/setup-kind@v0.6.2` action with `helm/kind-action@v1` and bump `actions/checkout` from v5 to v6 across all workflows.

## Motivation

The `engineerd/setup-kind@v0.6.2` action is broken. its published artifact (`dist/main/index.js`) no longer exists, causing all e2e workflow runs to fail with:
```bash
Error: File not found: '/home/runner/work/_actions/engineerd/setup-kind/v0.6.2/dist/main/index.js'
```
The replacement (`helm/kind-action@v1` with `install_only: true`) is actively maintained and provides the same functionality - installing the Kind binary without creating a cluster.

The `actions/checkout` bump to v6 keeps CI on supported action versions.

  ## Changes
  - `e2eEnvironment.yml`: Replace `engineerd/setup-kind@v0.6.2` with `helm/kind-action@v1`
  - `live-e2e.yml`: Same replacement
  - `go.yml`, `release-api.yml`, `release.yml`, `verifyContent.yml`, `verifyDocumentation.yml`: Bump `actions/checkout@v5` → `actions/checkout@v6`

  ## Testing

  - Verified `helm/kind-action@v1` supports `install_only: true` which skips cluster creation (equivalent to the previous `skipClusterCreation: true`)
  - Kind version `v0.32.0` is preserved

## AI Disclosure
 - Kiro CLI has been used to draft this PR message.