### PR TITLE
 Standardize annotation prefix: use config.kubernetes.io instead of  config.k8s.io

### DIFF
--- a/pkg/fn/runtime/utils.go
+++ b/pkg/fn/runtime/utils.go
@@ -28,7 +28,7 @@ import (
 // ResourceIDAnnotation is used to uniquely identify the resource during round trip
 // to and from a function execution. This annotation is meant to be consumed by
 // kpt during round trip and should be deleted after that
-const ResourceIDAnnotation = "internal.config.k8s.io/kpt-resource-id"
+const ResourceIDAnnotation = "internal.config.kubernetes.io/kpt-resource-id"
 
 // SaveResults saves results gathered from running the pipeline at specified dir in the input FileSystem.
 func SaveResults(fsys filesys.FileSystem, resultsDir string, fnResults *fnresultv1.ResultList) (string, error) {

--- a/pkg/fn/runtime/utils_test.go
+++ b/pkg/fn/runtime/utils_test.go
@@ -36,7 +36,7 @@ kind: Deployment
 metadata:
   name: nginx-deployment
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "0"
+    internal.config.kubernetes.io/kpt-resource-id: "0"
 spec:
   replicas: 3`,
 			selector: kptfilev1.Selector{
@@ -51,7 +51,7 @@ kind: Deployment
 metadata:
   name: nginx-deployment
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "0"
+    internal.config.kubernetes.io/kpt-resource-id: "0"
 spec:
   replicas: 3`,
 			selector: kptfilev1.Selector{
@@ -67,7 +67,7 @@ metadata:
   name: nginx-deployment
   namespace: staging
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "0"
+    internal.config.kubernetes.io/kpt-resource-id: "0"
 spec:
   replicas: 3`,
 			selector: kptfilev1.Selector{
@@ -82,7 +82,7 @@ kind: Deployment
 metadata:
   name: nginx-deployment
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "0"
+    internal.config.kubernetes.io/kpt-resource-id: "0"
 spec:
   replicas: 3`,
 			selector: kptfilev1.Selector{
@@ -98,7 +98,7 @@ metadata:
   name: nginx-deployment
   namespace: staging
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "0"
+    internal.config.kubernetes.io/kpt-resource-id: "0"
 spec:
   replicas: 3`,
 			selector: kptfilev1.Selector{
@@ -117,7 +117,7 @@ metadata:
   name: nginx-deployment
   namespace: staging
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "0"
+    internal.config.kubernetes.io/kpt-resource-id: "0"
 spec:
   replicas: 3`,
 			selector: kptfilev1.Selector{

--- a/pkg/lib/kptops/render_executor_test.go
+++ b/pkg/lib/kptops/render_executor_test.go
@@ -122,7 +122,7 @@ kind: Deployment
 metadata:
   name: nginx-deployment
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "0"
+    internal.config.kubernetes.io/kpt-resource-id: "0"
 spec:
   replicas: 3`,
 			selectedInput: `apiVersion: apps/v1
@@ -130,7 +130,7 @@ kind: Deployment
 metadata:
   name: nginx-deployment
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "0"
+    internal.config.kubernetes.io/kpt-resource-id: "0"
 spec:
   replicas: 3`,
 			output: `apiVersion: apps/v1
@@ -139,7 +139,7 @@ metadata:
   name: nginx-deployment
   namespace: staging
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "0"
+    internal.config.kubernetes.io/kpt-resource-id: "0"
 spec:
   replicas: 3`,
 			expected: `apiVersion: apps/v1
@@ -148,7 +148,7 @@ metadata:
   name: nginx-deployment
   namespace: staging
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "0"
+    internal.config.kubernetes.io/kpt-resource-id: "0"
 spec:
   replicas: 3
 `,
@@ -160,35 +160,35 @@ kind: Deployment
 metadata:
   name: nginx-deployment-0
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "0"
+    internal.config.kubernetes.io/kpt-resource-id: "0"
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment-1
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "1"
+    internal.config.kubernetes.io/kpt-resource-id: "1"
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment-2
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "2"
+    internal.config.kubernetes.io/kpt-resource-id: "2"
 `,
 			selectedInput: `apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment-0
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "0"
+    internal.config.kubernetes.io/kpt-resource-id: "0"
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment-1
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "1"
+    internal.config.kubernetes.io/kpt-resource-id: "1"
 `,
 			output: `apiVersion: apps/v1
 kind: Deployment
@@ -196,7 +196,7 @@ metadata:
   name: nginx-deployment-0
   namespace: staging # transformed
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "0"
+    internal.config.kubernetes.io/kpt-resource-id: "0"
 ---
 apiVersion: apps/v1 # generated resource
 kind: Deployment
@@ -209,14 +209,14 @@ metadata:
   name: nginx-deployment-0
   namespace: staging # transformed
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "0"
+    internal.config.kubernetes.io/kpt-resource-id: "0"
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment-2
   annotations:
-    internal.config.k8s.io/kpt-resource-id: "2"
+    internal.config.kubernetes.io/kpt-resource-id: "2"
 ---
 apiVersion: apps/v1 # generated resource
 kind: Deployment
@@ -1005,7 +1005,7 @@ metadata:
     config.k8s.io/id: "123"
     internal.config.kubernetes.io/annotations-migration-resource-id: "456"
     internal.config.kubernetes.io/id: "789"
-    internal.config.k8s.io/kpt-resource-id: "abc"
+    internal.config.kubernetes.io/kpt-resource-id: "abc"
     other.annotation: "keep"`,
 			hasNonRenderingAnnotation: true,
 		},
@@ -1041,7 +1041,7 @@ metadata:
 				assert.NotContains(t, annotations, "config.k8s.io/id")
 				assert.NotContains(t, annotations, "internal.config.kubernetes.io/annotations-migration-resource-id")
 				assert.NotContains(t, annotations, "internal.config.kubernetes.io/id")
-				assert.NotContains(t, annotations, "internal.config.k8s.io/kpt-resource-id")
+				assert.NotContains(t, annotations, "internal.config.kubernetes.io/kpt-resource-id")
 				// Verify other.annotation is preserved after clearing
 				if tc.hasNonRenderingAnnotation {
 					assert.Contains(t, annotations, "other.annotation")


### PR DESCRIPTION
## Description
- Rename the internal `kpt-resource-id` annotation from `internal.config.k8s.io/kpt-resource-id` to `internal.config.kubernetes.io/kpt-resource-id` to align with the `config.kubernetes.io` prefix used consistently across kyaml and kpt.
- This resolves the last kpt-owned annotation using the short `config.k8s.io` prefix. The annotation is fully transient (added before a selector/exclusion pipeline step and removed immediately after), so this change has no user-visible impact.

Fixes https://github.com/kptdev/kpt/issues/1257

  ## Type of Change

  - [x] Bug fix
  - [x] Tests

  ## Checklist

  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [x] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
  - Kiro to investigate the issue, identify the inconsistency, and create PR message.