### PR TITLE
Add possibility to skip waiting in `kpt live apply`

### DIFF
--- a/commands/live/apply/cmdapply.go
+++ b/commands/live/apply/cmdapply.go
@@ -90,6 +90,8 @@ func NewRunner(
 	c.Flags().StringVar(&r.statusPolicyString, "status-policy", "all",
 		"It determines which status information should be saved in the inventory (if compatible). Available options "+
 			fmt.Sprintf("%q and %q.", "all", "none"))
+	c.Flags().BoolVar(&r.wait, "wait", true,
+		"Whether or not to wait for the resources to be ready")
 	return r
 }
 
@@ -117,6 +119,7 @@ type Runner struct {
 	dryRun                       bool
 	printStatusEvents            bool
 	statusPolicyString           string
+	wait                         bool
 
 	inventoryPolicy inventory.Policy
 	prunePropPolicy metav1.DeletionPropagation
@@ -261,7 +264,7 @@ func runApply(r *Runner, invInfo inventory.Info, objs []*unstructured.Unstructur
 	ch := applier.Run(r.ctx, invInfo, objs, apply.ApplierOptions{
 		ServerSideOptions:      r.serverSideOptions,
 		ReconcileTimeout:       r.reconcileTimeout,
-		EmitStatusEvents:       true, // We are always waiting for reconcile.
+		EmitStatusEvents:       r.wait,
 		DryRunStrategy:         dryRunStrategy,
 		PrunePropagationPolicy: r.prunePropPolicy,
 		PruneTimeout:           r.pruneTimeout,
@@ -275,6 +278,11 @@ func runApply(r *Runner, invInfo inventory.Info, objs []*unstructured.Unstructur
 		} else {
 			fmt.Println("Dry-run strategy: client")
 		}
+	}
+
+	if !r.wait {
+		_, _ = fmt.Fprintf(r.ioStreams.Out, "Apply started in the background")
+		return nil
 	}
 
 	// The printer will print updates from the channel. It will block

--- a/e2e/testdata/live-apply/no-wait/config.yaml
+++ b/e2e/testdata/live-apply/no-wait/config.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+parallel: true
+kptArgs:
+  - "live"
+  - "apply"
+  - "--wait=false"
+stdOut: Apply started in the background

--- a/e2e/testdata/live-apply/no-wait/resources/Kptfile
+++ b/e2e/testdata/live-apply/no-wait/resources/Kptfile
@@ -1,0 +1,4 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: no-wait

--- a/e2e/testdata/live-apply/no-wait/resources/cm.yaml
+++ b/e2e/testdata/live-apply/no-wait/resources/cm.yaml
@@ -1,0 +1,21 @@
+# Copyright 2026 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+  namespace: no-wait
+data:
+  foo: "bar"

--- a/e2e/testdata/live-apply/no-wait/resources/resourcegroup.yaml
+++ b/e2e/testdata/live-apply/no-wait/resources/resourcegroup.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kpt.dev/v1alpha1
+kind: ResourceGroup
+metadata:
+  labels:
+    cli-utils.sigs.k8s.io/inventory-id: no-wait
+  name: no-wait
+  namespace: no-wait
+resources:
+  - kind: ConfigMap
+    name: cm
+    namespace: no-wait


### PR DESCRIPTION
Added a `--wait` flag so that it is possible to not wait for resources to be ready. Useful when wait conditions are not always as simple as Ready=True. The default is still `true`.

Further improvements: Add support for `kubectl wait --for=...` style wait conditions, or possibility to define such conditions in the Kptfile or resource metadata.