### PR TITLE
Remove dead --keywords/-k flag from kpt fn eval

### DIFF
--- a/documentation/content/en/guides/namespace-provisioning-cli.md
+++ b/documentation/content/en/guides/namespace-provisioning-cli.md
@@ -162,14 +162,14 @@ that can be used to ensure all resources in a package use the same namespace.
 ```shell
 # You should be under the "./blueprint/basens" directory.
 # Make sure you have kpt autocomplete enabled.
-# How it works: 
+# How it works:
 # Reset your brain, assume you do not know how to use `kpt fn eval`, the goal
 # is to find and add a "namespace" function.
 # Press the keyboard key `tab` or `tab tab` after each flag `--type`,
-# `--keywords`, `--image`, `--fn-config` to see available choices, click `tab`
-# to autocomplete your choice or to see further options. 
+# `--image`, `--fn-config` to see available choices, click `tab`
+# to autocomplete your choice or to see further options.
 
-$ kpt fn eval --type mutator --keywords namespace --image set-namespace:latest --fn-config package-context.yaml
+$ kpt fn eval --type mutator --image set-namespace:latest --fn-config package-context.yaml
 [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
 [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 600ms
   Results:

--- a/pkg/lib/util/cmdutil/cmdutil.go
+++ b/pkg/lib/util/cmdutil/cmdutil.go
@@ -114,21 +114,6 @@ func CheckDirectoryNotPresent(outDir string) error {
 	return nil
 }
 
-func GetKeywordsFromFlag(cmd *cobra.Command) []string {
-	flagVal := cmd.Flag("keywords").Value.String()
-	flagVal = strings.TrimPrefix(flagVal, "[")
-	flagVal = strings.TrimSuffix(flagVal, "]")
-	splitted := strings.Split(flagVal, ",")
-	var trimmed []string
-	for _, val := range splitted {
-		if strings.TrimSpace(val) == "" {
-			continue
-		}
-		trimmed = append(trimmed, strings.TrimSpace(val))
-	}
-	return trimmed
-}
-
 // InstallResourceGroupCRD will install the ResourceGroup CRD into the cluster.
 // The function will block until the CRD is either installed and established, or
 // an error was encountered.

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
@@ -55,8 +55,6 @@ func GetEvalFnRunner(ctx context.Context, parent string) *EvalFnRunner {
 		&r.Image, "image", "i", "", "run this image as a function")
 	r.Command.Flags().StringVar(
 		&r.Tag, "tag", "", "semantic version constraint for the image tag or exact tag replacement")
-	r.Command.Flags().StringArrayVarP(
-		&r.Keywords, "keywords", "k", nil, "filter functions that match one or more keywords")
 	r.Command.Flags().StringVarP(&r.FnType, "type", "t", "",
 		"`mutator` (default) or `validator`. tell the function type for autocompletion and `--save` flag")
 	_ = r.Command.RegisterFlagCompletionFunc("type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -141,7 +139,6 @@ type EvalFnRunner struct {
 	Image                string
 	Tag                  string
 	SaveFn               bool
-	Keywords             []string
 	FnType               string
 	Exec                 string
 	FnConfigPath         string


### PR DESCRIPTION
## Description
  - **What changed**: Removed the orphaned `--keywords/-k` flag from `kpt fn eval`, its `Keywords []string` struct field, and the unused `GetKeywordsFromFlag()` helper. Updated the `namespace-provisioning-cli` guide to remove stale `--keywords` references.
  - **Why it's needed**: The flag was left behind as dead code when https://github.com/kptdev/kpt/pull/4355 removed the Porch dependency from kpt. It was originally introduced in https://github.com/kptdev/kpt/pull/2980 for shell tab-completion only (filtering Porch function catalog suggestions via `SuggestFunctions()` and `SuggestKeywords()`). The flag was never consumed at runtime and passing it had no effect on function execution.
  - **How it works**: Removes the flag registration, struct field, and helper function. No behavioral change other than the flag no longer appearing in `kpt fn eval --help`.

  ## Type of Change
  - [x] Refactor
  - [x] Documentation

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [x] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to analyse the flag's history, and generate the PR message.