### PR TITLE
Update e2e test image tags from pinned versions to :latest

### DIFF
--- a/e2e/testdata/fn-eval/function-env/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/function-env/.expected/exec.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 
 set -eo pipefail
 
-IMAGE_TAG="ghcr.io/kptdev/krm-functions-catalog/printenv:v0.1"
+IMAGE_TAG="ghcr.io/kptdev/krm-functions-catalog/printenv:latest"
 export EXPORT_ENV="export_env_value"
 
 kpt fn source \

--- a/e2e/testdata/fn-eval/image-pull-policy-always/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/image-pull-policy-always/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/foo:v0.1
+image: ghcr.io/kptdev/krm-functions-catalog/foo:latest
 sequential: true
 imagePullPolicy: Always
 exitCode: 1

--- a/e2e/testdata/fn-eval/image-pull-policy-always/.expected/setup.sh
+++ b/e2e/testdata/fn-eval/image-pull-policy-always/.expected/setup.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ set -eo pipefail
 
 KRM_FN_RUNTIME="${KRM_FN_RUNTIME:=docker}"
 
-# Function ghcr.io/kptdev/krm-functions-catalog/foo:v0.1 prints "foo" to stderr and
-# function ghcr.io/kptdev/krm-functions-catalog/bar:v0.1 prints "bar" to stderr.
-# We intentionally tag a wrong image as ghcr.io/kptdev/krm-functions-catalog/foo:v0.1, since we
+# Function ghcr.io/kptdev/krm-functions-catalog/foo:latest prints "foo" to stderr and
+# function ghcr.io/kptdev/krm-functions-catalog/bar:latest prints "bar" to stderr.
+# We intentionally tag a wrong image as ghcr.io/kptdev/krm-functions-catalog/foo:latest, since we
 # expect the correct image to be pulled and override the wrong image.
-${KRM_FN_RUNTIME} pull ghcr.io/kptdev/krm-functions-catalog/bar:v0.1
-${KRM_FN_RUNTIME} tag ghcr.io/kptdev/krm-functions-catalog/bar:v0.1 ghcr.io/kptdev/krm-functions-catalog/foo:v0.1
+${KRM_FN_RUNTIME} pull ghcr.io/kptdev/krm-functions-catalog/bar:latest
+${KRM_FN_RUNTIME} tag ghcr.io/kptdev/krm-functions-catalog/bar:latest ghcr.io/kptdev/krm-functions-catalog/foo:latest

--- a/e2e/testdata/fn-eval/image-pull-policy-if-not-present/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/image-pull-policy-if-not-present/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/bar:v0.1
+image: ghcr.io/kptdev/krm-functions-catalog/bar:latest
 sequential: true
 imagePullPolicy: IfNotPresent
 exitCode: 1

--- a/e2e/testdata/fn-eval/image-pull-policy-if-not-present/.expected/setup.sh
+++ b/e2e/testdata/fn-eval/image-pull-policy-if-not-present/.expected/setup.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@ set -eo pipefail
 
 KRM_FN_RUNTIME="${KRM_FN_RUNTIME:=docker}"
 
-# Function ghcr.io/kptdev/krm-functions-catalog/foo:v0.1 prints "foo" to stderr and
-# function ghcr.io/kptdev/krm-functions-catalog/bar:v0.1 prints "bar" to stderr.
-# We intentionally tag a wrong image as pull ghcr.io/kptdev/krm-functions-catalog/bar:v0.1
-${KRM_FN_RUNTIME} pull ghcr.io/kptdev/krm-functions-catalog/foo:v0.1
-${KRM_FN_RUNTIME} tag ghcr.io/kptdev/krm-functions-catalog/foo:v0.1 ghcr.io/kptdev/krm-functions-catalog/bar:v0.1
+# Function ghcr.io/kptdev/krm-functions-catalog/foo:latest prints "foo" to stderr and
+# function ghcr.io/kptdev/krm-functions-catalog/bar:latest prints "bar" to stderr.
+# We intentionally tag foo as ghcr.io/kptdev/krm-functions-catalog/bar:latest so
+# the locally cached bar image is actually foo (wrong image).
+${KRM_FN_RUNTIME} pull ghcr.io/kptdev/krm-functions-catalog/foo:latest
+${KRM_FN_RUNTIME} tag ghcr.io/kptdev/krm-functions-catalog/foo:latest ghcr.io/kptdev/krm-functions-catalog/bar:latest

--- a/e2e/testdata/fn-eval/preserve-comments/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/preserve-comments/.expected/config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 testType: eval
-image: ghcr.io/kptdev/krm-functions-catalog/drop-comments:v0.1
+image: ghcr.io/kptdev/krm-functions-catalog/drop-comments:latest

--- a/e2e/testdata/fn-render/image-pull-policy-always/.expected/setup.sh
+++ b/e2e/testdata/fn-render/image-pull-policy-always/.expected/setup.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ set -eo pipefail
 
 KRM_FN_RUNTIME="${KRM_FN_RUNTIME:=docker}"
 
-# Function ghcr.io/kptdev/krm-functions-catalog/foo:v0.1 prints "foo" to stderr and
-# function ghcr.io/kptdev/krm-functions-catalog/bar:v0.1 prints "bar" to stderr.
-# We intentionally tag a wrong image as ghcr.io/kptdev/krm-functions-catalog/foo:v0.1, since we
+# Function ghcr.io/kptdev/krm-functions-catalog/foo:latest prints "foo" to stderr and
+# function ghcr.io/kptdev/krm-functions-catalog/bar:latest prints "bar" to stderr.
+# We intentionally tag a wrong image as ghcr.io/kptdev/krm-functions-catalog/foo:latest, since we
 # expect the correct image to be pulled and override the wrong image.
-${KRM_FN_RUNTIME} pull ghcr.io/kptdev/krm-functions-catalog/bar:v0.1
-${KRM_FN_RUNTIME} tag ghcr.io/kptdev/krm-functions-catalog/bar:v0.1 ghcr.io/kptdev/krm-functions-catalog/foo:v0.1
+${KRM_FN_RUNTIME} pull ghcr.io/kptdev/krm-functions-catalog/bar:latest
+${KRM_FN_RUNTIME} tag ghcr.io/kptdev/krm-functions-catalog/bar:latest ghcr.io/kptdev/krm-functions-catalog/foo:latest

--- a/e2e/testdata/fn-render/image-pull-policy-always/Kptfile
+++ b/e2e/testdata/fn-render/image-pull-policy-always/Kptfile
@@ -4,4 +4,4 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: pull ghcr.io/kptdev/krm-functions-catalog/foo:v0.1
+    - image: pull ghcr.io/kptdev/krm-functions-catalog/foo:latest

--- a/e2e/testdata/fn-render/image-pull-policy-if-not-present/.expected/setup.sh
+++ b/e2e/testdata/fn-render/image-pull-policy-if-not-present/.expected/setup.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2021 The kpt Authors
+# Copyright 2021, 2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@ set -eo pipefail
 
 KRM_FN_RUNTIME="${KRM_FN_RUNTIME:=docker}"
 
-# Function ghcr.io/kptdev/krm-functions-catalog/foo:v0.1 prints "foo" to stderr and
-# function ghcr.io/kptdev/krm-functions-catalog/bar:v0.1 prints "bar" to stderr.
-# We intentionally tag a wrong image as pull ghcr.io/kptdev/krm-functions-catalog/bar:v0.1
-${KRM_FN_RUNTIME} pull ghcr.io/kptdev/krm-functions-catalog/foo:v0.1
-${KRM_FN_RUNTIME} tag ghcr.io/kptdev/krm-functions-catalog/foo:v0.1 ghcr.io/kptdev/krm-functions-catalog/bar:v0.1
+# Function ghcr.io/kptdev/krm-functions-catalog/foo:latest prints "foo" to stderr and
+# function ghcr.io/kptdev/krm-functions-catalog/bar:latest prints "bar" to stderr.
+# We intentionally tag foo as ghcr.io/kptdev/krm-functions-catalog/bar:latest so
+# the locally cached bar image is actually foo (wrong image).
+${KRM_FN_RUNTIME} pull ghcr.io/kptdev/krm-functions-catalog/foo:latest
+${KRM_FN_RUNTIME} tag ghcr.io/kptdev/krm-functions-catalog/foo:latest ghcr.io/kptdev/krm-functions-catalog/bar:latest

--- a/e2e/testdata/fn-render/image-pull-policy-if-not-present/Kptfile
+++ b/e2e/testdata/fn-render/image-pull-policy-if-not-present/Kptfile
@@ -4,4 +4,4 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: pull ghcr.io/kptdev/krm-functions-catalog/foo:v0.1
+    - image: pull ghcr.io/kptdev/krm-functions-catalog/foo:latest

--- a/e2e/testdata/fn-render/preserve-comments/.expected/diff.patch
+++ b/e2e/testdata/fn-render/preserve-comments/.expected/diff.patch
@@ -1,11 +1,11 @@
 diff --git a/Kptfile b/Kptfile
-index 828d292..7502f3c 100644
+index d8eebcb..a84934e 100644
 --- a/Kptfile
 +++ b/Kptfile
 @@ -5,3 +5,12 @@ metadata:
  pipeline:
    mutators:
-     - image: ghcr.io/kptdev/krm-functions-catalog/drop-comments:v0.1
+     - image: ghcr.io/kptdev/krm-functions-catalog/drop-comments:latest
 +status:
 +  conditions:
 +    - type: Rendered
@@ -13,5 +13,5 @@ index 828d292..7502f3c 100644
 +      reason: RenderSuccess
 +  renderStatus:
 +    mutationSteps:
-+      - image: ghcr.io/kptdev/krm-functions-catalog/drop-comments:v0.1
++      - image: ghcr.io/kptdev/krm-functions-catalog/drop-comments:latest
 +        exitCode: 0

--- a/e2e/testdata/fn-render/preserve-comments/Kptfile
+++ b/e2e/testdata/fn-render/preserve-comments/Kptfile
@@ -4,4 +4,4 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/drop-comments:v0.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/drop-comments:latest


### PR DESCRIPTION
 ## Description
  - What changed: Updated e2e test cases referencing `bar:v0.1`, `foo:v0.1`, `printenv:v0.1`, and `drop-comments:v0.1` to use `:latest`.
  - Why it's needed: These images now have a `latest` tag published in `ghcr.io/kptdev/krm-functions-catalog`. Aligning to `:latest` keeps the test suite consistent and avoids depending on old pinned versions.
  - How it works: Replaced `:v0.1` with `:latest` in Kptfiles, config files, setup scripts, exec scripts, and expected diff patches.

  ## Related Issue(s)
  - Closes #4297 

  ## Type of Change
  - [x] Tests
  - [x] Enhancement

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [x] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass


  ## AI Disclosure
  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to identify all affected files and perform the replacements.
