### PR TITLE
Validate git ref and repo values to reject dash-prefixed inputs

### DIFF
--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -357,6 +357,23 @@ func (gur *GitUpstreamRepo) getRepoCacheDir() (string, error) {
 // cacheRepo fetches a remote repo to a cache location, and fetches the provided refs.
 func (gur *GitUpstreamRepo) cacheRepo(ctx context.Context, uri string, requiredRefs []string, optionalRefs []string) (string, error) {
 	const op errors.Op = "gitutil.cacheRepo"
+
+	// Validate that refs and URI do not start with '-' to prevent them from
+	// being interpreted as git command-line options.
+	if strings.HasPrefix(uri, "-") {
+		return "", errors.E(op, errors.Git, fmt.Errorf("invalid git repo %q: must not start with '-'", uri))
+	}
+	for _, ref := range requiredRefs {
+		if strings.HasPrefix(ref, "-") {
+			return "", errors.E(op, errors.Git, fmt.Errorf("invalid git ref %q: must not start with '-'", ref))
+		}
+	}
+	for _, ref := range optionalRefs {
+		if strings.HasPrefix(ref, "-") {
+			return "", errors.E(op, errors.Git, fmt.Errorf("invalid git ref %q: must not start with '-'", ref))
+		}
+	}
+
 	kptCacheDir, err := gur.getRepoCacheDir()
 	if err != nil {
 		return "", errors.E(op, err)

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -361,16 +361,16 @@ func (gur *GitUpstreamRepo) cacheRepo(ctx context.Context, uri string, requiredR
 	// Validate that refs and URI do not start with '-' to prevent them from
 	// being interpreted as git command-line options.
 	if strings.HasPrefix(uri, "-") {
-		return "", errors.E(op, errors.Git, fmt.Errorf("invalid git repo %q: must not start with '-'", uri))
+		return "", errors.E(op, errors.InvalidParam, fmt.Errorf("invalid git repo %q: must not start with '-'", uri))
 	}
 	for _, ref := range requiredRefs {
 		if strings.HasPrefix(ref, "-") {
-			return "", errors.E(op, errors.Git, fmt.Errorf("invalid git ref %q: must not start with '-'", ref))
+			return "", errors.E(op, errors.InvalidParam, fmt.Errorf("invalid git ref %q: must not start with '-'", ref))
 		}
 	}
 	for _, ref := range optionalRefs {
 		if strings.HasPrefix(ref, "-") {
-			return "", errors.E(op, errors.Git, fmt.Errorf("invalid git ref %q: must not start with '-'", ref))
+			return "", errors.E(op, errors.InvalidParam, fmt.Errorf("invalid git ref %q: must not start with '-'", ref))
 		}
 	}
 

--- a/internal/gitutil/gitutil_test.go
+++ b/internal/gitutil/gitutil_test.go
@@ -441,3 +441,30 @@ func toKeys(m map[string]string) []string {
 	sort.Strings(keys)
 	return keys
 }
+
+// TestGitUpstreamRepo_GetRepo_flagLikeRefRejected verifies that a ref
+// starting with '--' is rejected as invalid input.
+func TestGitUpstreamRepo_GetRepo_flagLikeRefRejected(t *testing.T) {
+	repoContent := map[string][]testutil.Content{
+		testutil.Upstream: {
+			{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithResource(pkgbuilder.DeploymentResource),
+				Branch: "main",
+			},
+		},
+	}
+
+	g, _, clean := testutil.SetupReposAndWorkspace(t, repoContent)
+	defer clean()
+
+	gur, err := internalgitutil.NewGitUpstreamRepo(fake.CtxWithDefaultPrinter(), g[testutil.Upstream].RepoDirectory)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	// A ref starting with '--' should be rejected by input validation.
+	_, err = gur.GetRepo(fake.CtxWithDefaultPrinter(), []string{"--some-invalid-ref"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must not start with '-'")
+}

--- a/pkg/lib/kptops/pkgupdate.go
+++ b/pkg/lib/kptops/pkgupdate.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The kpt Authors
+// Copyright 2022,2026 The kpt Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	kptfilev1 "github.com/kptdev/kpt/api/kptfile/v1"
 	"github.com/kptdev/kpt/pkg/kptfile/kptfileutil"
@@ -59,10 +60,16 @@ func PkgUpdate(ctx context.Context, ref string, packageDir string, _ PkgUpdateOp
 	if kf.Upstream == nil || kf.Upstream.Git == nil {
 		return fmt.Errorf("package must have an upstream reference")
 	}
+	if strings.HasPrefix(kf.Upstream.Git.Repo, "-") {
+		return fmt.Errorf("invalid git repo %q: must not start with '-'", kf.Upstream.Git.Repo)
+	}
 
 	// originalRootKfRef := rootKf.Upstream.Git.Ref
 	if ref != "" {
 		kf.Upstream.Git.Ref = ref
+	}
+	if strings.HasPrefix(kf.Upstream.Git.Ref, "-") {
+		return fmt.Errorf("invalid git ref %q: must not start with '-'", kf.Upstream.Git.Ref)
 	}
 	// if u.Strategy != "" {
 	// 	rootKf.Upstream.UpdateStrategy = u.Strategy

--- a/pkg/lib/update/update.go
+++ b/pkg/lib/update/update.go
@@ -134,9 +134,17 @@ func (u *Command) Run(ctx context.Context) error {
 		return errors.E(op, u.Pkg.UniquePath,
 			fmt.Errorf("package must have an upstream reference"))
 	}
+	if strings.HasPrefix(rootKf.Upstream.Git.Repo, "-") {
+		return errors.E(op, u.Pkg.UniquePath,
+			fmt.Errorf("invalid git repo %q: must not start with '-'", rootKf.Upstream.Git.Repo))
+	}
 	originalRootKfRef := rootKf.Upstream.Git.Ref
 	if u.Ref != "" {
 		rootKf.Upstream.Git.Ref = u.Ref
+	}
+	if strings.HasPrefix(rootKf.Upstream.Git.Ref, "-") {
+		return errors.E(op, u.Pkg.UniquePath,
+			fmt.Errorf("invalid git ref %q: must not start with '-'", rootKf.Upstream.Git.Ref))
 	}
 	if u.Strategy != "" {
 		rootKf.Upstream.UpdateStrategy = u.Strategy

--- a/pkg/lib/update/update.go
+++ b/pkg/lib/update/update.go
@@ -135,7 +135,7 @@ func (u *Command) Run(ctx context.Context) error {
 			fmt.Errorf("package must have an upstream reference"))
 	}
 	if strings.HasPrefix(rootKf.Upstream.Git.Repo, "-") {
-		return errors.E(op, u.Pkg.UniquePath,
+		return errors.E(op, u.Pkg.UniquePath, errors.InvalidParam,
 			fmt.Errorf("invalid git repo %q: must not start with '-'", rootKf.Upstream.Git.Repo))
 	}
 	originalRootKfRef := rootKf.Upstream.Git.Ref
@@ -143,7 +143,7 @@ func (u *Command) Run(ctx context.Context) error {
 		rootKf.Upstream.Git.Ref = u.Ref
 	}
 	if strings.HasPrefix(rootKf.Upstream.Git.Ref, "-") {
-		return errors.E(op, u.Pkg.UniquePath,
+		return errors.E(op, u.Pkg.UniquePath, errors.InvalidParam,
 			fmt.Errorf("invalid git ref %q: must not start with '-'", rootKf.Upstream.Git.Ref))
 	}
 	if u.Strategy != "" {

--- a/pkg/lib/util/fetch/fetch.go
+++ b/pkg/lib/util/fetch/fetch.go
@@ -82,8 +82,14 @@ func (c Command) validate(kf *kptfilev1.KptFile) error {
 	if len(g.Repo) == 0 {
 		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify repo"))
 	}
+	if strings.HasPrefix(g.Repo, "-") {
+		return errors.E(op, errors.InvalidParam, fmt.Errorf("invalid git repo %q: must not start with '-'", g.Repo))
+	}
 	if len(g.Ref) == 0 {
 		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify ref"))
+	}
+	if strings.HasPrefix(g.Ref, "-") {
+		return errors.E(op, errors.InvalidParam, fmt.Errorf("invalid git ref %q: must not start with '-'", g.Ref))
 	}
 	if len(g.Directory) == 0 {
 		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify directory"))

--- a/pkg/lib/util/get/get.go
+++ b/pkg/lib/util/get/get.go
@@ -218,8 +218,14 @@ func (c *Command) DefaultValues() error {
 	if len(g.Repo) == 0 {
 		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify repo"))
 	}
+	if strings.HasPrefix(g.Repo, "-") {
+		return errors.E(op, errors.InvalidParam, fmt.Errorf("invalid git repo %q: must not start with '-'", g.Repo))
+	}
 	if len(g.Ref) == 0 {
 		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify ref"))
+	}
+	if strings.HasPrefix(g.Ref, "-") {
+		return errors.E(op, errors.InvalidParam, fmt.Errorf("invalid git ref %q: must not start with '-'", g.Ref))
 	}
 	if len(c.Destination) == 0 {
 		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify destination"))


### PR DESCRIPTION
## Description
- What changed: Added input validation to reject git ref and repo values that start with `-` across all command entry points (`get`, `fetch`, `update`, `pkgupdate`) and in the internal `gitutil.cacheRepo` function.
- Why it's needed: A ref or repo value starting with `-` is not a valid git ref. Accepting such values leads to confusing git errors downstream. Rejecting them early provides a clear error message to the user.
- How it works: Each command's existing validation function (`DefaultValues`, `validate`, `Run`) now checks for `-` prefixes and returns an early, clear error. Additionally, `cacheRepo` in `internal/gitutil` validates all refs and URIs before executing any git commands, acting as a catch-all for all callers regardless of entry point.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Enhancement
- [ ] Refactor
- [ ] Documentation
- [x] Tests
- [ ] Other: ________

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed changes
- [x] Tests added/updated
- [ ] Documentation added/updated
- [x] All tests and gating checks pass

## AI Disclosure

- [x] **I have used AI in the creation of this PR.**

If so, please describe how:
- Kiro to trace the affected call paths, implement the fix, and generate the test.