### PR TITLE
Docs: fix broken links and spelling mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The kpt toolchain includes the following components:
   be used to create functions to transform and/or validate the YAML KRM input/output format, but we provide SDKs to
   simplify the function authoring process in [Go](https://kpt.dev/book/05-developing-functions/#developing-in-Go).
 
-- [**Function catalog**](https://github.com/kptdev/krm-functions-catalog): A [catalog](https://catalog.kpt.dev/function-catalog) of
+- [**Function catalog**](https://github.com/kptdev/krm-functions-catalog): A [catalog](https://catalog.kpt.dev) of
   off-the-shelf, tested functions. kpt makes configuration easy to create and transform, via reusable functions. Because
   they are expected to be used for in-place transformation, the functions need to be idempotent.
 

--- a/documentation/content/en/_index.md
+++ b/documentation/content/en/_index.md
@@ -45,7 +45,7 @@ kpt is an open source project and anyone can [contribute](https://github.com/kpt
 # For users
 
 To get familiar with kpt, the best way to start is with the first 4 chapters of the kpt [Book]({{< relref "book" >}}).
-Furthermore it is useful to check the [references]({{< relref "reference" >}}) and the catalog of [selected krm functions](https://catalog.kpt.dev/function-catalog).
+Furthermore it is useful to check the [references]({{< relref "reference" >}}) and the catalog of [selected krm functions](https://catalog.kpt.dev).
 
 Use our [public Dosu space](https://github.dosu.com/kptdev/kpt) to ask anything about kpt.
 

--- a/documentation/content/en/book/02-concepts/_index.md
+++ b/documentation/content/en/book/02-concepts/_index.md
@@ -63,7 +63,7 @@ The kpt toolchain includes the following components:
  and/or validate the YAML KRM input/output format, but we provide SDKs to simplify the function authoring process, in 
   [Go](../05-developing-functions/#developing-in-Go). 
 
-- [**Function catalog**](https://catalog.kpt.dev/function-catalog): A catalog of off-the-shelf, tested functions. kpt makes
+- [**Function catalog**](https://catalog.kpt.dev): A catalog of off-the-shelf, tested functions. kpt makes
   configuration easy to create and transform, via reusable functions. Because they are expected to be used for in-place
   transformation, the functions need to be idempotent.
 

--- a/documentation/content/en/book/04-using-functions/_index.md
+++ b/documentation/content/en/book/04-using-functions/_index.md
@@ -46,7 +46,7 @@ This pipeline declares the following two functions:
 - `set-label`: this is a mutator function which adds a set of labels to the resources.
 - `kubeconform`: this is a validator function which validates the resources against their OpenAPI schemas.
 
-See the [Functions Catalog](https://catalog.kpt.dev/function-catalog) for details about how to use a particular function.
+See the [Functions Catalog](https://catalog.kpt.dev) for details about how to use a particular function.
 
 There are two differences between the mutator functions and the validator functions:
 

--- a/documentation/content/en/book/05-developing-functions/_index.md
+++ b/documentation/content/en/book/05-developing-functions/_index.md
@@ -15,7 +15,7 @@ menu:
 ---
 
  > Before you start developing your custom function, check out the
-[Functions Catalog](https://catalog.kpt.dev/function-catalog ":target=_self") in case there is
+[Functions Catalog](https://catalog.kpt.dev ":target=_self") in case there is
 an existing function that meets your needs. This is an ever-growing catalog of
 functions that we consider to be generally useful to many users. If your use
 case fits that description, please
@@ -86,7 +86,7 @@ In order to enable functions to be developed in different toolchains and
 languages and be interoperable and backwards compatible, the kpt project created
 a standard for the inter-process communication between the orchestrator (i.e.
 kpt CLI) and functions. This standard was published as the
-[KRM Functions Specification](https://github.com/kubernetes-sigs/kustomize/blob/main/cmd/config/docs/api-conventions/functions-spec.md#krm-functions-specification)
+[KRM Functions Specification](https://github.com/kubernetes-sigs/kustomize/blob/master/cmd/config/docs/api-conventions/functions-spec.md#krm-functions-specification)
 and donated to the CNCF as part of the Kubernetes SIG-CLI.
 
 Understanding this specification enables you to have a deeper understanding of

--- a/documentation/content/en/book/06-deploying-packages/_index.md
+++ b/documentation/content/en/book/06-deploying-packages/_index.md
@@ -122,7 +122,7 @@ and namespace of the `ResourceGroup` resource. Refer to the
 [init command reference](../../reference/cli/live/init/) for usage.
 
 {{< warning type=warning >}}
-Once a package is applied to the cluster, do not change the `ResourceGroup` CR. Doing so corrupts the association between the package and the inventory in the cluster, possibly leading to unpredictible and destructive operations.
+Once a package is applied to the cluster, do not change the `ResourceGroup` CR. Doing so corrupts the association between the package and the inventory in the cluster, possibly leading to unpredictable and destructive operations.
 {{< /warning >}}
 
 ## Applying a Package

--- a/documentation/content/en/book/07-effective-customizations/_index.md
+++ b/documentation/content/en/book/07-effective-customizations/_index.md
@@ -91,14 +91,14 @@ pipeline:
    directly by the user.
 1. Attributes like resource names which are often updated by consumers to add prefixes or suffixes
    (e.g. *-dev, *-stage, *-prod, na1-*, eu1-*) are best handled by the
-   [ensure-name-substring](https://catalog.kpt.dev/function-catalog/ensure-name-substring/v0.2/) function that will handle dependency
+   [ensure-name-substring](https://catalog.kpt.dev/ensure-name-substring/v0.2/) function that will handle dependency
    updates as well as capture all the resources in the package.
 1. Instead of setting a particular value on a resource, a bulk operation can be applied to all the resources that fit a
    particular interface.  This can be done by a custom function or by the
-   [set-namespace](https://catalog.kpt.dev/function-catalog/set-namespace/v0.4/),
-   [search-and-replace](https://catalog.kpt.dev/function-catalog/search-replace/v0.2/),
-   [set-labels](https://catalog.kpt.dev/function-catalog/set-labels/v0.2/) and
-   [set-annotations](https://catalog.kpt.dev/function-catalog/set-annotations/v0.1/) functions.
+   [set-namespace](https://catalog.kpt.dev/set-namespace/v0.4/),
+   [search-and-replace](https://catalog.kpt.dev/search-replace/v0.2/),
+   [set-labels](https://catalog.kpt.dev/set-labels/v0.2/) and
+   [set-annotations](https://catalog.kpt.dev/set-annotations/v0.1/) functions.
 
 The new bucket configuration:
 
@@ -139,17 +139,17 @@ pipeline:
 ```
 
 The mark up in the resource configuration YAML showing where the namespace value should
-go is no longer needed.  The [set-namespace](https://catalog.kpt.dev/function-catalog/set-namespace/v0.4/) function is smart enough to 
+go is no longer needed.  The [set-namespace](https://catalog.kpt.dev/set-namespace/v0.4/) function is smart enough to 
 find all the appropriate resources that need the namespace.
 
 We have put in the starter name `bucket` and have an
-[ensure-name-substring](https://catalog.kpt.dev/function-catalog/ensure-name-substring/v0.2/) 
+[ensure-name-substring](https://catalog.kpt.dev/ensure-name-substring/v0.2/) 
 that shows the package consumer that the project ID prefix is what we suggest.
 However if they have a different naming convention they can alter the name 
 prefix or suffix on all the resources in the package.
 
 Since we are trying to set the annotation to the project ID we can run the 
-[set-annotations](https://catalog.kpt.dev/function-catalog/set-annotations/v0.1/)
+[set-annotations](https://catalog.kpt.dev/set-annotations/v0.1/)
 function once and the annotation is set on all the resources in the package. 
 If we add additional resources or whole sub packages, we will get the consistent annotations across all resources 
 without having to find all the places where annotations should go.
@@ -216,7 +216,7 @@ the package author's rules are not clear and not easily validated.
 ### Solution:
 
 1. General ways to describe policy already exist.  kpt has a
-[gatekeeper](https://catalog.kpt.dev/function-catalog/gatekeeper/v0.2/)
+[gatekeeper](https://catalog.kpt.dev/gatekeeper/v0.2/)
 function that allows the author to describe intended limitations for a class 
 of resources or the entire package. This gives the consumer the freedom to customize 
 and get an error or a warning when the policy is violated. 
@@ -225,7 +225,7 @@ In the sample provided by the function, we see how to provide a policy that will
 clearly describe the intent using the [Rego policy language](https://www.openpolicyagent.org/docs/policy-language)
 of the [Open Policy Agent (OPA)](https://www.openpolicyagent.org/):
 
-The Kptfile uses the [gatekeeper](https://catalog.kpt.dev/function-catalog/gatekeeper/v0.2/) function to
+The Kptfile uses the [gatekeeper](https://catalog.kpt.dev/gatekeeper/v0.2/) function to
 ensure that resources comply with this policy every time `kpt fn render` is used.
 
 

--- a/documentation/content/en/faq.md
+++ b/documentation/content/en/faq.md
@@ -101,7 +101,7 @@ For a more complete explanation, see the [rationale].
 
 Yes. kpt supports plugging in solutions which generate or manipulate
 configuration, e.g. from DSLs and templates. This may be performed using the
-[Functions Catalog](https://catalog.kpt.dev/function-catalog). The generated output may be modified directly, and merged
+[Functions Catalog](https://catalog.kpt.dev). The generated output may be modified directly, and merged
 when regenerated.
 
 ### I want to write high-level abstractions like CRDs, but on the client-side. Can I do this with kpt?

--- a/documentation/content/en/guides/namespace-provisioning-cli.md
+++ b/documentation/content/en/guides/namespace-provisioning-cli.md
@@ -155,8 +155,8 @@ Package "basens"
 
 Before we add more resources to the package, let's configure our package to
 ensure that the namespace for new resources in the package is set correctly.
-kpt offers a set of common functions as part of the [Functions Catalog](https://catalog.kpt.dev/function-catalog/)
-and it has a [set-namespace](https://catalog.kpt.dev/function-catalog/set-namespace/v0.4/) function
+kpt offers a set of common functions as part of the [Functions Catalog](https://catalog.kpt.dev/)
+and it has a [set-namespace](https://catalog.kpt.dev/set-namespace/v0.4/) function
 that can be used to ensure all resources in a package use the same namespace.
 
 ```shell
@@ -211,7 +211,7 @@ Successfully executed 1 function(s) in 1 package(s).
 ```
 
 Note: if you are curious about how KRM functions are implemented. Take a look
-at [set-namespace code](https://github.com/kptdev/krm-functions-catalog/blob/master/functions/go/set-namespace/transformer/namespace.go)
+at [set-namespace code](https://github.com/kptdev/krm-functions-catalog/blob/main/functions/go/set-namespace/transformer/namespace.go)
 to get a feel for the implementation. You can also check out [Chapter 5: Developing Functions](https://kpt.dev/book/05-developing-functions/)
 of the kpt book.
 
@@ -249,7 +249,7 @@ subjects:
 To enable automatic customization of this role binding for an instance of a
 namespace package, we can bind the value of package instance name to the group
 name in the above role binding resource. We will use the
-[apply-replacements function](https://catalog.kpt.dev/function-catalog/apply-replacements/v0.1/)
+[apply-replacements function](https://catalog.kpt.dev/apply-replacements/v0.1/)
 from kpt-function-catalog for binding the values.
 Here is an snippet that does that:
 

--- a/documentation/content/en/guides/rationale.md
+++ b/documentation/content/en/guides/rationale.md
@@ -64,7 +64,7 @@ These resource representations were intended to form the core of a declarative d
 to support pre-deployment validation, preview, and approval and post-deployment auditing, versioning, and undo. 
 
 kpt supports management of
-[Configuration as Data](https://github.com/kptdev/kpt/blob/main/docs/design-docs/06-config-as-data.md).
+[Configuration as Data]({{< relref "/book/02-concepts/#configuration-as-data-key-principles" >}}).
 The core ideas are simple:
 
 * uses a uniform, serializable data model to represent configuration
@@ -86,7 +86,7 @@ in other approches, notably packaging and a client-side CLI.
 
 kpt enables WYSIWYG management of configuration similar to how the live state can be modified with traditional
 imperative tools, thus eliminating this dichotomy:
-<img src="https://raw.githubusercontent.com/kptdev/kpt/main/docs/design-docs/CaD%20Overview.svg">
+<img src="/images/cad-overview.svg">
 
 Configuration as Data is a novel approach that doesn’t sacrifice usability or the potential for higher-level automation
 in order to enable reproducibility. Instead, it supports an interoperable, WYSIWYG, automatable configuration authoring

--- a/documentation/content/en/guides/value-propagation.md
+++ b/documentation/content/en/guides/value-propagation.md
@@ -1,5 +1,5 @@
-[starlark]: https://catalog.kpt.dev/function-catalog/starlark/v0.5/
-[apply-replacements]: https://catalog.kpt.dev/function-catalog/apply-replacements/v0.1/
+[starlark]: https://catalog.kpt.dev/starlark/v0.5/
+[apply-replacements]: https://catalog.kpt.dev/apply-replacements/v0.1/
 
 # Value propagation pattern
 

--- a/documentation/content/en/guides/variant-constructor-pattern.md
+++ b/documentation/content/en/guides/variant-constructor-pattern.md
@@ -49,12 +49,12 @@ then the `metadata.name` uniquely identifies the resource in a cluster. If the r
 is namespace scoped, then (`metadata.namespace`, `metadata.name`) together identifies the
 resource uniquely.
 
-The [Function Catalog](https://catalog.kpt.dev/function-catalog/) provides two function that help
+The [Function Catalog](https://catalog.kpt.dev/) provides two function that help
 with customizing the identify of the resources:
 
-1. [set-namespace](https://catalog.kpt.dev/function-catalog/set-namespace/v0.4/): sets the
+1. [set-namespace](https://catalog.kpt.dev/set-namespace/v0.4/): sets the
    namespace for all resources in the package.
-2. [ensure-name-substring](https://catalog.kpt.dev/function-catalog/ensure-name-substring/v0.2/):
+2. [ensure-name-substring](https://catalog.kpt.dev/ensure-name-substring/v0.2/):
    sets the name of the resources in the package.
 
 You can use appropriate functions from the catalog or implement a custom
@@ -63,9 +63,9 @@ function to ensure unique identities for all resources.
 ## Customizing non-identifier fields of resources
 
 Packages can use other functions such as
-[set-labels](https://catalog.kpt.dev/function-catalog/set-labels/v0.2/),
-[set-annotations](https://catalog.kpt.dev/function-catalog/set-annotations/v0.1/),
-[apply-replacements](https://catalog.kpt.dev/function-catalog/apply-replacements/v0.1/),
+[set-labels](https://catalog.kpt.dev/set-labels/v0.2/),
+[set-annotations](https://catalog.kpt.dev/set-annotations/v0.1/),
+[apply-replacements](https://catalog.kpt.dev/apply-replacements/v0.1/),
 or custom functions to transform other fields of resources.
 
 ## Core mechanism
@@ -76,7 +76,7 @@ Enabling automatic variant construction involves two steps:
 2. Generating inputs for the functions declarared in the package
 
 Here is an example of `Kptfile` of a package that uses
-[set-namespace](https://catalog.kpt.dev/function-catalog/set-namespace/v0.4/) and a custom
+[set-namespace](https://catalog.kpt.dev/set-namespace/v0.4/) and a custom
  function called `apply-transform` to enable customization.
 
 ```Kptfile


### PR DESCRIPTION
  ## Description
  - **What changed**: Fixed broken hyperlinks and corrected spelling mistakes across the kpt documentation site content (`documentation/content/`).
  - **Why it's needed**: Several links pointed to old URL structures (`catalog.kpt.dev/function-catalog/...`) that now return 404 and spelling mistakes existed across documentation pages.
  - **How it works**: Updated URLs to their correct current paths, replaced an external GitHub raw link with the local static asset, and corrected typos.

  ## Related Issue(s)
  - None

  ## Type of Change
  - [x] Documentation

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [x] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to identify broken links (via `curl` validation) and spelling mistakes (via `codespell`), and to apply fixes.