### PR TITLE
Show meaningful paths in kpt pkg diff output

### DIFF
--- a/pkg/lib/pkg/diff/diff.go
+++ b/pkg/lib/pkg/diff/diff.go
@@ -298,10 +298,11 @@ func (d *defaultPkgDiffer) Diff(pkgs ...string) error {
 	}
 	cmd := exec.Command(d.DiffTool, args...)
 
-	// Capture output so we can replace temp paths with meaningful ones
+	// Capture stdout so we can replace temp paths with meaningful ones.
+	// Stderr goes directly to output since it won't contain staging paths.
 	var buf bytes.Buffer
 	cmd.Stdout = &buf
-	cmd.Stderr = &buf
+	cmd.Stderr = d.Output
 
 	if d.Debug {
 		fmt.Fprintf(d.Output, "%s\n", strings.Join(cmd.Args, " "))

--- a/pkg/lib/pkg/diff/diff.go
+++ b/pkg/lib/pkg/diff/diff.go
@@ -16,6 +16,7 @@
 package diff
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -245,6 +246,7 @@ func (c *Command) DefaultValues() {
 			DiffToolOpts: c.DiffToolOpts,
 			Debug:        c.Debug,
 			Output:       c.Output,
+			LocalPath:    c.Path,
 		}
 	}
 }
@@ -271,6 +273,10 @@ type defaultPkgDiffer struct {
 	// Output is an io.Writer where command will write the output of the
 	// command.
 	Output io.Writer
+
+	// LocalPath is the original local package path on the user's filesystem.
+	// Used to replace temp staging paths in diff output with the real path.
+	LocalPath string
 }
 
 func (d *defaultPkgDiffer) Diff(pkgs ...string) error {
@@ -278,8 +284,8 @@ func (d *defaultPkgDiffer) Diff(pkgs ...string) error {
 	if err := addmergecomment.Process(pkgs...); err != nil {
 		return err
 	}
-	for _, pkg := range pkgs {
-		if err := d.prepareForDiff(pkg); err != nil {
+	for _, pkgPath := range pkgs {
+		if err := d.prepareForDiff(pkgPath); err != nil {
 			return err
 		}
 	}
@@ -291,8 +297,11 @@ func (d *defaultPkgDiffer) Diff(pkgs ...string) error {
 		args = pkgs
 	}
 	cmd := exec.Command(d.DiffTool, args...)
-	cmd.Stdout = d.Output
-	cmd.Stderr = d.Output
+
+	// Capture output so we can replace temp paths with meaningful ones
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
 
 	if d.Debug {
 		fmt.Fprintf(d.Output, "%s\n", strings.Join(cmd.Args, " "))
@@ -310,6 +319,21 @@ func (d *defaultPkgDiffer) Diff(pkgs ...string) error {
 			fmt.Printf(exitCodeDiffWarning, d.DiffTool, d.DiffType)
 		}
 	}
+
+	// Replace temp staging paths with meaningful ones in the output.
+	// The local staging path is replaced with the real filesystem path.
+	// Remote staging paths are replaced with their semantic directory name.
+	output := buf.String()
+	for _, stagingPath := range pkgs {
+		name := filepath.Base(stagingPath)
+		if d.LocalPath != "" && strings.HasPrefix(name, LocalPackageSource+"-") {
+			output = strings.ReplaceAll(output, stagingPath, d.LocalPath)
+		} else {
+			output = strings.ReplaceAll(output, stagingPath, name)
+		}
+	}
+	fmt.Fprint(d.Output, output)
+
 	return err
 }
 

--- a/pkg/lib/pkg/diff/diff_test.go
+++ b/pkg/lib/pkg/diff/diff_test.go
@@ -503,3 +503,85 @@ func TestStagingDirectoryNames(t *testing.T) {
 		})
 	}
 }
+
+// TestCommand_DiffOutputPaths verifies that diff output shows meaningful paths
+// instead of raw temp directory paths (https://github.com/kptdev/kpt/issues/591).
+func TestCommand_DiffOutputPaths(t *testing.T) {
+	g := &testutil.TestSetupManager{
+		T: t,
+		ReposChanges: map[string][]testutil.Content{
+			testutil.Upstream: {
+				{
+					Pkg: pkgbuilder.NewRootPkg().
+						WithResource(pkgbuilder.DeploymentResource),
+					Branch: "main",
+					Tag:    "v1",
+				},
+				{
+					Pkg: pkgbuilder.NewRootPkg().
+						WithResource(pkgbuilder.DeploymentResource,
+							pkgbuilder.SetFieldPath("5", "spec", "replicas")),
+				},
+			},
+		},
+		GetRef: "v1",
+		LocalChanges: []testutil.Content{
+			{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile(
+						pkgbuilder.NewKptfile().
+							WithUpstreamRef(testutil.Upstream, "/", "v1", "resource-merge").
+							WithUpstreamLockRef(testutil.Upstream, "/", "v1", 0),
+					).
+					WithResource(pkgbuilder.DeploymentResource,
+						pkgbuilder.SetFieldPath("10", "spec", "replicas")),
+			},
+		},
+	}
+	defer g.Clean()
+	if !g.Init() {
+		return
+	}
+
+	localPath := g.LocalWorkspace.FullPackagePath()
+
+	tests := []struct {
+		name       string
+		diffType   diff.Type
+		diffTool   string
+		wantLocal  bool
+		wantLabels []string
+	}{
+		{"local", diff.TypeLocal, "diff", true, []string{"remote-v1/"}},
+		{"remote", diff.TypeRemote, "diff", false, []string{"remote-v1/", "target-main/"}},
+		{"combined", diff.TypeCombined, "diff", true, []string{"target-main/"}},
+		{"3way", diff.Type3Way, "echo", true, []string{"remote-v1", "target-main"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			diffToolOpts := "-r -i -w"
+			if tt.diffTool == "echo" {
+				diffToolOpts = ""
+			}
+			err := (&diff.Command{
+				Path:         localPath,
+				Ref:          "main",
+				DiffType:     tt.diffType,
+				DiffTool:     tt.diffTool,
+				DiffToolOpts: diffToolOpts,
+				Output:       &out,
+			}).Run(fake.CtxWithDefaultPrinter())
+			assert.NoError(t, err)
+
+			output := out.String()
+			if tt.wantLocal {
+				assert.Contains(t, output, localPath)
+			}
+			for _, label := range tt.wantLabels {
+				assert.Contains(t, output, label)
+			}
+		})
+	}
+}

--- a/pkg/lib/pkg/diff/diff_test.go
+++ b/pkg/lib/pkg/diff/diff_test.go
@@ -505,7 +505,6 @@ func TestStagingDirectoryNames(t *testing.T) {
 }
 
 // TestCommand_DiffOutputPaths verifies that diff output shows meaningful paths
-// instead of raw temp directory paths (https://github.com/kptdev/kpt/issues/591).
 func TestCommand_DiffOutputPaths(t *testing.T) {
 	g := &testutil.TestSetupManager{
 		T: t,
@@ -582,6 +581,8 @@ func TestCommand_DiffOutputPaths(t *testing.T) {
 			for _, label := range tt.wantLabels {
 				assert.Contains(t, output, label)
 			}
+			// Verify temp staging directory prefix is not in the output
+			assert.NotRegexp(t, regexp.MustCompile(`/kpt-[^/\s]+/(local|remote|target)-`), output)
 		})
 	}
 }


### PR DESCRIPTION
 ## Description
  - **What changed**: `kpt pkg diff` output now shows the real local package path and semantic upstream labels instead of raw temp directory paths that no longer exist after the command completes.
  - **Why it's needed**: The temp paths (e.g. `/tmp/kpt-941888986/local-v0.9/deploy.yaml`) are meaningless and not actionable. The directories are deleted before the user sees the output.
  - **How it works**: The diff tool output is captured to a buffer. Before writing to the user, staging paths are replaced: the local staging path (`local-<ref>`) becomes the real filesystem path, and remote staging paths (`remote-<ref>`, `target-<ref>`) are stripped to just their semantic directory name.
     - Before: `diff -r /tmp/kpt-941888986/local-v0.9/deploy.yaml /tmp/kpt-941888986/remote-v0.9/deploy.yaml`
     - After: `diff -r /home/user/my-package/deploy.yaml remote-v0.9/deploy.yaml`

  ## Related Issue(s)
  - Fixes #591

  ## Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [x] Enhancement
  - [ ] Refactor
  - [ ] Documentation
  - [x] Tests
  - [ ] Other: ________

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [x] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to analyse the issue, help in the fix, write the unit test and PR message.