### PR TITLE
chore: regenerate CLI docs from markdown sources

### DIFF
--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -81,9 +81,17 @@ Flags:
   
   --image, i:
     Container image of the function to execute e.g. ` + "`" + `ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest` + "`" + `.
-    For convenience, if full image path is not specified, ` + "`" + `ghcr.io/kptdev/krm-functions-catalog/` + "`" + ` is added as default prefix.
+    For convenience, if full image path is not specified, a default prefix is added.
+    The default prefix is ` + "`" + `ghcr.io/kptdev/krm-functions-catalog/` + "`" + `, but can be customized via the
+    ` + "`" + `--image-prefix` + "`" + ` flag or ` + "`" + `KPT_IMAGE_PREFIX` + "`" + ` environment variable.
     e.g. instead of passing ` + "`" + `ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest` + "`" + ` you can pass ` + "`" + `set-namespace:latest` + "`" + `.
     ` + "`" + `eval` + "`" + ` executes only one function, so do not use ` + "`" + `--exec` + "`" + ` flag with this flag.
+  
+  --image-prefix:
+    The container registry prefix to prepend to short image names when resolving functions.
+    This allows customization of the default registry instead of using the hardcoded default
+    (` + "`" + `ghcr.io/kptdev/krm-functions-catalog` + "`" + `). Can also be set via the KPT_IMAGE_PREFIX environment
+    variable. The command-line flag takes precedence over the environment variable.
   
   --image-pull-policy:
     If the image should be pulled before rendering the package(s). It can be set
@@ -155,6 +163,10 @@ Flags:
 
 Environment Variables:
 
+  KPT_IMAGE_PREFIX:
+    The default container registry prefix to use when resolving short image names.
+    This can be overridden by the --image-prefix flag.
+  
   KRM_FN_RUNTIME:
     The runtime to run kpt functions. It must be one of "docker", "podman" and "nerdctl".
 `
@@ -252,6 +264,9 @@ Flags:
   --allow-network:
     Allow functions to access network during pipeline execution. Default: ` + "`" + `false` + "`" + `. Note that this is applicable to container based functions only.
   
+  --image-prefix:
+    The container registry prefix to prepend to short image names when resolving functions. This allows customization of the default registry instead of using the hardcoded default (` + "`" + `ghcr.io/kptdev/krm-functions-catalog` + "`" + `). Can also be set via the KPT_IMAGE_PREFIX environment variable. The command-line flag takes precedence over the environment variable.
+  
   --image-pull-policy:
     If the image should be pulled before rendering the package(s). It can be set
     to one of always, ifNotPresent, never. If unspecified, always will be the
@@ -284,6 +299,9 @@ Kptfile Annotations:
 
 Environment Variables:
 
+  KPT_IMAGE_PREFIX:
+    The default container registry prefix to use when resolving short image names. This can be overridden by the --image-prefix flag.
+  
   KRM_FN_RUNTIME:
     The runtime to run kpt functions. It must be one of "docker", "podman" and "nerdctl".
 `

--- a/internal/docs/generated/pkgdocs/docs.go
+++ b/internal/docs/generated/pkgdocs/docs.go
@@ -7,22 +7,27 @@ The ` + "`" + `pkg` + "`" + ` command group contains subcommands for fetching, u
 from git repositories.
 `
 
-var CatShort = `Print the resources in a file/directory`
+var CatShort = `Print the contents of a package`
 var CatLong = `
   kpt pkg cat [FILE | DIR]
 
 Args:
 
   FILE | DIR:
-    Path to a directory either a directory containing files with KRM resources, or
-    a file with KRM resource(s). Defaults to the current directory.
+    Path to a file or a directory containing a kpt package. Displays all
+    package files: KRM resources (YAML/JSON) are formatted by default,
+    and non-KRM text files (e.g., README.md) are shown as raw content.
+    Binary files are skipped. Defaults to the current directory.
 `
 var CatExamples = `
-  # Print resource from a file.
+  # Print all package contents from current directory.
+  $ kpt pkg cat
+
+  # Print a single resource file.
   $ kpt pkg cat path/to/deployment.yaml
 
-  # Print resources from current directory.
-  $ kpt pkg cat
+  # Print a non-KRM file.
+  $ kpt pkg cat path/to/README.md
 `
 
 var DiffShort = `Show differences between a local package and upstream.`
@@ -206,13 +211,6 @@ var InitExamples = `
 var TreeShort = `Display resources, files and packages in a tree structure.`
 var TreeLong = `
   kpt pkg tree [DIR]
-
-Args:
-
-  DIR:
-    Path to a local package directory. Defaults to the current directory.
-    Displays KRM resources with their Kind and Name, and non-KRM text files
-    as plain filenames. Dotfiles and symlinks are excluded.
 `
 var TreeExamples = `
   # Show resources in the current directory.


### PR DESCRIPTION
 ## Description
  - **What changed**: Regenerated `internal/docs/generated/fndocs/docs.go` and `internal/docs/generated/pkgdocs/docs.go` via `make generate`.
  
  ## Type of Change
  - [x] Documentation

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure
  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to generate PR message