### PR TITLE
Fix basicpipeline-semver e2e expected output for set-labels v0.2.5

### DIFF
--- a/e2e/testdata/fn-render/basicpipeline-semver/.expected/diff.patch
+++ b/e2e/testdata/fn-render/basicpipeline-semver/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/Kptfile b/Kptfile
-index 2336da4..ca2bcea 100644
+index 2336da4..cc5a267 100644
 --- a/Kptfile
 +++ b/Kptfile
 @@ -2,13 +2,34 @@ apiVersion: kpt.dev/v1
@@ -34,7 +34,7 @@ index 2336da4..ca2bcea 100644
 +            severity: info
 +          - message: all `depends-on` annotations are up-to-date. no `namespace` changed
 +            severity: info
-+      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.4
++      - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.5
 +        exitCode: 0
 +        results:
 +          - message: set 4 labels in total


### PR DESCRIPTION
 ## Description
  - **What changed**: Updated the expected diff patch for the `basicpipeline-semver` e2e test to reflect the new resolved version of `set-labels` (`v0.2.4` → `v0.2.5`) and the corresponding git index hash.
  - **Why it's needed**: The `set-labels` function was released as `v0.2.5` in the krm-functions-catalog. Since the test uses a semver range constraint (`~0.2`), the resolved image tag now picks up `v0.2.5`, causing the e2e test to fail against the old expected output.
  - **How it works**: The expected diff patch file is updated to match the current resolved output.

 
  ## Type of Change
  - [x] Tests
  - [x] Bug fix

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [x] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass


  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to generate the PR message.