### PR TITLE
Use versioned API module and comment out replace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/kptdev/kpt
 
 go 1.26.3
 
-replace github.com/kptdev/kpt/api => ./api
+//replace github.com/kptdev/kpt/api => ./api
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.6
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
-	github.com/kptdev/kpt/api v0.0.0-00010101000000-000000000000
+	github.com/kptdev/kpt/api v0.0.1
 	github.com/kptdev/krm-functions-sdk/go/fn v1.0.3
 	github.com/otiai10/copy v1.14.1
 	github.com/philopon/go-toposort v0.0.0-20170620085441-9be86dbd762f

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/kptdev/kpt/api v0.0.1 h1:1PZ/lA0IuMYkgrSXCJqk3fcVok8tyuP6gOmHhrTETdM=
+github.com/kptdev/kpt/api v0.0.1/go.mod h1:JviL89EPiMTdxSSJL9sXnOuckflKVXZKKDCu9YJ5kM4=
 github.com/kptdev/krm-functions-sdk/go/fn v1.0.3 h1:Gmkqbc2cbwJxamVoRSs409TZinuNGZaMYmNmlQcF6Bs=
 github.com/kptdev/krm-functions-sdk/go/fn v1.0.3/go.mod h1:+MgNIVQMGs6WcNhQZYIbgFINnmskX8VMYcUvJBtE01M=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
Now that we have a released API module tag, we can use that and remove the replace directive (kept commented out for convenience).