### PR TITLE
Docs: Fix broken download links

### DIFF
--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -16,14 +16,14 @@ production-build:
 	git submodule update --init --recursive
 	git fetch --tags
 	hugo version
-	HUGO_KPT_VERSION=$$(git describe --tags --abbrev=0 2>/dev/null || true) hugo \
+	HUGO_KPT_VERSION=$$(git describe --tags --abbrev=0 --match='v[0-9]*' 2>/dev/null || true) hugo \
 		--minify
 	npx -y pagefind --site public
 
 preview-build:
 	git submodule update --init --recursive
 	git fetch --tags
-	HUGO_KPT_VERSION=$$(git describe --tags --abbrev=0 2>/dev/null || true) hugo \
+	HUGO_KPT_VERSION=$$(git describe --tags --abbrev=0 --match='v[0-9]*' 2>/dev/null || true) hugo \
 		--baseURL $(DEPLOY_PRIME_URL) \
 		--buildDrafts \
 		--buildFuture \

--- a/documentation/content/en/reference/schema/function-result-list/_index.md
+++ b/documentation/content/en/reference/schema/function-result-list/_index.md
@@ -10,4 +10,4 @@ menu:
 
 
 See the
-[definition here](https://github.com/kptdev/kpt/blob/next/pkg/api/fnresult/v1/types.go#L50)
+[definition here](https://github.com/kptdev/kpt/blob/main/api/fnresult/v1/types.go#L51)


### PR DESCRIPTION
## Description
Add `--match='v[0-9]*'` to `git describe` in the documentation Makefile to ensure only CLI release tags are used when resolving the kpt version for download links.

## Motivation
The recent release of `api/v0.0.2` caused `git describe --tags --abbrev=0` to return `api/v0.0.2` instead of the latest CLI release tag (e.g. `v1.0.0-beta.65.1`).  The `--match='v[0-9]*'` filter excludes Go module sub-path tags (`api/*`,
  `porch/*`, etc.) which follow standard Go module versioning conventions and
  will never be CLI release tags.

  Fixes #4623

## AI Usage Disclosure
- [x] Kiro has been used to draft PR message.