### PR TITLE
Simplify CI workflows: remove legacy GOPATH checkout pattern

### DIFF
--- a/.github/workflows/e2eEnvironment.yml
+++ b/.github/workflows/e2eEnvironment.yml
@@ -37,21 +37,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-        with:
-          path: go/src/github.com/kptdev/kpt
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go/src/github.com/kptdev/kpt/go.mod
-          cache: true
-          cache-dependency-path: go/src/github.com/kptdev/kpt/go.sum
+          go-version-file: go.mod
       - name: Install Kind
         uses: helm/kind-action@v1
         with:
           version: v0.32.0
           install_only: true
       - name: Run Tests
-        working-directory: go/src/github.com/kptdev/kpt
         env:
           K8S_VERSION: ${{ matrix.version }}
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,9 +31,6 @@ on:
     branches:
     - '!dependabot/*'
 
-env:
-  GOPATH: ${{ github.workspace }}/go
-
 jobs:
   build-test-linux:
     name: Build-test-kpt-CLI
@@ -49,18 +46,13 @@ jobs:
         run: |
           which podman
           podman version
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v6
-        with:
-          path: ${{ env.GOPATH }}/src/github.com/kptdev/kpt
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go/src/github.com/kptdev/kpt/go.mod
-          cache: true
-          cache-dependency-path: go/src/github.com/kptdev/kpt/go.sum
+          go-version-file: go.mod
       - name: Build, Test, Lint
-        working-directory: ${{ env.GOPATH }}/src/github.com/kptdev/kpt
         run: |
           git config --global user.email you@example.com
           git config --global user.name Your Name
@@ -72,18 +64,13 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-      - name: Check out code into the Go module directory
+      - name: Check out code
         uses: actions/checkout@v6
-        with:
-          path: ${{ env.GOPATH }}/src/github.com/kptdev/kpt
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go/src/github.com/kptdev/kpt/go.mod
-          cache: true
-          cache-dependency-path: go/src/github.com/kptdev/kpt/go.sum
+          go-version-file: go.mod
       - name: Build
-        working-directory: ${{ env.GOPATH }}/src/github.com/kptdev/kpt
         run: |
           make build
 
@@ -91,16 +78,12 @@ jobs:
 #  build-windows:
 #    runs-on: windows-2019
 #    steps:
+#      - name: Check out code
+#        uses: actions/checkout@v6
 #      - name: Set up Go
 #        uses: actions/setup-go@v6
 #        with:
-#          go-version: '>=1.24'
-#        id: go
-#      - name: Check out code into the Go module directory
-#        uses: actions/checkout@v5
-#        with:
-#          path: ${{ env.GOPATH }}/src/github.com/kptdev/kpt
+#          go-version-file: go.mod
 #      - name: Build
-#        working-directory: ${{ env.GOPATH }}/src/github.com/kptdev/kpt
 #        run: |
 #          make build

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -36,22 +36,16 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
-        with:
-          path: go/src/github.com/kptdev/kpt
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go/src/github.com/kptdev/kpt/go.mod
-          cache: true
-          cache-dependency-path: go/src/github.com/kptdev/kpt/go.sum
+          go-version-file: go.mod
       - name: Install Kind
         uses: helm/kind-action@v1
         with:
           version: v0.32.0
           install_only: true
-
       - name: Run Tests
-        working-directory: go/src/github.com/kptdev/kpt
         env:
           K8S_VERSION: ${{ matrix.version }}
         run: |

--- a/.github/workflows/release-api.yml
+++ b/.github/workflows/release-api.yml
@@ -27,15 +27,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          path: go/src/github.com/kptdev/kpt
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go/src/github.com/kptdev/kpt/api/go.mod
-          cache: true
-          cache-dependency-path: go/src/github.com/kptdev/kpt/api/go.sum
+          go-version-file: api/go.mod
+          cache-dependency-path: api/go.sum
       - name: Build, test, lint (api module)
-        working-directory: ${{ env.GOPATH }}/src/github.com/kptdev/kpt
         run: |
           git config --global user.email you@example.com
           git config --global user.name Your Name

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,15 +31,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          path: go/src/github.com/kptdev/kpt
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go/src/github.com/kptdev/kpt/go.mod
-          cache: true
-          cache-dependency-path: go/src/github.com/kptdev/kpt/go.sum
+          go-version-file: go.mod
       - name: Build, Test, Lint
-        working-directory: go/src/github.com/kptdev/kpt
         run: |
           git config --global user.email you@example.com
           git config --global user.name Your Name
@@ -61,19 +57,17 @@ jobs:
         with:
           distribution: goreleaser
           version: "~> v2"
-          workdir: go/src/github.com/kptdev/kpt
           args: release --skip=validate -f release/tag/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate SLSA subjects for provenance
         id: hash
-        working-directory: go/src/github.com/kptdev/kpt
         run: |
           set -euo pipefail
 
           checksum_file=$(cat dist/artifacts.json | jq -r '.[] | select (.type=="Checksum") | .path')
 
-          echo "::set-output name=hashes::$(cat $checksum_file | base64 -w0)"
+          echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
   
   provenance:
     needs: [build]

--- a/.github/workflows/verifyContent.yml
+++ b/.github/workflows/verifyContent.yml
@@ -32,23 +32,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          path: go/src/github.com/kptdev/kpt
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go/src/github.com/kptdev/kpt/go.mod
-          cache: true
-          cache-dependency-path: go/src/github.com/kptdev/kpt/go.sum
+          go-version-file: go.mod
       - name: Build
-        working-directory: go/src/github.com/kptdev/kpt
         run: |
           make build
       - name: Get dependencies
-        working-directory: go/src/github.com/kptdev/kpt
         run: |
           make install-mdrip
           make install-kind
       - name: Verify Examples
-        working-directory: go/src/github.com/kptdev/kpt
         run: make site-verify-examples


### PR DESCRIPTION
  ## Description
  - What changed: 

    - Removed the legacy GOPATH-style checkout layout (`path: go/src/github.com/kptdev/kpt`), the top-level `GOPATH` env variable, and all associated `working-directory` directives from 6 workflow files. 
    - Simplified `actions/setup-go@v6` configuration by dropping explicit `cache: true` and `cache-dependency-path` where defaults suffice. 
    - Retained `cache-dependency-path: api/go.sum` in `release-api.yml` for the submodule. 
    - Fixed deprecated `::set-output` in `release.yml` with `$GITHUB_OUTPUT`. 
    - Removed `workdir` from `goreleaser/goreleaser-action@v6` in `release.yml`.

  - Why it's needed: The project uses Go modules, the GOPATH checkout layout is unnecessary legacy from the pre-modules era. It adds verbosity and fragility to every workflow. The `::set-output` deprecation will eventually break release builds.
  - How it works: With Go modules, `go` commands work from any directory containing `go.mod`. Checking out to the default workspace root eliminates the need for custom paths and `working-directory` overrides.


  ## Type of Change
  - [x] Refactor

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass
  
  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to identify the unnecessary GOPATH pattern across all workflow files and to generate PR message.