### PR TITLE
Clarify path annotation semantics and link to metadata schema reference

### DIFF
--- a/documentation/content/en/book/05-developing-functions/_index.md
+++ b/documentation/content/en/book/05-developing-functions/_index.md
@@ -93,6 +93,13 @@ Understanding this specification enables you to have a deeper understanding of
 how things work under the hood. It also enables to create your own toolchain for
 function development if you so desire.
 
+Each resource in the `ResourceList` carries an `internal.config.kubernetes.io/path`
+annotation indicating its file path relative to the package directory. When a
+function creates new resources, it should set this annotation to a path relative
+to the same package directory. See the
+[annotations reference](/reference/annotations/#path-annotation-details)
+for full details.
+
 As an example, you can see the `ResourceList` containing resources in the
 `wordpress` package:
 

--- a/documentation/content/en/book/05-developing-functions/_index.md
+++ b/documentation/content/en/book/05-developing-functions/_index.md
@@ -363,3 +363,4 @@ kpt fn eval ./testdata/noop-passthrough/resources.yaml --image ${FN_CONTAINER_RE
 
 - See other [go documentation examples](https://pkg.go.dev/github.com/kptdev/krm-functions-sdk/go/fn/examples) to use KubeObject.
 - To contribute to KRM catalog functions, please follow the [contributor guide](https://github.com/kptdev/krm-functions-catalog/blob/main/CONTRIBUTING.md)
+- For the `metadata.yaml` schema reference (required fields, allowed tags), see the [metadata schema documentation](https://catalog.kpt.dev/metadata-schema/)

--- a/documentation/content/en/book/05-developing-functions/_index.md
+++ b/documentation/content/en/book/05-developing-functions/_index.md
@@ -93,10 +93,10 @@ Understanding this specification enables you to have a deeper understanding of
 how things work under the hood. It also enables to create your own toolchain for
 function development if you so desire.
 
-Each resource in the `ResourceList` carries an `internal.config.kubernetes.io/path`
-annotation indicating its file path relative to the package directory. When a
-function creates new resources, it should set this annotation to a path relative
-to the same package directory. See the
+When kpt reads resources from disk, each resource in the `ResourceList` carries an
+`internal.config.kubernetes.io/path` annotation indicating its file path relative to
+the package directory. When a function creates new resources, it should set this
+annotation to a path relative to the same package directory. See the
 [annotations reference](/reference/annotations/#path-annotation-details)
 for full details.
 

--- a/documentation/content/en/reference/annotations/_index.md
+++ b/documentation/content/en/reference/annotations/_index.md
@@ -25,6 +25,19 @@ The following annotations are used by kpt internally:
 | `internal.config.kubernetes.io/index`  | specifies the index of the resource in a file when formatted as a ResourceList |
 | `config.kubernetes.io/merge-source`    | specifies the source of the resource during a three way merge |
 
+## Path annotation details
+
+The `internal.config.kubernetes.io/path` annotation specifies the file path of a
+resource relative to the package directory (the directory containing the Kptfile
+whose pipeline invoked the function).
+
+When kpt reads resources from disk, it sets this annotation on each resource.
+When a function creates new resources, it should set this annotation to a path
+relative to the same package directory. kpt handles adjusting paths to be
+relative to the root package before writing to disk.
+
+For `kpt fn eval DIR`, the path is relative to DIR.
+
 [config.kubernetes.io/depends-on]: /reference/annotations/depends-on/
 [config.kubernetes.io/apply-time-mutation]: /reference/annotations/apply-time-mutation/
 [config.kubernetes.io/local-config]: /reference/annotations/local-config/

--- a/documentation/content/en/reference/annotations/_index.md
+++ b/documentation/content/en/reference/annotations/_index.md
@@ -36,7 +36,8 @@ When a function creates new resources, it should set this annotation to a path
 relative to the same package directory. kpt handles adjusting paths to be
 relative to the root package before writing to disk.
 
-For `kpt fn eval DIR`, the path is relative to DIR.
+For `kpt fn eval DIR`, the path is relative to the package directory DIR
+(the directory passed as the evaluation target).
 
 [config.kubernetes.io/depends-on]: /reference/annotations/depends-on/
 [config.kubernetes.io/apply-time-mutation]: /reference/annotations/apply-time-mutation/


### PR DESCRIPTION
## Description
  - **What changed**:
    - Added path annotation details section to the annotations reference page explaining that the path is relative to the package directory containing the Kptfile whose pipeline invoked the function.
    - Added cross-reference from the Functions Specification section in book chapter 5 to the annotations reference.
    - Added link to the catalog's metadata schema documentation in the "Next Steps" section of book chapter 5.
  - **Why it's needed**: The path annotation semantics were only documented in code comments, not in user-facing docs. Function authors had no guidance on what "relative to that directory" means in the functions spec.
  - **How it works**: Expands the annotations reference and adds cross-references from the developing functions chapter.

  ## Related Issue(s)
  - Fixes https://github.com/kptdev/kpt/issues/1718
  - Fixes https://github.com/kptdev/kpt/issues/1668
  - Should be merged after https://github.com/kptdev/krm-functions-catalog/pull/1287

  ## Type of Change
  - [x] Documentation

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [x] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**