### PR TITLE
Fix go-releaser, migrate away from deprecations

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,8 +23,8 @@ on:
       - "firebase/**"
       - "logo/**"
       - "package-examples/**"
-      - "release/images/**"
-      - "release/tag/**"
+#      - "release/images/**"
+#      - "release/tag/**"
       - "site/**"
       - "**.md"
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ public/
 
 # Build directory
 .build/
+dist/

--- a/release/images/Dockerfile
+++ b/release/images/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2019 The kpt Authors
+# Copyright 2019,2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine
+FROM alpine:3
 ARG TARGETPLATFORM
 RUN apk update && apk upgrade && \
     apk add --no-cache git less mandoc diffutils bash openssh docker-cli && \

--- a/release/images/Dockerfile
+++ b/release/images/Dockerfile
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.18
+FROM alpine
+ARG TARGETPLATFORM
 RUN apk update && apk upgrade && \
     apk add --no-cache git less mandoc diffutils bash openssh docker-cli && \
     rm -rf /var/lib/apt/lists/* && \
     rm /var/cache/apk/*
-# This is set up for the Dockerfile to be used by goreleaser: https://goreleaser.com/customization/docker/
-COPY kpt /usr/local/bin/kpt
+# This is set up for the Dockerfile to be used by goreleaser: https://goreleaser.com/customization/package/dockers_v2/
+COPY ${TARGETPLATFORM}/kpt /usr/local/bin/kpt
 ENTRYPOINT ["kpt"]

--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -67,7 +67,7 @@ builds:
 dockers_v2:
   - ids:
       - linux-amd64
-      - linux-arm64
+#      - linux-arm64 # TODO: set this up correctly
     images:
       - ghcr.io/kptdev/kpt
     tags:
@@ -75,7 +75,7 @@ dockers_v2:
     dockerfile: release/images/Dockerfile
     platforms:
       - linux/amd64
-      - linux/arm64
+#      - linux/arm64 # TODO: set this up correctly
     labels:
       org.opencontainers.image.title: "{{ .ProjectName }}"
       org.opencontainers.image.description: "kpt - Automate Kubernetes Configuration Editing"

--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -67,6 +67,7 @@ builds:
 dockers_v2:
   - ids:
       - linux-amd64
+      - linux-arm64
     images:
       - ghcr.io/kptdev/kpt
     tags:
@@ -74,6 +75,7 @@ dockers_v2:
     dockerfile: release/images/Dockerfile
     platforms:
       - linux/amd64
+      - linux/arm64
     labels:
       org.opencontainers.image.title: "{{ .ProjectName }}"
       org.opencontainers.image.description: "kpt - Automate Kubernetes Configuration Editing"

--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 The kpt Authors
+# Copyright 2019,2026 The kpt Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -64,23 +64,27 @@ builds:
       - arm64
     ldflags: -s -w -X github.com/kptdev/kpt/run.version={{.Version}} -extldflags "-z noexecstack"
 
-dockers:
+dockers_v2:
   - ids:
       - linux-amd64
-    image_templates:
-      - "ghcr.io/kptdev/kpt:{{ .Tag }}"
-    dockerfile: "release/images/Dockerfile"
-    build_flag_templates:
-      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-      - "--label=org.opencontainers.image.description=kpt - Automate Kubernetes Configuration Editing"
-      - "--label=org.opencontainers.image.url=https://github.com/{{ envOrDefault \"GITHUB_REPOSITORY\" \"kptdev/kpt\" }}"
-      - "--label=org.opencontainers.image.source=https://github.com/{{ envOrDefault \"GITHUB_REPOSITORY\" \"kptdev/kpt\" }}"
-      - "--label=org.opencontainers.image.version={{ .Tag }}"
-      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.created={{ .Date }}"
+    images:
+      - ghcr.io/kptdev/kpt
+    tags:
+      - "{{ .Tag }}"
+    dockerfile: release/images/Dockerfile
+    platforms:
+      - linux/amd64
+    labels:
+      org.opencontainers.image.title: "{{ .ProjectName }}"
+      org.opencontainers.image.description: "kpt - Automate Kubernetes Configuration Editing"
+      org.opencontainers.image.url: "https://github.com/{{ envOrDefault \"GITHUB_REPOSITORY\" \"kptdev/kpt\" }}"
+      org.opencontainers.image.source: "https://github.com/{{ envOrDefault \"GITHUB_REPOSITORY\" \"kptdev/kpt\" }}"
+      org.opencontainers.image.version: "{{ .Tag }}"
+      org.opencontainers.image.revision: "{{ .FullCommit }}"
+      org.opencontainers.image.created: "{{ .Date }}"
 archives:
   - id: archived
-    builds:
+    ids:
       - darwin-amd64
       - darwin-arm64
       - linux-amd64
@@ -90,8 +94,8 @@ archives:
       - lib.zip*
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}-{{ .Version }}"
   - id: bin-only
-    format: binary
-    builds:
+    formats: binary
+    ids:
       - darwin-amd64
       - darwin-arm64
       - linux-amd64
@@ -100,7 +104,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "master"
+  version_template: "master"
 changelog:
   sort: asc
   filters:

--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -73,11 +73,11 @@ dockers:
     build_flag_templates:
       - "--label=org.opencontainers.image.title={{ .ProjectName }}"
       - "--label=org.opencontainers.image.description=kpt - Automate Kubernetes Configuration Editing"
-      - "--label=org.opencontainers.image.url=https://github.com/{{ .Env.GITHUB_REPOSITORY | default \"kptdev/kpt\" }}"
-      - "--label=org.opencontainers.image.source=https://github.com/{{ .Env.GITHUB_REPOSITORY | default \"kptdev/kpt\" }}"
+      - "--label=org.opencontainers.image.url=https://github.com/{{ envOrDefault \"GITHUB_REPOSITORY\" \"kptdev/kpt\" }}"
+      - "--label=org.opencontainers.image.source=https://github.com/{{ envOrDefault \"GITHUB_REPOSITORY\" \"kptdev/kpt\" }}"
       - "--label=org.opencontainers.image.version={{ .Tag }}"
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-      - "--label=org.opencontainers.image.created={{ now | date \"2006-01-02T15:04:05Z07:00\" }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
 archives:
   - id: archived
     builds:


### PR DESCRIPTION
The kpt-release action is currently failing, caused by incorrect go template functions. This PR fixes that, plus migrates the go-releaser file to use `dockers_v2` instead of the deprecated `dockers`.

~~Also added the publishing of linux-arm64 images, we can discuss if we actually need that.~~

Building the arm images requires QEMU or some other setup, we can do that later.

Cursor composer-2.5 was used for the migration from dockers -> dockers_v2