### PR TITLE
porch docs navbar redirect

### DIFF
--- a/documentation/config.toml
+++ b/documentation/config.toml
@@ -185,6 +185,6 @@ target = "_self"
 
 [[menu.main]]
 name = "Porch"
-url = "https://porch.kpt.dev/"
+url = "https://porch.kpt.dev/docs/"
 weight = 50
 target = "_self"


### PR DESCRIPTION
Description: the porch navbar menu will redirect to the porch documentation directly rather than to the porch main menu.

Motivation: its the natural expectation to be redirected to the porch docs not the porch header page.

No AI was used / required.

Linked with https://github.com/kptdev/porch/pull/1087 & https://github.com/kptdev/krm-functions-catalog/pull/1270