### PR TITLE
Add upstream push protection to go-upgrade script

### DIFF
--- a/scripts/go-upgrade/README.md
+++ b/scripts/go-upgrade/README.md
@@ -58,6 +58,7 @@ krm-functions-sdk  (leaf — no upstream deps)
 | `--repo=NAME` | Scope to a single repository |
 | `--continue` | Don't fail-fast; accumulate errors and report at end |
 | `--push` | After successful operations, create branch, commit, push, and raise draft PR |
+| `--force`, `-f` | Override upstream push protection (allows push when `FORK_OWNER` is `kptdev`) |
 | `--for=CMD` | With `push` subcommand: specify which upgrade was done (default: `all`) |
 
 ## Configuration
@@ -68,12 +69,18 @@ Edit `config.env` to change target versions, repositories, or exclusions.
 
 The `FORK_OWNER` variable controls which GitHub org/user to clone from. All repo URLs are derived from it. Defaults to `Nordix` (shared development forks). PRs always target upstream `kptdev/*` regardless of fork owner.
 
+If `FORK_OWNER` is set to `kptdev`, the script will refuse to push branches to prevent accidental upstream modifications. Use `--force` to override this protection.
+
 ```bash
 # Use your personal fork
 FORK_OWNER=myuser ./upgrade.sh go-version
 
 # Default: uses Nordix forks
 ./upgrade.sh go-version
+
+# Push to kptdev (blocked by default)
+FORK_OWNER=kptdev ./upgrade.sh all --push        # ← blocked
+FORK_OWNER=kptdev ./upgrade.sh all --push --force # ← allowed
 ```
 
 ### Target Versions

--- a/scripts/go-upgrade/README.md
+++ b/scripts/go-upgrade/README.md
@@ -58,7 +58,7 @@ krm-functions-sdk  (leaf — no upstream deps)
 | `--repo=NAME` | Scope to a single repository |
 | `--continue` | Don't fail-fast; accumulate errors and report at end |
 | `--push` | After successful operations, create branch, commit, push, and raise draft PR |
-| `--force`, `-f` | Override upstream push protection (allows push when `FORK_OWNER` is `kptdev`) |
+| `--force`, `-f` | Override upstream push protection (allows push to `kptdev`) |
 | `--for=CMD` | With `push` subcommand: specify which upgrade was done (default: `all`) |
 
 ## Configuration
@@ -69,7 +69,7 @@ Edit `config.env` to change target versions, repositories, or exclusions.
 
 The `FORK_OWNER` variable controls which GitHub org/user to clone from. All repo URLs are derived from it. Defaults to `Nordix` (shared development forks). PRs always target upstream `kptdev/*` regardless of fork owner.
 
-If `FORK_OWNER` is set to `kptdev`, the script will refuse to push branches to prevent accidental upstream modifications. Use `--force` to override this protection.
+If `FORK_OWNER` is set to `kptdev`, the script will refuse to push branches to prevent accidental upstream modifications. The check also inspects the actual `origin` remote URL of the cloned workspace, so it catches stale workspaces previously cloned from upstream even if `FORK_OWNER` has since changed. Use `--force` to override this protection.
 
 ```bash
 # Use your personal fork

--- a/scripts/go-upgrade/lib/push.sh
+++ b/scripts/go-upgrade/lib/push.sh
@@ -137,7 +137,13 @@ Automated via go-upgrade script (AI-assisted development)."
 
     log "  committed: ${branch_name}"
 
-    # Push
+    # Push — protect against accidental pushes to upstream
+    if [[ "$FORK_OWNER" == "kptdev" && "${FORCE:-false}" != true ]]; then
+      err "  ${name}: refusing to push to upstream org 'kptdev'. Use --force to override."
+      record_failure "push blocked: ${name} (FORK_OWNER is 'kptdev')"
+      continue
+    fi
+
     if ! (cd "$dir" && git push -u origin "$branch_name" 2>&1); then
       record_failure "push: ${name}"
       continue

--- a/scripts/go-upgrade/lib/push.sh
+++ b/scripts/go-upgrade/lib/push.sh
@@ -138,9 +138,12 @@ Automated via go-upgrade script (AI-assisted development)."
     log "  committed: ${branch_name}"
 
     # Push — protect against accidental pushes to upstream
-    if [[ "$FORK_OWNER" == "kptdev" && "${FORCE:-false}" != true ]]; then
-      err "  ${name}: refusing to push to upstream org 'kptdev'. Use --force to override."
-      record_failure "push blocked: ${name} (FORK_OWNER is 'kptdev')"
+    local origin_url origin_owner
+    origin_url=$(cd "$dir" && (git remote get-url --push origin 2>/dev/null || git remote get-url origin))
+    origin_owner=$(echo "$origin_url" | sed -E 's|.*[:/]([^/]+)/[^/]+(\.git)?$|\1|')
+    if [[ ("$FORK_OWNER" == "kptdev" || "$origin_owner" == "kptdev") && "${FORCE:-false}" != true ]]; then
+      err "  ${name}: refusing to push to upstream org 'kptdev' (FORK_OWNER=${FORK_OWNER}, origin owner=${origin_owner}). Use --force to override."
+      record_failure "push blocked: ${name} (upstream protection)"
       continue
     fi
 
@@ -158,8 +161,7 @@ Automated via go-upgrade script (AI-assisted development)."
     fi
 
     # Determine head ref and repository IDs for cross-fork PR
-    local origin_repo
-    origin_repo=$(cd "$dir" && git remote get-url origin | sed -E 's|.*[:/]([^/]+/[^/]+)\.git$|\1|')
+    local origin_repo="${origin_owner}/$(echo "$origin_url" | sed -E 's|.*[:/][^/]+/||; s|\.git$||')"
 
     log "  PR: ${origin_repo}:${branch_name} → ${target}:${base_branch}"
     log "  commits ahead: $(cd "$dir" && git log --oneline "origin/${base_branch}..HEAD" | wc -l)"
@@ -170,7 +172,6 @@ Automated via go-upgrade script (AI-assisted development)."
     # Use GraphQL mutation with headRepositoryId for reliable cross-fork PRs
     local target_owner="${target%%/*}"
     local target_name="${target##*/}"
-    local origin_owner="${origin_repo%%/*}"
     local origin_name="${origin_repo##*/}"
 
     local target_repo_id origin_repo_id

--- a/scripts/go-upgrade/upgrade.sh
+++ b/scripts/go-upgrade/upgrade.sh
@@ -63,7 +63,7 @@ Options:
   --repo=NAME   Run only against the specified repository
   --continue    Don't fail-fast; accumulate errors and report at end
   --push        After operations, create branch, commit, push, and raise PR
-  --force, -f   Override upstream push protection (allows push when FORK_OWNER is kptdev)
+  --force, -f   Override upstream push protection (allows push to kptdev)
   --for=CMD     With 'push' subcommand: specify which upgrade was done
                 (go-version, lint-version, cross-deps, generate-docs, all). Default: all
 

--- a/scripts/go-upgrade/upgrade.sh
+++ b/scripts/go-upgrade/upgrade.sh
@@ -41,6 +41,7 @@ source "${SCRIPT_DIR}/lib/push.sh"
 # --- Options ---
 FAIL_FAST=true
 GIT_PUSH=false
+FORCE=false
 FILTER_REPO=""
 SUBCOMMAND=""
 PUSH_FOR=""
@@ -62,6 +63,7 @@ Options:
   --repo=NAME   Run only against the specified repository
   --continue    Don't fail-fast; accumulate errors and report at end
   --push        After operations, create branch, commit, push, and raise PR
+  --force, -f   Override upstream push protection (allows push when FORK_OWNER is kptdev)
   --for=CMD     With 'push' subcommand: specify which upgrade was done
                 (go-version, lint-version, cross-deps, generate-docs, all). Default: all
 
@@ -90,6 +92,8 @@ parse_args() {
         FAIL_FAST=false ;;
       --push)
         GIT_PUSH=true ;;
+      --force|-f)
+        FORCE=true ;;
       --for=*)
         PUSH_FOR="${arg#--for=}" ;;
       --repo=*)
@@ -143,6 +147,7 @@ main() {
   log "Target golangci-lint: ${TARGET_GOLANGCI_LINT_VERSION}"
   log "Fork owner: ${FORK_OWNER}"
   if [[ "$GIT_PUSH" == true ]]; then log "Mode: push enabled"; fi
+  if [[ "$FORCE" == true ]]; then log "Mode: force (upstream push protection overridden)"; fi
   if [[ -n "$FILTER_REPO" ]]; then log "Repo filter: ${FILTER_REPO}"; fi
   echo ""
 


### PR DESCRIPTION
## Description
  - **What changed**: Added a safety check in the `go-upgrade` push flow that blocks pushing branches when `FORK_OWNER` is set to `kptdev` (upstream org), preventing accidental modifications to upstream repositories.
  - **Why it's needed**: If someone configures `FORK_OWNER=kptdev` (intentionally or accidentally), the script would push branches directly to the upstream repos. This adds a guardrail with a `--force` (or `-f`) flag to override when intentional.
  - **How it works**: Before `git push` in `cmd_push()`, the script checks if `FORK_OWNER == "kptdev"`. If so, it refuses to push and records a failure unless `--force` is passed.

  ## Changes

  - `scripts/go-upgrade/lib/push.sh`: Added upstream protection check before `git push`
  - `scripts/go-upgrade/upgrade.sh`: Added `FORCE` option variable, `--force|-f` arg parsing, usage text, and startup logging
  - `scripts/go-upgrade/README.md`: Updated Options table and Fork Owner section with protection docs and examples

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**