### PR TITLE
Add go.mod replace directive guard to release workflows

### DIFF
--- a/.github/actions/check-go-mod-replace/action.yml
+++ b/.github/actions/check-go-mod-replace/action.yml
@@ -1,0 +1,47 @@
+# Copyright 2026 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Check go.mod replace directives
+description: >
+  Fails if the go.mod in the specified directory contains active replace
+  directives that are not in the allowed list.
+
+inputs:
+  working-directory:
+    description: Directory containing the go.mod to check.
+    required: false
+    default: "."
+  allowed-replacements:
+    description: >
+      JSON array of module paths that are allowed to have replace directives.
+      Example: '["k8s.io/apiserver", "sigs.k8s.io/kustomize/kyaml"]'
+    required: false
+    default: "[]"
+
+runs:
+  using: composite
+  steps:
+    - name: Check for replace directives
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        ALLOWED='${{ inputs.allowed-replacements }}'
+        UNEXPECTED=$(go mod edit -json | jq --argjson allowed "$ALLOWED" \
+          '[(.Replace // [])[] | select(.Old.Path as $p | $allowed | index($p) | not)]')
+        COUNT=$(echo "$UNEXPECTED" | jq 'length')
+        if [ "$COUNT" -gt 0 ]; then
+          echo "::error::$(pwd)/go.mod contains unexpected replace directives. Remove them before releasing."
+          echo "$UNEXPECTED" | jq .
+          exit 1
+        fi

--- a/.github/workflows/release-api.yml
+++ b/.github/workflows/release-api.yml
@@ -32,6 +32,10 @@ jobs:
         with:
           go-version-file: api/go.mod
           cache-dependency-path: api/go.sum
+      - name: Check for replace directives in api/go.mod
+        uses: ./.github/actions/check-go-mod-replace
+        with:
+          working-directory: api
       - name: Build, test, lint (api module)
         run: |
           git config --global user.email you@example.com

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - name: Check for replace directives in go.mod
+        uses: ./.github/actions/check-go-mod-replace
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Description
  - **What changed**: Added a reusable composite action (`.github/actions/check-go-mod-replace`) and integrated it into both
    `release.yml` and `release-api.yml` workflows.
  - **Why it's needed**: Accidentally releasing with active `replace` directives in `go.mod` (e.g. local path overrides left from development) produces a broken module, consumers cannot resolve local replace targets. This gate catches the mistake before GoReleaser runs.
  - **How it works**: The composite action uses `go mod edit -json` and `jq` to semantically parse the module file and detect active replace directives. Commented-out replacements are ignored. An `allowed-replacements` input (JSON array of module paths) supports repos that have legitimate permanent replacements (e.g. porch's `k8s.io/apiserver`). If unexpected replacements
are found, the step emits a GitHub Actions error annotation and exits non-zero, blocking the release.

The action is designed to be reusable across repos (porch, catalog, sdk) via `uses: kptdev/kpt/.github/actions/check-go-mod-replace@main`.

  ## Related Issue(s)
  - None

  ## Type of Change
  - [ ] Bug fix
  - [ ] New feature
  - [x] Enhancement
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other: ________

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [x] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to locally validate the composite action and workflow changes and draft PR Message.