### PR TITLE
Improve logging of render pipeline execution (part 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,24 +80,24 @@ test: test-api
 # KRM_FN_RUNTIME can be set to select the desired function runtime.
 # If unspecified, the default function runtime will be used.
 test-docker: build
-	PATH="$(GOBIN):$(PATH)" go test -cover --tags=docker ./...
+	PATH="$(GOBIN):$(PATH)" go test -cover ${LDFLAGS} --tags=docker ./...
 
 # KPT_E2E_UPDATE_EXPECTED=true (if expected output to be updated)
 # target to run e2e tests for "kpt fn render" command
 # KRM_FN_RUNTIME can be set to select the desired function runtime.
 # If unspecified, the default function runtime will be used.
 test-fn-render: build
-	PATH="$(GOBIN):$(PATH)" go test -v --tags=docker --run=TestFnRender/testdata/fn-render/$(T) ./e2e/
+	PATH="$(GOBIN):$(PATH)" go test -v ${LDFLAGS} --tags=docker --run=TestFnRender/testdata/fn-render/$(T) ./e2e/
 
 # target to run e2e tests for "kpt fn eval" command
 # KRM_FN_RUNTIME can be set to select the desired function runtime.
 # If unspecified, the default function runtime will be used.
 test-fn-eval: build
-	PATH="$(GOBIN):$(PATH)" go test -v --tags=docker --run=TestFnEval/testdata/fn-eval/$(T)  ./e2e/
+	PATH="$(GOBIN):$(PATH)" go test -v ${LDFLAGS} --tags=docker --run=TestFnEval/testdata/fn-eval/$(T)  ./e2e/
 
 # target to run e2e tests for "kpt live apply" command
 test-live-apply: build
-	PATH="$(GOBIN):$(PATH)" go test -v -timeout=20m --tags=kind -p 2 --run=TestLiveApply/testdata/live-apply/$(T)  ./e2e/
+	PATH="$(GOBIN):$(PATH)" go test -v ${LDFLAGS} -timeout=20m --tags=kind -p 2 --run=TestLiveApply/testdata/live-apply/$(T)  ./e2e/
 
 vet: vet-api
 	go vet ./...

--- a/api/Makefile
+++ b/api/Makefile
@@ -47,7 +47,7 @@ lint:
 
 .PHONY: test
 test:
-	go test -cover ./...
+	go test -cover ${LDFLAGS} ./...
 
 .PHONY: vet
 vet:

--- a/commands/pkg/update/cmdupdate_test.go
+++ b/commands/pkg/update/cmdupdate_test.go
@@ -485,7 +485,7 @@ func TestCmd_output(t *testing.T) {
 				).
 				WithResource(pkgbuilder.SecretResource),
 			expectedOutput: `
-Package: "{{ .PKG_NAME }}"
+Package "{{ .PKG_NAME }}":
 Fetching upstream from {{ (index .REPOS "upstream").RepoDirectory }}@master
 <git_output>
 Fetching origin from {{ (index .REPOS "upstream").RepoDirectory }}@master
@@ -559,7 +559,7 @@ Updated 1 package(s).
 						WithResource(pkgbuilder.ConfigMapResource),
 				),
 			expectedOutput: `
-Package: "{{ .PKG_NAME }}"
+Package "{{ .PKG_NAME }}":
 Fetching upstream from {{ (index .REPOS "upstream").RepoDirectory }}@master
 <git_output>
 Fetching origin from {{ (index .REPOS "upstream").RepoDirectory }}@master
@@ -567,7 +567,7 @@ Fetching origin from {{ (index .REPOS "upstream").RepoDirectory }}@master
 Updating package "{{ .PKG_NAME }}" with strategy "resource-merge".
 Updating package "subpkg" with strategy "fast-forward".
 
-Package: "{{ .PKG_NAME }}/subpkg"
+Package "{{ .PKG_NAME }}/subpkg":
 Fetching upstream from {{ (index .REPOS "foo").RepoDirectory }}@master
 <git_output>
 Fetching origin from {{ (index .REPOS "foo").RepoDirectory }}@master
@@ -667,7 +667,7 @@ Updated 2 package(s).
 						WithResource(pkgbuilder.DeploymentResource, pkgbuilder.SetFieldPath("5", "spec", "replicas")),
 				),
 			expectedOutput: `
-Package: "{{ .PKG_NAME }}"
+Package "{{ .PKG_NAME }}":
 Fetching upstream from {{ (index .REPOS "upstream").RepoDirectory }}@master
 <git_output>
 Fetching origin from {{ (index .REPOS "upstream").RepoDirectory }}@master
@@ -676,7 +676,7 @@ Updating package "{{ .PKG_NAME }}" with strategy "resource-merge".
 Deleting package "subpkg2" from local since it is removed in upstream.
 Package "subpkg1" deleted from upstream, but keeping local since it has changes.
 
-Package: "{{ .PKG_NAME }}/subpkg1"
+Package "{{ .PKG_NAME }}/subpkg1":
 Fetching upstream from {{ (index .REPOS "foo").RepoDirectory }}@master
 <git_output>
 Fetching origin from {{ (index .REPOS "foo").RepoDirectory }}@master
@@ -735,7 +735,7 @@ Updated 2 package(s).
 						WithResource(pkgbuilder.DeploymentResource),
 				),
 			expectedOutput: `
-Package: "{{ .PKG_NAME }}"
+Package "{{ .PKG_NAME }}":
 Fetching upstream from {{ (index .REPOS "upstream").RepoDirectory }}@master
 <git_output>
 Fetching origin from {{ (index .REPOS "upstream").RepoDirectory }}@master
@@ -743,7 +743,7 @@ Fetching origin from {{ (index .REPOS "upstream").RepoDirectory }}@master
 Updating package "{{ .PKG_NAME }}" with strategy "resource-merge".
 Adding package "subpkg" from upstream.
 
-Package: "{{ .PKG_NAME }}/subpkg"
+Package "{{ .PKG_NAME }}/subpkg":
 Fetching upstream from {{ (index .REPOS "foo").RepoDirectory }}@v1
 <git_output>
 Updating package "subpkg" with strategy "force-delete-replace".

--- a/documentation/content/en/book/04-using-functions/_index.md
+++ b/documentation/content/en/book/04-using-functions/_index.md
@@ -376,21 +376,30 @@ pipeline:
     - image: ghcr.io/kptdev/krm-functions-catalog/kubeconform:latest
 ```
 
-When you invoke the render command, the `mysql` package is rendered first, and the `set-annotations` function is invoked only on the resources with the name `wordpress-mysql`. The `set-label` function is then invoked on all the resources in the package hierarchy of the `wordpress` package.
+When you invoke the render command, the `mysql` package is rendered first, and the `set-annotations` function is invoked only on the resources with the name `wordpress-mysql`.
+The `set-label` function is then invoked on all the resources in the package hierarchy of the `wordpress` package.
 
 ```shell
 $ kpt fn render wordpress
-Package "wordpress/mysql": 
-[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
-[PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+Package "wordpress/mysql":
+[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on package "wordpress/mysql"
+[PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 311ms
+  [Results]:
+    [info]: set 7 labels in total
 
-Package "wordpress": 
-[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" on 3 resource(s)
-[PASS] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest"
-[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
-[PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
-[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/kubeconform:latest"
-[PASS] "ghcr.io/kptdev/krm-functions-catalog/kubeconform:latest"
+Package "wordpress":
+[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" on 2 resource(s) on package "wordpress"
+[PASS] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" in 223ms
+  [Results]:
+    [info] metadata.annotations: set annotations: {"tier":"mysql"}
+    [info] metadata.annotations: set annotations: {"tier":"mysql"}
+    [info] spec.template.metadata.annotations: set annotations: {"tier":"mysql"}
+[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on package "wordpress"
+[PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 204ms
+  [Results]:
+    [info]: set 14 labels in total
+[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/kubeconform:latest" on package "wordpress"
+[PASS] "ghcr.io/kptdev/krm-functions-catalog/kubeconform:latest" in 431ms
 
 Successfully executed 4 function(s) in 2 package(s).
 ```
@@ -431,20 +440,28 @@ pipeline:
 Render the package as follows:
 
 ```shell
-kpt fn render wordpress
-Package "wordpress/mysql": 
-[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
-[PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+$ kpt fn render wordpress
+Package "wordpress/mysql":
+[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on package "wordpress/mysql"
+[PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 310ms
+  [Results]:
+    [info]: set 7 labels in total
 
-Package "wordpress": 
-[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" on 3 resource(s)
-[PASS] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest"
-[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
-[PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
-[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/ensure-name-substring:latest" on 2 resource(s)
-[PASS] "ghcr.io/kptdev/krm-functions-catalog/ensure-name-substring:latest"
-[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/kubeconform:latest"
-[PASS] "ghcr.io/kptdev/krm-functions-catalog/kubeconform:latest"
+Package "wordpress":
+[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" on 2 resource(s) on package "wordpress"
+[PASS] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" in 184ms
+  [Results]:
+    [info] metadata.annotations: set annotations: {"tier":"mysql"}
+    [info] metadata.annotations: set annotations: {"tier":"mysql"}
+    [info] spec.template.metadata.annotations: set annotations: {"tier":"mysql"}
+[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on package "wordpress"
+[PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 193ms
+  [Results]:
+    [info]: set 14 labels in total
+[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/ensure-name-substring:latest" on 2 resource(s) on package "wordpress"
+[PASS] "ghcr.io/kptdev/krm-functions-catalog/ensure-name-substring:latest" in 187ms
+[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/kubeconform:latest" on package "wordpress"
+[PASS] "ghcr.io/kptdev/krm-functions-catalog/kubeconform:latest" in 358ms
 
 Successfully executed 5 function(s) in 2 package(s).
 ```

--- a/documentation/content/en/book/07-effective-customizations/_index.md
+++ b/documentation/content/en/book/07-effective-customizations/_index.md
@@ -267,7 +267,7 @@ spec:
           - Deployment
 ```
 
-2. `deployment-root-securitycontext.yaml.yaml`
+2. `deployment-root-securitycontext.yaml`
 
 ```yaml
 apiVersion: apps/v1
@@ -305,19 +305,19 @@ pipeline:
 Now, run `kpt fn render` on the kpt package:
 
 ```bash
-kpt fn render
-Package "Gatekeeper": 
-[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/gatekeeper:latest"
-[FAIL] "ghcr.io/kptdev/krm-functions-catalog/gatekeeper:latest" in 200ms
-  Results:
+$ kpt fn render
+Package "Gatekeeper":
+[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/gatekeeper:latest" on package "Gatekeeper"
+[FAIL] "ghcr.io/kptdev/krm-functions-catalog/gatekeeper:latest" in 314ms
+  [Results]:
     [error] apps/v1/Deployment/nginx-deploy: Containers must not run as root violatedConstraint: disallowroot
   Stderr:
-    "[error] apps/v1/Deployment/nginx-deploy : Containers must not run as root"
-    "violatedConstraint: disallowroot"
+    [error] apps/v1/Deployment/nginx-deploy: Containers must not run as root
+    violatedConstraint: disallowroot
   Exit code: 1
 ```
 
-The mutation pipeline fais because the Rego policy has been violated.
+The mutation pipeline fails because the Rego policy has been violated.
 
 ## Generation
 

--- a/documentation/content/en/guides/namespace-provisioning-cli.md
+++ b/documentation/content/en/guides/namespace-provisioning-cli.md
@@ -202,11 +202,12 @@ pipeline:
 
 # render the package to ensure we have a working package.
 $ kpt fn render
-Package "tenant": 
-[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+Package "tenant":
+[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on package "tenant"
 [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 600ms
   Results:
     [info]: namespace "example" updated to "example", 0 values changed
+
 Successfully executed 1 function(s) in 1 package(s).
 ```
 
@@ -380,11 +381,11 @@ Render the `backend` package so that the package is customized for the `backend`
 
 $ kpt fn render backend
 Package "backend":
-[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on package "backend"
 [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 900ms
   Results:
     [info]: namespace "example" updated to "backend", 3 values changed
-[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/apply-replacements:latest"
+[RUNNING] "ghcr.io/kptdev/krm-functions-catalog/apply-replacements:latest" on package "backend"
 [PASS] "ghcr.io/kptdev/krm-functions-catalog/apply-replacements:latest" in 1s
 
 Successfully executed 2 function(s) in 1 package(s).

--- a/e2e/testdata/fn-eval/exec-function-stderr/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/exec-function-stderr/.expected/config.yaml
@@ -18,4 +18,26 @@ testType: eval
 stdErr: |
   [RUNNING] "./function.sh"
   [PASS] "./function.sh" in 0s
-   Stderr: Hello world 0!, Hello world 1!, Hello world 2!, Hello world 3!, Hello world 4!, Hello world 5!, Hello world 6!, Hello world 7!, Hello world 8!, Hello world 9!, Hello world 10!, Hello world 11!, Hello world 12!, Hello world 13!, Hello world 14!, Hello world 15!, Hello world 16!, Hello world 17!, Hello world 18!, Hello world 19!, Hello world 20!,
+    Stderr:
+      Hello world 0!
+      Hello world 1!
+      Hello world 2!
+      Hello world 3!
+      Hello world 4!
+      Hello world 5!
+      Hello world 6!
+      Hello world 7!
+      Hello world 8!
+      Hello world 9!
+      Hello world 10!
+      Hello world 11!
+      Hello world 12!
+      Hello world 13!
+      Hello world 14!
+      Hello world 15!
+      Hello world 16!
+      Hello world 17!
+      Hello world 18!
+      Hello world 19!
+      Hello world 20!
+      

--- a/e2e/testdata/fn-eval/missing-fn-config/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/missing-fn-config/.expected/config.yaml
@@ -16,7 +16,10 @@ testType: eval
 exitCode: 1
 image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest
 stdErr: |
- [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
- [FAIL] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
- [Results]: [error] v1/ConfigMap/function-input: `data.namespace` should not be empty
-  Stderr: failed to evaluate function: error: function failure  Exit code: 1
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [FAIL] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
+    [Results]:
+      [error] v1/ConfigMap/function-input: `data.namespace` should not be empty
+    Stderr:
+      failed to evaluate function: error: function failure
+    Exit code: 1

--- a/e2e/testdata/fn-eval/out-of-place-fnchain-stdout/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/out-of-place-fnchain-stdout/.expected/config.yaml
@@ -8,13 +8,19 @@ stdErrStripLines:
 stdErr: |
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" in 0s
-  [Results]: [info] metadata.annotations: set annotations: {"foo":"bar"}, [info] spec.template.metadata.annotations: set annotations: {"foo":"bar"}, [info] metadata.annotations: set annotations: {"foo":"bar"}
+    [Results]:
+      [info] metadata.annotations: set annotations: {"foo":"bar"}
+      [info] spec.template.metadata.annotations: set annotations: {"foo":"bar"}
+      [info] metadata.annotations: set annotations: {"foo":"bar"}
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
-  [Results]: [info]: set 4 labels in total
+    [Results]:
+      [info]: set 4 labels in total
 
 stdOut: |
   apiVersion: config.kubernetes.io/v1

--- a/e2e/testdata/fn-eval/out-of-place-fnchain-unwrap/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/out-of-place-fnchain-unwrap/.expected/config.yaml
@@ -22,13 +22,20 @@ stdErrStripLines:
 stdErr: |
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" in 0s
-  [Results]: [info] metadata.annotations: set annotations: {"foo":"bar"}, [info] metadata.annotations: set annotations: {"foo":"bar"}, [info] spec.template.metadata.annotations: set annotations: {"foo":"bar"}, [info] metadata.annotations: set annotations: {"foo":"bar"}
+    [Results]:
+      [info] metadata.annotations: set annotations: {"foo":"bar"}
+      [info] metadata.annotations: set annotations: {"foo":"bar"}
+      [info] spec.template.metadata.annotations: set annotations: {"foo":"bar"}
+      [info] metadata.annotations: set annotations: {"foo":"bar"}
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
-  [Results]: [info]: set 5 labels in total
+    [Results]:
+      [info]: set 5 labels in total
 
 stdOut: |
   # Copyright 2021 The kpt Authors

--- a/e2e/testdata/fn-eval/save-fn/custom-pkg-path/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/custom-pkg-path/.expected/config.yaml
@@ -26,5 +26,7 @@ args:
 stdErr: |
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   Added "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" as mutator in the Kptfile.

--- a/e2e/testdata/fn-eval/save-fn/image/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/image/.expected/config.yaml
@@ -26,5 +26,7 @@ args:
 stdErr: |
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   Added "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" as mutator in the Kptfile.

--- a/e2e/testdata/fn-eval/save-fn/match-selector/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/match-selector/.expected/config.yaml
@@ -19,5 +19,7 @@ stdErrStripLines:
 stdErr: |
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   Added "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" as mutator in the Kptfile.

--- a/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/config.yaml
@@ -26,5 +26,7 @@ args:
 stdErr: |
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   function not added: Kptfile not exists

--- a/e2e/testdata/fn-eval/save-fn/override-fn/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/.expected/config.yaml
@@ -26,5 +26,7 @@ args:
 stdErr: |
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "newNs", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "newNs", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   Updated "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" as mutator in the Kptfile.

--- a/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/config.yaml
@@ -26,5 +26,7 @@ args:
 stdErr: |
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   Added "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" as mutator in the Kptfile.

--- a/e2e/testdata/fn-eval/save-fn/validator-type/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/validator-type/.expected/config.yaml
@@ -26,5 +26,7 @@ args:
 stdErr: |
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   Added "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" as validator in the Kptfile.

--- a/e2e/testdata/fn-eval/selectors/out-of-place-fnchain-unwrap/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/selectors/out-of-place-fnchain-unwrap/.expected/config.yaml
@@ -19,13 +19,17 @@ stdErrStripLines:
 stdErr: |
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" on 1 resource(s)
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" in 0s
-  [Results]: [info] metadata.annotations: set annotations: {"foo":"bar"}
+    [Results]:
+      [info] metadata.annotations: set annotations: {"foo":"bar"}
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
-  [Results]: [info]: set 3 labels in total
+    [Results]:
+      [info]: set 3 labels in total
 
 stdOut: |
   apiVersion: apps/v1

--- a/e2e/testdata/fn-eval/selectors/selectors-with-exclude/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/selectors/selectors-with-exclude/.expected/config.yaml
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s) on "selectors-with-exclude"
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s

--- a/e2e/testdata/fn-eval/selectors/selectors-with-exclude/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/selectors/selectors-with-exclude/.expected/config.yaml
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s) on "selectors-with-exclude"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s

--- a/e2e/testdata/fn-render/basicpipeline-symlink/.expected/config.yaml
+++ b/e2e/testdata/fn-render/basicpipeline-symlink/.expected/config.yaml
@@ -24,8 +24,12 @@ stdErr: |-
   Package "basicpipeline-symlink":
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on package "basicpipeline-symlink"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on package "basicpipeline-symlink"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
-  [Results]: [info]: set 4 labels in total
+    [Results]:
+      [info]: set 4 labels in total
+
   Successfully executed 2 function(s) in 1 package(s).

--- a/e2e/testdata/fn-render/basicpipeline-symlink/.expected/config.yaml
+++ b/e2e/testdata/fn-render/basicpipeline-symlink/.expected/config.yaml
@@ -21,11 +21,11 @@ stdErrStripLines:
 
 stdErr: |-
   [WARN] resolved symlink "new-link" to ".", please note that the symlinks within the package are ignored
-  Package: "basicpipeline-symlink"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  Package "basicpipeline-symlink":
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on package "basicpipeline-symlink"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
   [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on package "basicpipeline-symlink"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
   [Results]: [info]: set 4 labels in total
   Successfully executed 2 function(s) in 1 package(s).

--- a/e2e/testdata/fn-render/exec-function-stderr/.expected/config.yaml
+++ b/e2e/testdata/fn-render/exec-function-stderr/.expected/config.yaml
@@ -17,4 +17,28 @@ stdErr: |
     Package "exec-function-stderr":
     [RUNNING] "./testdata/fn-render/exec-function-stderr/function.sh" on package "exec-function-stderr"
     [PASS] "./testdata/fn-render/exec-function-stderr/function.sh" in 0s
-     Stderr: Hello world 0!, Hello world 1!, Hello world 2!, Hello world 3!, Hello world 4!, Hello world 5!, Hello world 6!, Hello world 7!, Hello world 8!, Hello world 9!, Hello world 10!, Hello world 11!, Hello world 12!, Hello world 13!, Hello world 14!, Hello world 15!, Hello world 16!, Hello world 17!, Hello world 18!, Hello world 19!, Hello world 20!, Successfully executed 1 function(s) in 1 package(s).
+      Stderr:
+        Hello world 0!
+        Hello world 1!
+        Hello world 2!
+        Hello world 3!
+        Hello world 4!
+        Hello world 5!
+        Hello world 6!
+        Hello world 7!
+        Hello world 8!
+        Hello world 9!
+        Hello world 10!
+        Hello world 11!
+        Hello world 12!
+        Hello world 13!
+        Hello world 14!
+        Hello world 15!
+        Hello world 16!
+        Hello world 17!
+        Hello world 18!
+        Hello world 19!
+        Hello world 20!
+        
+
+    Successfully executed 1 function(s) in 1 package(s).

--- a/e2e/testdata/fn-render/exec-function-stderr/.expected/config.yaml
+++ b/e2e/testdata/fn-render/exec-function-stderr/.expected/config.yaml
@@ -14,7 +14,7 @@
 
 allowExec: true
 stdErr: |
-    Package: "exec-function-stderr"
-    [RUNNING] "./testdata/fn-render/exec-function-stderr/function.sh"
+    Package "exec-function-stderr":
+    [RUNNING] "./testdata/fn-render/exec-function-stderr/function.sh" on package "exec-function-stderr"
     [PASS] "./testdata/fn-render/exec-function-stderr/function.sh" in 0s
      Stderr: Hello world 0!, Hello world 1!, Hello world 2!, Hello world 3!, Hello world 4!, Hello world 5!, Hello world 6!, Hello world 7!, Hello world 8!, Hello world 9!, Hello world 10!, Hello world 11!, Hello world 12!, Hello world 13!, Hello world 14!, Hello world 15!, Hello world 16!, Hello world 17!, Hello world 18!, Hello world 19!, Hello world 20!, Successfully executed 1 function(s) in 1 package(s).

--- a/e2e/testdata/fn-render/fn-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/fn-failure/.expected/config.yaml
@@ -19,6 +19,9 @@ stdErr: |
   Package "fn-failure":
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/starlark:latest" on package "fn-failure"
   [FAIL] "ghcr.io/kptdev/krm-functions-catalog/starlark:latest" in 0s
-  [Results]: [error]: httpbin-gen:3:73: got newline, want primary expression
-   Stderr: failed to evaluate function: error: function failure  Exit code: 1
+    [Results]:
+      [error]: httpbin-gen:3:73: got newline, want primary expression
+    Stderr:
+      failed to evaluate function: error: function failure
+    Exit code: 1
 

--- a/e2e/testdata/fn-render/fn-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/fn-failure/.expected/config.yaml
@@ -16,8 +16,8 @@
 # non-zero exit code and no changes in the resources.
 exitCode: 1
 stdErr: |
-  Package: "fn-failure"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/starlark:latest"
+  Package "fn-failure":
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/starlark:latest" on package "fn-failure"
   [FAIL] "ghcr.io/kptdev/krm-functions-catalog/starlark:latest" in 0s
   [Results]: [error]: httpbin-gen:3:73: got newline, want primary expression
    Stderr: failed to evaluate function: error: function failure  Exit code: 1

--- a/e2e/testdata/fn-render/no-fnconfig/.expected/config.yaml
+++ b/e2e/testdata/fn-render/no-fnconfig/.expected/config.yaml
@@ -22,11 +22,11 @@ stdErrStripLines:
 exitCode: 1
 
 stdErr: |
-  Package: "no-fnconfig"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  Package "no-fnconfig":
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on package "no-fnconfig"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
   [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on package "no-fnconfig"
   [FAIL] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
   [Results]: [info]: `FunctionConfig` is not given
    Stderr: failed to evaluate function: error: function failure  Exit code: 1

--- a/e2e/testdata/fn-render/no-fnconfig/.expected/config.yaml
+++ b/e2e/testdata/fn-render/no-fnconfig/.expected/config.yaml
@@ -25,8 +25,12 @@ stdErr: |
   Package "no-fnconfig":
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on package "no-fnconfig"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on package "no-fnconfig"
   [FAIL] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
-  [Results]: [info]: `FunctionConfig` is not given
-   Stderr: failed to evaluate function: error: function failure  Exit code: 1
+    [Results]:
+      [info]: `FunctionConfig` is not given
+      failed to evaluate function: error: function failure
+    Exit code: 1

--- a/e2e/testdata/fn-render/out-of-place-dir/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-dir/.expected/config.yaml
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on package "out-of-place-dir"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s

--- a/e2e/testdata/fn-render/out-of-place-fnchain-stdout-results/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-stdout-results/.expected/config.yaml
@@ -78,5 +78,5 @@ stdOut: |
         configMap:
           namespace: staging
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on package "out-of-place-fnchain-stdout-results"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s

--- a/e2e/testdata/fn-render/out-of-place-fnchain-stdout/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-stdout/.expected/config.yaml
@@ -6,13 +6,21 @@ stdErr: |
   Package "out-of-place-fnchain-stdout":
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on package "out-of-place-fnchain-stdout"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest" in 0s
-  [Results]: [info] metadata.annotations: set annotations: {"foo":"bar"}, [info] metadata.annotations: set annotations: {"foo":"bar"}, [info] spec.template.metadata.annotations: set annotations: {"foo":"bar"}, [info] metadata.annotations: set annotations: {"foo":"bar"}
+    [Results]:
+      [info] metadata.annotations: set annotations: {"foo":"bar"}
+      [info] metadata.annotations: set annotations: {"foo":"bar"}
+      [info] spec.template.metadata.annotations: set annotations: {"foo":"bar"}
+      [info] metadata.annotations: set annotations: {"foo":"bar"}
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
-  [Results]: [info]: set 5 labels in total
+    [Results]:
+      [info]: set 5 labels in total
 
 stdOut: |
   apiVersion: config.kubernetes.io/v1

--- a/e2e/testdata/fn-render/out-of-place-fnchain-stdout/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-stdout/.expected/config.yaml
@@ -3,8 +3,8 @@ stdErrStripLines:
   - "    \"WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\""
 
 stdErr: |
-  Package: "out-of-place-fnchain-stdout"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  Package "out-of-place-fnchain-stdout":
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on package "out-of-place-fnchain-stdout"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
   [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-annotations:latest"

--- a/e2e/testdata/fn-render/out-of-place-stdout/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-stdout/.expected/config.yaml
@@ -3,7 +3,7 @@ stdErrStripLines:
   - "    \"WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\""
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on package "out-of-place-stdout"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
 
 stdOut: |

--- a/e2e/testdata/fn-render/out-of-place-unwrap/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-unwrap/.expected/config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 stdErr: |
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on package "out-of-place-unwrap"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
 
 stdOut: |

--- a/e2e/testdata/fn-render/selectors/basicpipeline/.expected/config.yaml
+++ b/e2e/testdata/fn-render/selectors/basicpipeline/.expected/config.yaml
@@ -23,9 +23,13 @@ stdErr: |
   Package "basicpipeline":
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s) on package "basicpipeline"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on package "basicpipeline"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
-  [Results]: [info]: set 4 labels in total
+    [Results]:
+      [info]: set 4 labels in total
+
   Successfully executed 2 function(s) in 1 package(s).
 

--- a/e2e/testdata/fn-render/selectors/basicpipeline/.expected/config.yaml
+++ b/e2e/testdata/fn-render/selectors/basicpipeline/.expected/config.yaml
@@ -20,11 +20,11 @@ stdErrStripLines:
   - "    \"WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\""
 
 stdErr: |
-  Package: "basicpipeline"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  Package "basicpipeline":
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s) on package "basicpipeline"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
   [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on package "basicpipeline"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
   [Results]: [info]: set 4 labels in total
   Successfully executed 2 function(s) in 1 package(s).

--- a/e2e/testdata/fn-render/selectors/exclude/.expected/config.yaml
+++ b/e2e/testdata/fn-render/selectors/exclude/.expected/config.yaml
@@ -20,11 +20,11 @@ stdErrStripLines:
   - "    \"WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\""
 
 stdErr: |
-  Package: "exclude"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  Package "exclude":
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s) on package "exclude"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
   [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on 2 resource(s)
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on 2 resource(s) on package "exclude"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
   [Results]: [info]: set 3 labels in total
   Successfully executed 2 function(s) in 1 package(s).

--- a/e2e/testdata/fn-render/selectors/exclude/.expected/config.yaml
+++ b/e2e/testdata/fn-render/selectors/exclude/.expected/config.yaml
@@ -23,8 +23,12 @@ stdErr: |
   Package "exclude":
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s) on package "exclude"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on 2 resource(s) on package "exclude"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
-  [Results]: [info]: set 3 labels in total
+    [Results]:
+      [info]: set 3 labels in total
+
   Successfully executed 2 function(s) in 1 package(s).

--- a/e2e/testdata/fn-render/selectors/generator/.expected/config.yaml
+++ b/e2e/testdata/fn-render/selectors/generator/.expected/config.yaml
@@ -20,20 +20,20 @@ stdErrStripLines:
   - "    \"WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\""
 
 stdErr: |
-  Package: "generator/db"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/starlark:latest"
+  Package "generator/db":
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/starlark:latest" on package "generator/db"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/starlark:latest" in 0s
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s) on package "generator/db"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
   [Results]: [info]: namespace [default] updated to "db", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on 1 resource(s)
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on 1 resource(s) on package "generator/db"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
   [Results]: [info]: set 3 labels in total
-  Package: "generator"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  Package "generator":
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s) on package "generator"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
   [Results]: [info]: namespace [db] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on 1 resource(s)
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on 1 resource(s) on package "generator"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
   [Results]: [info]: set 3 labels in total
   Successfully executed 5 function(s) in 2 package(s).

--- a/e2e/testdata/fn-render/selectors/generator/.expected/config.yaml
+++ b/e2e/testdata/fn-render/selectors/generator/.expected/config.yaml
@@ -25,15 +25,23 @@ stdErr: |
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/starlark:latest" in 0s
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s) on package "generator/db"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "db", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "db", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on 1 resource(s) on package "generator/db"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
-  [Results]: [info]: set 3 labels in total
+    [Results]:
+      [info]: set 3 labels in total
+
   Package "generator":
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s) on package "generator"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [db] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [db] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on 1 resource(s) on package "generator"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
-  [Results]: [info]: set 3 labels in total
+    [Results]:
+      [info]: set 3 labels in total
+
   Successfully executed 5 function(s) in 2 package(s).

--- a/e2e/testdata/fn-render/selectors/selectors-with-exclude/.expected/config.yaml
+++ b/e2e/testdata/fn-render/selectors/selectors-with-exclude/.expected/config.yaml
@@ -23,8 +23,12 @@ stdErr: |
   Package "selectors-with-exclude":
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s) on package "selectors-with-exclude"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on package "selectors-with-exclude"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
-  [Results]: [info]: set 4 labels in total
+    [Results]:
+      [info]: set 4 labels in total
+
   Successfully executed 2 function(s) in 1 package(s).

--- a/e2e/testdata/fn-render/selectors/selectors-with-exclude/.expected/config.yaml
+++ b/e2e/testdata/fn-render/selectors/selectors-with-exclude/.expected/config.yaml
@@ -20,11 +20,11 @@ stdErrStripLines:
   - "    \"WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested\""
 
 stdErr: |
-  Package: "selectors-with-exclude"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s)
+  Package "selectors-with-exclude":
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on 1 resource(s) on package "selectors-with-exclude"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
   [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on package "selectors-with-exclude"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
   [Results]: [info]: set 4 labels in total
   Successfully executed 2 function(s) in 1 package(s).

--- a/e2e/testdata/fn-render/short-image-path/.expected/config.yaml
+++ b/e2e/testdata/fn-render/short-image-path/.expected/config.yaml
@@ -16,11 +16,11 @@ actualStripLines:
   - "    stderr: 'WARNING: The requested image''s platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested'"
 
 stdErr: |
-  Package: "short-image-path"
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest"
+  Package "short-image-path":
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on package "short-image-path"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
   [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
-  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+  [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on package "short-image-path"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
   [Results]: [info]: set 4 labels in total
   Successfully executed 2 function(s) in 1 package(s).

--- a/e2e/testdata/fn-render/short-image-path/.expected/config.yaml
+++ b/e2e/testdata/fn-render/short-image-path/.expected/config.yaml
@@ -19,10 +19,14 @@ stdErr: |
   Package "short-image-path":
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" on package "short-image-path"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest" in 0s
-  [Results]: [info]: namespace [default] updated to "staging", 1 value(s) changed, [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
+    [Results]:
+      [info]: namespace [default] updated to "staging", 1 value(s) changed
+      [info]: all `depends-on` annotations are up-to-date. no `namespace` changed
   [RUNNING] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" on package "short-image-path"
   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest" in 0s
-  [Results]: [info]: set 4 labels in total
+    [Results]:
+      [info]: set 4 labels in total
+
   Successfully executed 2 function(s) in 1 package(s).
   For complete results, see results/results.yaml
 

--- a/pkg/fn/render.go
+++ b/pkg/fn/render.go
@@ -24,6 +24,9 @@ import (
 type RenderOptions struct {
 	PkgPath string
 	Runtime FunctionRuntime
+
+	// Deprecated: use RunnerOptions.PackageName instead
+	//
 	// DisplayName is a human-readable name used for logs and diagnostics.
 	// It is not intended to be a unique or stable identifier; if empty, no
 	// explicit display name was provided.

--- a/pkg/fn/runtime/fnerrors_test.go
+++ b/pkg/fn/runtime/fnerrors_test.go
@@ -31,7 +31,8 @@ func TestExecErrorString(t *testing.T) {
 		{
 			name:        "no truncate - empty stderr",
 			fnExecError: ExecError{},
-			expected: `[Stderr]:   Exit Code: 0
+			expected: `[Stderr]:
+  Exit Code: 0
 `,
 		},
 		{
@@ -41,7 +42,8 @@ func TestExecErrorString(t *testing.T) {
 error message2`,
 				ExitCode: 1,
 			},
-			expected: `[Stderr]: error message1, error message2  Exit Code: 1
+			expected: `[Stderr]:
+error message1, error message2  Exit Code: 1
 `,
 		},
 		{
@@ -54,7 +56,8 @@ error message
 error message`,
 				ExitCode: 1,
 			},
-			expected: `[Stderr]: error message, error message, error message, error message, error message  Exit Code: 1
+			expected: `[Stderr]:
+error message, error message, error message, error message, error message  Exit Code: 1
 `,
 		},
 		{
@@ -67,7 +70,8 @@ error message`,
 				ExitCode: 1,
 			},
 			truncate: true,
-			expected: `[Stderr]: error message, error message, error message, error message  Exit Code: 1
+			expected: `[Stderr]:
+error message, error message, error message, error message  Exit Code: 1
 `,
 		},
 		{
@@ -81,7 +85,8 @@ error message`,
 				ExitCode: 1,
 			},
 			truncate: true,
-			expected: `[Stderr]: error message, error message, error message, error message, error message  Exit Code: 1
+			expected: `[Stderr]:
+error message, error message, error message, error message, error message  Exit Code: 1
 `,
 		},
 		{
@@ -98,7 +103,8 @@ error message`,
 				ExitCode: 1,
 			},
 			truncate: true,
-			expected: `[Stderr]: error message, error message, error message, error message, error message, error message, error message, error message  Exit Code: 1
+			expected: `[Stderr]:
+error message, error message, error message, error message, error message, error message, error message, error message  Exit Code: 1
 `,
 		},
 	}

--- a/pkg/fn/runtime/runner.go
+++ b/pkg/fn/runtime/runner.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -225,6 +226,7 @@ type FunctionRunner struct {
 
 func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err error) {
 	pr := printer.FromContextOrDie(fr.ctx)
+	// prOpts := printer.NewOpt().DisplayName(fr.opts.FullDisplayName).Path(fr.pkgPath)
 	fnName := fr.name
 	if fr.opts.TruncateImageName {
 		baseName, tag := baseNameAndTag(fr.name)
@@ -235,27 +237,28 @@ func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err
 		}
 	}
 	if !fr.disableCLIOutput {
+		sb := strings.Builder{}
+		sb.WriteString("[RUNNING] ")
 		if fr.opts.AllowWasm {
-			pr.Printf("[RUNNING] WASM %q", fnName)
-		} else {
-			pr.Printf("[RUNNING] %q", fnName)
+			sb.WriteString("WASM ")
 		}
+		sb.WriteString(strconv.Quote(fnName))
 		if fr.opts.DisplayResourceCount {
-			pr.Printf(" on %d resource(s)", len(input))
+			sb.WriteString(" on " + strconv.Itoa(len(input)) + " resource(s)")
 		}
-		if fr.opts.RootPackageName != "" {
-			pr.Printf(" on package %q", fr.opts.RootPackageName)
+		if fr.opts.FullDisplayName != "" {
+			sb.WriteString(" on package " + strconv.Quote(fr.opts.FullDisplayName))
 		} else if fr.pkgPath != "" {
-			pr.Printf(" on package at path %q", fr.pkgPath)
+			sb.WriteString(" on package at path " + strconv.Quote(fr.pkgPath.String()))
 		}
-		pr.Printf("\n")
+		sb.WriteString("\n")
+		pr.Printf("%s", sb.String()) // TODO: use OptPrintf
 	}
 	t0 := time.Now()
 	output, err = fr.do(input)
-	printerOpts := printer.NewOpt().DisplayName(fr.opts.RootPackageName).Path(fr.pkgPath)
 	if err != nil {
-		pr.OptPrintf(printerOpts, "[FAIL] %q in %v\n", fnName, time.Since(t0).Truncate(time.Millisecond*100))
-		printFnResult(fr.ctx, fr.fnResult, printerOpts)
+		pr.OptPrintf(printer.NewOpt(), "[FAIL] %q in %v\n", fnName, time.Since(t0).Truncate(time.Millisecond*100)) // TODO: use OptPrintf correctly
+		printFnResult(fr.ctx, fr.fnResult, printer.NewOpt())                                                       // TODO: pass opts
 		if fnErr, ok := goerrors.AsType[*ExecError](err); ok {
 			printFnExecErr(fr.ctx, fnErr)
 			return nil, errors.ErrAlreadyHandled
@@ -263,8 +266,8 @@ func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err
 		return nil, err
 	}
 	if !fr.disableCLIOutput {
-		pr.OptPrintf(printerOpts, "[PASS] %q in %v\n", fnName, time.Since(t0).Truncate(time.Millisecond*100))
-		printFnResult(fr.ctx, fr.fnResult, printerOpts)
+		pr.Printf("[PASS] %q in %v\n", fnName, time.Since(t0).Truncate(time.Millisecond*100)) // TODO: use OptPrintf
+		printFnResult(fr.ctx, fr.fnResult, printer.NewOpt())                                  // TODO: pass opts
 		printFnStderr(fr.ctx, fr.fnResult.Stderr)
 	}
 	return output, err

--- a/pkg/fn/runtime/runner.go
+++ b/pkg/fn/runtime/runner.go
@@ -228,7 +228,7 @@ func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err
 	pr := printer.FromContextOrDie(fr.ctx)
 	// prOpts := printer.NewOpt().DisplayName(fr.opts.FullDisplayName).Path(fr.pkgPath)
 	fnName := fr.name
-	if fr.opts.TruncateImageName {
+	if fr.opts.LogOptions.TruncateImageName {
 		baseName, tag := baseNameAndTag(fr.name)
 		if tag != "" {
 			fnName = fmt.Sprintf("%s (%s)", baseName, tag)

--- a/pkg/fn/runtime/runner.go
+++ b/pkg/fn/runtime/runner.go
@@ -243,17 +243,19 @@ func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err
 		if fr.opts.DisplayResourceCount {
 			pr.Printf(" on %d resource(s)", len(input))
 		}
-		if fr.opts.PackageName != "" {
-			pr.Printf(" on package %q", fr.opts.PackageName)
+		if fr.opts.RootPackageName != "" {
+			pr.Printf(" on package %q", fr.opts.RootPackageName)
+		} else if fr.pkgPath != "" {
+			pr.Printf(" on package at path %q", fr.pkgPath)
 		}
 		pr.Printf("\n")
 	}
 	t0 := time.Now()
 	output, err = fr.do(input)
+	printerOpts := printer.NewOpt().DisplayName(fr.opts.RootPackageName).Path(fr.pkgPath)
 	if err != nil {
-		printOpt := printer.NewOpt()
-		pr.OptPrintf(printOpt, "[FAIL] %q in %v\n", fnName, time.Since(t0).Truncate(time.Millisecond*100))
-		printFnResult(fr.ctx, fr.fnResult, printOpt)
+		pr.OptPrintf(printerOpts, "[FAIL] %q in %v\n", fnName, time.Since(t0).Truncate(time.Millisecond*100))
+		printFnResult(fr.ctx, fr.fnResult, printerOpts)
 		if fnErr, ok := goerrors.AsType[*ExecError](err); ok {
 			printFnExecErr(fr.ctx, fnErr)
 			return nil, errors.ErrAlreadyHandled
@@ -261,8 +263,8 @@ func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err
 		return nil, err
 	}
 	if !fr.disableCLIOutput {
-		pr.Printf("[PASS] %q in %v\n", fnName, time.Since(t0).Truncate(time.Millisecond*100))
-		printFnResult(fr.ctx, fr.fnResult, printer.NewOpt())
+		pr.OptPrintf(printerOpts, "[PASS] %q in %v\n", fnName, time.Since(t0).Truncate(time.Millisecond*100))
+		printFnResult(fr.ctx, fr.fnResult, printerOpts)
 		printFnStderr(fr.ctx, fr.fnResult.Stderr)
 	}
 	return output, err

--- a/pkg/fn/runtime/runner.go
+++ b/pkg/fn/runtime/runner.go
@@ -257,8 +257,8 @@ func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err
 	t0 := time.Now()
 	output, err = fr.do(input)
 	if err != nil {
-		pr.OptPrintf(printer.NewOpt(), "[FAIL] %q in %v\n", fnName, time.Since(t0).Truncate(time.Millisecond*100)) // TODO: use OptPrintf correctly
-		printFnResult(fr.ctx, fr.fnResult, printer.NewOpt())                                                       // TODO: pass opts
+		pr.Printf("[FAIL] %q in %v\n", fnName, time.Since(t0).Truncate(time.Millisecond)) // TODO: use OptPrintf
+		printFnResult(fr.ctx, fr.fnResult)
 		if fnErr, ok := goerrors.AsType[*ExecError](err); ok {
 			printFnExecErr(fr.ctx, fnErr)
 			return nil, errors.ErrAlreadyHandled
@@ -266,8 +266,8 @@ func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err
 		return nil, err
 	}
 	if !fr.disableCLIOutput {
-		pr.Printf("[PASS] %q in %v\n", fnName, time.Since(t0).Truncate(time.Millisecond*100)) // TODO: use OptPrintf
-		printFnResult(fr.ctx, fr.fnResult, printer.NewOpt())                                  // TODO: pass opts
+		pr.Printf("[PASS] %q in %v\n", fnName, time.Since(t0).Truncate(time.Millisecond)) // TODO: use OptPrintf
+		printFnResult(fr.ctx, fr.fnResult)
 		printFnStderr(fr.ctx, fr.fnResult.Stderr)
 	}
 	return output, err
@@ -466,7 +466,7 @@ func populateResourceRef(item *yaml.RNode, resultItem *fnresultv1.ResultItem) er
 }
 
 // printFnResult prints given function result in a user-friendly format on kpt CLI.
-func printFnResult(ctx context.Context, fnResult *fnresultv1.Result, opt *printer.Options) {
+func printFnResult(ctx context.Context, fnResult *fnresultv1.Result) {
 	pr := printer.FromContextOrDie(ctx)
 	if len(fnResult.Results) > 0 {
 		// function returned structured results
@@ -478,9 +478,12 @@ func printFnResult(ctx context.Context, fnResult *fnresultv1.Result, opt *printe
 			Title:     "[Results]",
 			Lines:     lines,
 			UseQuote:  false,
-			Separator: ", ",
+			Separator: "\n",
+
+			Indent:     2,
+			LineIndent: 2,
 		}
-		pr.OptPrintf(opt, "%s\n", ri.String())
+		pr.Printf("%s\n", ri.String())
 	}
 }
 
@@ -489,7 +492,7 @@ func printFnResult(ctx context.Context, fnResult *fnresultv1.Result, opt *printe
 func printFnExecErr(ctx context.Context, fnErr *ExecError) {
 	pr := printer.FromContextOrDie(ctx)
 	printFnStderr(ctx, fnErr.Stderr)
-	pr.Printf("  Exit code: %d\n\n", fnErr.ExitCode)
+	pr.Printf("  Exit code: %d\n", fnErr.ExitCode)
 }
 
 // printFnStderr prints given stdErr in a user friendly format on kpt CLI.
@@ -500,9 +503,12 @@ func printFnStderr(ctx context.Context, stdErr string) {
 			Title:     "Stderr",
 			Lines:     strings.Split(stdErr, "\n"),
 			UseQuote:  false,
-			Separator: ", ",
+			Separator: "\n",
+
+			Indent:     2,
+			LineIndent: 2,
 		}
-		pr.Printf(" %s", errLine.String())
+		pr.Printf("%s\n", errLine.String())
 	}
 }
 

--- a/pkg/fn/runtime/runner.go
+++ b/pkg/fn/runtime/runner.go
@@ -225,19 +225,26 @@ type FunctionRunner struct {
 
 func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err error) {
 	pr := printer.FromContextOrDie(fr.ctx)
+	fnName := fr.name
+	if fr.opts.TruncateImageName {
+		baseName, tag := baseNameAndTag(fr.name)
+		if tag != "" {
+			fnName = fmt.Sprintf("%s (%s)", baseName, tag)
+		} else {
+			fnName = baseName
+		}
+	}
 	if !fr.disableCLIOutput {
 		if fr.opts.AllowWasm {
-			if fr.opts.DisplayResourceCount {
-				pr.Printf("[RUNNING] WASM %q on %d resource(s)", fr.name, len(input))
-			} else {
-				pr.Printf("[RUNNING] WASM %q", fr.name)
-			}
+			pr.Printf("[RUNNING] WASM %q", fnName)
 		} else {
-			if fr.opts.DisplayResourceCount {
-				pr.Printf("[RUNNING] %q on %d resource(s)", fr.name, len(input))
-			} else {
-				pr.Printf("[RUNNING] %q", fr.name)
-			}
+			pr.Printf("[RUNNING] %q", fnName)
+		}
+		if fr.opts.DisplayResourceCount {
+			pr.Printf(" on %d resource(s)", len(input))
+		}
+		if fr.opts.PackageName != "" {
+			pr.Printf(" on package %q", fr.opts.PackageName)
 		}
 		pr.Printf("\n")
 	}
@@ -245,7 +252,7 @@ func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err
 	output, err = fr.do(input)
 	if err != nil {
 		printOpt := printer.NewOpt()
-		pr.OptPrintf(printOpt, "[FAIL] %q in %v\n", fr.name, time.Since(t0).Truncate(time.Millisecond*100))
+		pr.OptPrintf(printOpt, "[FAIL] %q in %v\n", fnName, time.Since(t0).Truncate(time.Millisecond*100))
 		printFnResult(fr.ctx, fr.fnResult, printOpt)
 		if fnErr, ok := goerrors.AsType[*ExecError](err); ok {
 			printFnExecErr(fr.ctx, fnErr)
@@ -254,11 +261,34 @@ func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err
 		return nil, err
 	}
 	if !fr.disableCLIOutput {
-		pr.Printf("[PASS] %q in %v\n", fr.name, time.Since(t0).Truncate(time.Millisecond*100))
+		pr.Printf("[PASS] %q in %v\n", fnName, time.Since(t0).Truncate(time.Millisecond*100))
 		printFnResult(fr.ctx, fr.fnResult, printer.NewOpt())
 		printFnStderr(fr.ctx, fr.fnResult.Stderr)
 	}
 	return output, err
+}
+
+func baseNameAndTag(name string) (string, string) {
+	tag := ""
+
+	// remove digest if present
+	if at := strings.Index(name, "@"); at > -1 {
+		name = name[:at]
+	}
+
+	lastSlash := strings.LastIndex(name, "/")
+
+	if lastSlash > -1 {
+		name = name[lastSlash+1:]
+	}
+
+	firstColon := strings.Index(name, ":")
+
+	if firstColon > -1 {
+		name, tag = name[:firstColon], name[firstColon+1:]
+	}
+
+	return name, tag
 }
 
 // SetFnConfig updates the functionConfig for the FunctionRunner instance.

--- a/pkg/fn/runtime/runner_test.go
+++ b/pkg/fn/runtime/runner_test.go
@@ -113,7 +113,7 @@ func TestSingleLineFormatter(t *testing.T) {
 				UseQuote:  false,
 				Separator: ", ",
 			},
-			expected: `Summary: line1, line2, line3`,
+			expected: "Summary:\nline1, line2, line3",
 		},
 		"single line with quotes and space separator": {
 			sf: &runneroptions.SingleLineFormatter{
@@ -122,7 +122,7 @@ func TestSingleLineFormatter(t *testing.T) {
 				UseQuote:  true,
 				Separator: " ",
 			},
-			expected: `Summary: "line1" "line2" "line3"`,
+			expected: "Summary:\n\"line1\" \"line2\" \"line3\"",
 		},
 		"single line with newline suppression": {
 			sf: &runneroptions.SingleLineFormatter{
@@ -131,7 +131,7 @@ func TestSingleLineFormatter(t *testing.T) {
 				UseQuote:  false,
 				Separator: ", ",
 			},
-			expected: `Summary: line1, line2 extra, line3`,
+			expected: "Summary:\nline1, line2 extra, line3",
 		},
 		"empty lines": {
 			sf: &runneroptions.SingleLineFormatter{
@@ -140,7 +140,7 @@ func TestSingleLineFormatter(t *testing.T) {
 				UseQuote:  false,
 				Separator: ", ",
 			},
-			expected: `Empty: `,
+			expected: "Empty:\n",
 		},
 	}
 
@@ -596,7 +596,7 @@ func TestPrintFnStderr(t *testing.T) {
 4
 5`,
 			truncateOutput: true,
-			expected:       ` Stderr: 0, 1, 2, 3, 4, 5`,
+			expected:       "  Stderr:\n    0\n    1\n    2\n    3\n    4\n    5\n",
 		},
 		"non-truncated output": {
 			input: `0
@@ -606,7 +606,7 @@ func TestPrintFnStderr(t *testing.T) {
 4
 5`,
 			truncateOutput: false,
-			expected:       ` Stderr: 0, 1, 2, 3, 4, 5`,
+			expected:       "  Stderr:\n    0\n    1\n    2\n    3\n    4\n    5\n",
 		},
 	}
 	cleanupFunc := func() func() {

--- a/pkg/fn/runtime/runner_test.go
+++ b/pkg/fn/runtime/runner_test.go
@@ -847,3 +847,57 @@ items:
 		})
 	}
 }
+
+func TestBaseNameAndTag(t *testing.T) {
+	const digest = "sha256:7d89a74f106241391f687fc2985c8e6de597bb21f0d0014def5edc730618d9cc"
+	testCases := map[string]struct {
+		input        string
+		expectedName string
+		expectedTag  string
+	}{
+		"just basename": {
+			input:        "apply-setters",
+			expectedName: "apply-setters",
+		},
+		"basename and tag": {
+			input:        "apply-setters:v0.2.3",
+			expectedName: "apply-setters",
+			expectedTag:  "v0.2.3",
+		},
+		"with registry, no tag": {
+			input:        runneroptions.GHCRImagePrefix + "/apply-setters",
+			expectedName: "apply-setters",
+		},
+		"with registry, with tag": {
+			input:        runneroptions.GHCRImagePrefix + "/apply-setters:v0.2.3",
+			expectedName: "apply-setters",
+			expectedTag:  "v0.2.3",
+		},
+		"with digest, no tag": {
+			input:        "apply-setters@" + digest,
+			expectedName: "apply-setters",
+		},
+		"with digest, with tag": {
+			input:        "apply-setters:v0.2.3@" + digest,
+			expectedName: "apply-setters",
+			expectedTag:  "v0.2.3",
+		},
+		"fully qualified": {
+			input:        runneroptions.GHCRImagePrefix + "/apply-setters:v0.2.3@" + digest,
+			expectedName: "apply-setters",
+			expectedTag:  "v0.2.3",
+		},
+		"executable path": {
+			input:        "/usr/bin/apply-setters",
+			expectedName: "apply-setters",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			baseName, tag := baseNameAndTag(tc.input)
+			assert.Equal(t, tc.expectedName, baseName)
+			assert.Equal(t, tc.expectedTag, tag)
+		})
+	}
+}

--- a/pkg/lib/kptops/render.go
+++ b/pkg/lib/kptops/render.go
@@ -40,8 +40,8 @@ type renderer struct {
 var _ fn.Renderer = &renderer{}
 
 func (r *renderer) Render(ctx context.Context, pkg filesys.FileSystem, opts fn.RenderOptions) (*fnresultv1.ResultList, error) {
-	if opts.DisplayName != "" && r.runnerOptions.PackageName == "" { //nolint:staticcheck // SA1019
-		r.runnerOptions.PackageName = opts.DisplayName //nolint:staticcheck // SA1019
+	if opts.DisplayName != "" && r.runnerOptions.RootPackageName == "" { //nolint:staticcheck // SA1019
+		r.runnerOptions.RootPackageName = opts.DisplayName //nolint:staticcheck // SA1019
 	}
 
 	rr := Renderer{

--- a/pkg/lib/kptops/render.go
+++ b/pkg/lib/kptops/render.go
@@ -40,10 +40,13 @@ type renderer struct {
 var _ fn.Renderer = &renderer{}
 
 func (r *renderer) Render(ctx context.Context, pkg filesys.FileSystem, opts fn.RenderOptions) (*fnresultv1.ResultList, error) {
+	if opts.DisplayName != "" && r.runnerOptions.PackageName == "" { //nolint:staticcheck // SA1019
+		r.runnerOptions.PackageName = opts.DisplayName //nolint:staticcheck // SA1019
+	}
+
 	rr := Renderer{
 		PkgPath:       opts.PkgPath,
 		Runtime:       opts.Runtime,
-		DisplayName:   opts.DisplayName,
 		FileSystem:    pkg,
 		RunnerOptions: r.runnerOptions,
 	}

--- a/pkg/lib/kptops/render.go
+++ b/pkg/lib/kptops/render.go
@@ -40,8 +40,8 @@ type renderer struct {
 var _ fn.Renderer = &renderer{}
 
 func (r *renderer) Render(ctx context.Context, pkg filesys.FileSystem, opts fn.RenderOptions) (*fnresultv1.ResultList, error) {
-	if opts.DisplayName != "" && r.runnerOptions.RootPackageName == "" { //nolint:staticcheck // SA1019
-		r.runnerOptions.RootPackageName = opts.DisplayName //nolint:staticcheck // SA1019
+	if opts.DisplayName != "" && r.runnerOptions.RootDisplayName == "" { //nolint:staticcheck // SA1019
+		r.runnerOptions.RootDisplayName = opts.DisplayName //nolint:staticcheck // SA1019
 	}
 
 	rr := Renderer{
@@ -58,7 +58,7 @@ type packagePrinter struct{}
 var _ printer.Printer = &packagePrinter{}
 
 const (
-	packagePrefixFormat = "Package: %q"
+	packagePrefixFormat = "Package %q:"
 	logDepth            = 2
 )
 
@@ -82,11 +82,11 @@ func (p *packagePrinter) OptPrintf(opt *printer.Options, format string, args ...
 	var prefix string
 	switch {
 	case opt.PkgDisplayName != "":
-		prefix = fmt.Sprintf("Package %q: ", opt.PkgDisplayName)
+		prefix = fmt.Sprintf(packagePrefixFormat, opt.PkgDisplayName)
 	case !opt.PkgDisplayPath.Empty():
-		prefix = fmt.Sprintf("Package %q: ", string(opt.PkgDisplayPath))
+		prefix = fmt.Sprintf(packagePrefixFormat, string(opt.PkgDisplayPath))
 	case !opt.PkgPath.Empty():
-		prefix = fmt.Sprintf("Package %q: ", string(opt.PkgPath))
+		prefix = fmt.Sprintf(packagePrefixFormat, string(opt.PkgPath))
 	}
 	p.printfDepth(logDepth, prefix+format, args...)
 }

--- a/pkg/lib/kptops/render.go
+++ b/pkg/lib/kptops/render.go
@@ -40,9 +40,10 @@ type renderer struct {
 var _ fn.Renderer = &renderer{}
 
 func (r *renderer) Render(ctx context.Context, pkg filesys.FileSystem, opts fn.RenderOptions) (*fnresultv1.ResultList, error) {
-	if opts.DisplayName != "" && r.runnerOptions.RootDisplayName == "" { //nolint:staticcheck // SA1019
-		r.runnerOptions.RootDisplayName = opts.DisplayName //nolint:staticcheck // SA1019
-	}
+	// TODO: deal with this
+	// if opts.DisplayName != "" && r.runnerOptions.RootDisplayName == "" { //nolint:staticcheck // SA1019
+	//	 r.runnerOptions.RootDisplayName = opts.DisplayName //nolint:staticcheck // SA1019
+	// }
 
 	rr := Renderer{
 		PkgPath:       opts.PkgPath,

--- a/pkg/lib/kptops/render_executor.go
+++ b/pkg/lib/kptops/render_executor.go
@@ -708,8 +708,9 @@ func (pn *pkgNode) runPipeline(ctx context.Context, hctx *hydrationContext, inpu
 	// package structure. We should have function to get the relative package
 	// path here.
 	prOpts := printer.NewOpt().
+		Path(pn.pkg.UniquePath).
 		DisplayPath(pn.pkg.DisplayPath).
-		DisplayName(hctx.runnerOptions.PackageName)
+		DisplayName(hctx.runnerOptions.RootPackageName)
 	pr.OptPrintf(prOpts, "\n")
 
 	pl, err := pn.pkg.Pipeline()
@@ -731,11 +732,11 @@ func (pn *pkgNode) runPipeline(ctx context.Context, hctx *hydrationContext, inpu
 
 	mutatedResources, err := pn.runMutators(ctx, hctx, input)
 	if err != nil {
-		return mutatedResources, errors.E(op, hctx.runnerOptions.PackageName, pn.pkg.UniquePath, err)
+		return mutatedResources, errors.E(op, hctx.runnerOptions.RootPackageName, pn.pkg.UniquePath, err)
 	}
 
 	if err = pn.runValidators(ctx, hctx, mutatedResources); err != nil {
-		return mutatedResources, errors.E(op, hctx.runnerOptions.PackageName, pn.pkg.UniquePath, err)
+		return mutatedResources, errors.E(op, hctx.runnerOptions.RootPackageName, pn.pkg.UniquePath, err)
 	}
 	return mutatedResources, nil
 }

--- a/pkg/lib/kptops/render_executor.go
+++ b/pkg/lib/kptops/render_executor.go
@@ -704,8 +704,7 @@ func buildPipelineInputWithScopedVisibility(node *pkgNode, childrenMap map[kptfi
 func (pn *pkgNode) runPipeline(ctx context.Context, hctx *hydrationContext, input []*yaml.RNode) ([]*yaml.RNode, error) {
 	const op errors.Op = "pipeline.run"
 
-	// TODO: the way this constructs the subpackage name does not fit Porch
-	hctx.runnerOptions.FullDisplayName = resolveFullDisplayName(pn.pkg, hctx.runnerOptions.RootDisplayName)
+	hctx.runnerOptions.FullDisplayName = resolveFullDisplayName(pn.pkg, hctx.runnerOptions.LogOptions)
 
 	pr := printer.FromContextOrDie(ctx)
 	// TODO: the DisplayPath is a relative file path. It cannot represent the
@@ -749,37 +748,34 @@ func (pn *pkgNode) runPipeline(ctx context.Context, hctx *hydrationContext, inpu
 // resolveFullDisplayName constructs the "display name" of the current (sub)package
 // based on the parents' Kptfile metadata.name.
 // If `root` is non-empty, we substitute the first package's name.
-func resolveFullDisplayName(p *pkg.Pkg, root string) string {
+func resolveFullDisplayName(p *pkg.Pkg, opts runneroptions.LogOptions) string {
 	var names []string
 	for pp := p; pp != nil; pp = pp.Parent {
-		names = append(names, resolvePackageName(pp))
+		names = append(names, resolvePackageName(pp, opts.PkgNameID))
 	}
 
 	slices.Reverse(names)
-	if root != "" {
-		names[0] = root
-	}
-	return strings.Join(names, "/")
+	return fmt.Sprintf(opts.PkgNameFormat, strings.Join(names, opts.PkgNameSep))
 }
 
-func resolvePackageName(p *pkg.Pkg) string {
-	kptfile, err := p.Kptfile()
-	// try Kptfile metadata name first
-	if err == nil && kptfile.Name != "" {
-		return kptfile.Name
-	}
+func resolvePackageName(p *pkg.Pkg, typ runneroptions.PackageIDType) string {
+	switch typ {
+	case runneroptions.DirName:
+		if p.DisplayPath != "" {
+			if lastSlash := strings.LastIndex(string(p.DisplayPath), "/"); lastSlash > -1 {
+				return string(p.DisplayPath)[lastSlash+1:]
+			}
 
-	// try the basename of the directory
-	if p.DisplayPath != "" {
-		if lastSlash := strings.Index(string(p.DisplayPath), "/"); lastSlash > -1 {
-			return string(p.DisplayPath)[lastSlash+1:]
+			return string(p.DisplayPath)
 		}
-
-		return string(p.DisplayPath)
+	case runneroptions.KptfileMeta:
+		kptfile, err := p.Kptfile()
+		if err == nil && kptfile.Name != "" {
+			return kptfile.Name
+		}
 	}
 
-	// this should never happen
-	return "<UNKNOWN>"
+	return "<unknown>"
 }
 
 // runMutators runs a set of mutators functions on given input resources.

--- a/pkg/lib/kptops/render_executor.go
+++ b/pkg/lib/kptops/render_executor.go
@@ -84,13 +84,13 @@ func (e *Renderer) Execute(ctx context.Context) (*fnresultv1.ResultList, error) 
 
 	// initialize hydration context
 	hctx := &hydrationContext{
-		root:          root,
-		rootName:      e.DisplayName,
-		pkgs:          map[kptfilev1.UniquePath]*pkgNode{},
-		fnResults:     fnresultv1.NewResultList(),
-		runnerOptions: e.RunnerOptions,
-		fileSystem:    e.FileSystem,
-		runtime:       e.Runtime,
+		root:           root,
+		pkgDisplayName: e.DisplayName,
+		pkgs:           map[kptfilev1.UniquePath]*pkgNode{},
+		fnResults:      fnresultv1.NewResultList(),
+		runnerOptions:  e.RunnerOptions,
+		fileSystem:     e.FileSystem,
+		runtime:        e.Runtime,
 	}
 
 	kptfile, err := kptfileutil.ReadKptfile(e.FileSystem, e.PkgPath)
@@ -352,7 +352,7 @@ type hydrationContext struct {
 	// function runtime
 	runtime fn.FunctionRuntime
 
-	rootName string
+	pkgDisplayName string
 }
 
 // pkgNode represents a package being hydrated. Think of it as a node in the hydration DAG.
@@ -714,9 +714,8 @@ func (pn *pkgNode) runPipeline(ctx context.Context, hctx *hydrationContext, inpu
 	// package structure. We should have function to get the relative package
 	// path here.
 	prOpts := printer.NewOpt().
-		DisplayName(pn.pkg.DisplayName).
 		DisplayPath(pn.pkg.DisplayPath).
-		DisplayName(hctx.rootName)
+		DisplayName(hctx.pkgDisplayName)
 	pr.OptPrintf(prOpts, "\n")
 
 	pl, err := pn.pkg.Pipeline()
@@ -738,11 +737,11 @@ func (pn *pkgNode) runPipeline(ctx context.Context, hctx *hydrationContext, inpu
 
 	mutatedResources, err := pn.runMutators(ctx, hctx, input)
 	if err != nil {
-		return mutatedResources, errors.E(op, hctx.rootName, pn.pkg.UniquePath, err)
+		return mutatedResources, errors.E(op, hctx.pkgDisplayName, pn.pkg.UniquePath, err)
 	}
 
 	if err = pn.runValidators(ctx, hctx, mutatedResources); err != nil {
-		return mutatedResources, errors.E(op, hctx.rootName, pn.pkg.UniquePath, err)
+		return mutatedResources, errors.E(op, hctx.pkgDisplayName, pn.pkg.UniquePath, err)
 	}
 	return mutatedResources, nil
 }
@@ -853,6 +852,9 @@ func (pn *pkgNode) runValidators(ctx context.Context, hctx *hydrationContext, in
 		opts := hctx.runnerOptions
 		opts.SetPkgPathAnnotation = true
 		opts.DisplayResourceCount = displayResourceCount
+		if opts.PackageName == "" {
+			opts.PackageName = hctx.pkgDisplayName
+		}
 		validator, err = fnruntime.NewRunner(ctx, hctx.fileSystem, &function, pn.pkg.UniquePath, hctx.fnResults, opts, hctx.runtime)
 		if err != nil {
 			hctx.validationSteps = append(hctx.validationSteps, preExecFailureStep(function, err))
@@ -1008,6 +1010,9 @@ func fnChain(ctx context.Context, hctx *hydrationContext, pkgPath kptfilev1.Uniq
 		opts := hctx.runnerOptions
 		opts.SetPkgPathAnnotation = true
 		opts.DisplayResourceCount = displayResourceCount
+		if opts.PackageName == "" {
+			opts.PackageName = hctx.pkgDisplayName
+		}
 		runner, err = fnruntime.NewRunner(ctx, hctx.fileSystem, &fns[i], pkgPath, hctx.fnResults, opts, hctx.runtime)
 		if err != nil {
 			return nil, i, err

--- a/pkg/lib/kptops/render_executor.go
+++ b/pkg/lib/kptops/render_executor.go
@@ -66,9 +66,6 @@ type Renderer struct {
 
 	// FileSystem is the input filesystem to operate on
 	FileSystem filesys.FileSystem
-
-	// DisplayName is an optional field to modify the package name displayed in logs
-	DisplayName string
 }
 
 // Execute runs a pipeline.
@@ -84,13 +81,12 @@ func (e *Renderer) Execute(ctx context.Context) (*fnresultv1.ResultList, error) 
 
 	// initialize hydration context
 	hctx := &hydrationContext{
-		root:           root,
-		pkgDisplayName: e.DisplayName,
-		pkgs:           map[kptfilev1.UniquePath]*pkgNode{},
-		fnResults:      fnresultv1.NewResultList(),
-		runnerOptions:  e.RunnerOptions,
-		fileSystem:     e.FileSystem,
-		runtime:        e.Runtime,
+		root:          root,
+		pkgs:          map[kptfilev1.UniquePath]*pkgNode{},
+		fnResults:     fnresultv1.NewResultList(),
+		runnerOptions: e.RunnerOptions,
+		fileSystem:    e.FileSystem,
+		runtime:       e.Runtime,
 	}
 
 	kptfile, err := kptfileutil.ReadKptfile(e.FileSystem, e.PkgPath)
@@ -351,8 +347,6 @@ type hydrationContext struct {
 
 	// function runtime
 	runtime fn.FunctionRuntime
-
-	pkgDisplayName string
 }
 
 // pkgNode represents a package being hydrated. Think of it as a node in the hydration DAG.
@@ -715,7 +709,7 @@ func (pn *pkgNode) runPipeline(ctx context.Context, hctx *hydrationContext, inpu
 	// path here.
 	prOpts := printer.NewOpt().
 		DisplayPath(pn.pkg.DisplayPath).
-		DisplayName(hctx.pkgDisplayName)
+		DisplayName(hctx.runnerOptions.PackageName)
 	pr.OptPrintf(prOpts, "\n")
 
 	pl, err := pn.pkg.Pipeline()
@@ -737,11 +731,11 @@ func (pn *pkgNode) runPipeline(ctx context.Context, hctx *hydrationContext, inpu
 
 	mutatedResources, err := pn.runMutators(ctx, hctx, input)
 	if err != nil {
-		return mutatedResources, errors.E(op, hctx.pkgDisplayName, pn.pkg.UniquePath, err)
+		return mutatedResources, errors.E(op, hctx.runnerOptions.PackageName, pn.pkg.UniquePath, err)
 	}
 
 	if err = pn.runValidators(ctx, hctx, mutatedResources); err != nil {
-		return mutatedResources, errors.E(op, hctx.pkgDisplayName, pn.pkg.UniquePath, err)
+		return mutatedResources, errors.E(op, hctx.runnerOptions.PackageName, pn.pkg.UniquePath, err)
 	}
 	return mutatedResources, nil
 }
@@ -852,9 +846,6 @@ func (pn *pkgNode) runValidators(ctx context.Context, hctx *hydrationContext, in
 		opts := hctx.runnerOptions
 		opts.SetPkgPathAnnotation = true
 		opts.DisplayResourceCount = displayResourceCount
-		if opts.PackageName == "" {
-			opts.PackageName = hctx.pkgDisplayName
-		}
 		validator, err = fnruntime.NewRunner(ctx, hctx.fileSystem, &function, pn.pkg.UniquePath, hctx.fnResults, opts, hctx.runtime)
 		if err != nil {
 			hctx.validationSteps = append(hctx.validationSteps, preExecFailureStep(function, err))
@@ -1010,9 +1001,6 @@ func fnChain(ctx context.Context, hctx *hydrationContext, pkgPath kptfilev1.Uniq
 		opts := hctx.runnerOptions
 		opts.SetPkgPathAnnotation = true
 		opts.DisplayResourceCount = displayResourceCount
-		if opts.PackageName == "" {
-			opts.PackageName = hctx.pkgDisplayName
-		}
 		runner, err = fnruntime.NewRunner(ctx, hctx.fileSystem, &fns[i], pkgPath, hctx.fnResults, opts, hctx.runtime)
 		if err != nil {
 			return nil, i, err

--- a/pkg/lib/kptops/render_executor.go
+++ b/pkg/lib/kptops/render_executor.go
@@ -713,7 +713,10 @@ func (pn *pkgNode) runPipeline(ctx context.Context, hctx *hydrationContext, inpu
 	// TODO: the DisplayPath is a relative file path. It cannot represent the
 	// package structure. We should have function to get the relative package
 	// path here.
-	prOpts := printer.NewOpt().PkgDisplay(pn.pkg.DisplayPath).PkgName(hctx.rootName)
+	prOpts := printer.NewOpt().
+		DisplayName(pn.pkg.DisplayName).
+		DisplayPath(pn.pkg.DisplayPath).
+		DisplayName(hctx.rootName)
 	pr.OptPrintf(prOpts, "\n")
 
 	pl, err := pn.pkg.Pipeline()

--- a/pkg/lib/kptops/render_executor.go
+++ b/pkg/lib/kptops/render_executor.go
@@ -742,6 +742,9 @@ func (pn *pkgNode) runPipeline(ctx context.Context, hctx *hydrationContext, inpu
 	if err = pn.runValidators(ctx, hctx, mutatedResources); err != nil {
 		return mutatedResources, errors.E(op, hctx.runnerOptions.FullDisplayName, pn.pkg.UniquePath, err)
 	}
+
+	pr.Printf("\n")
+
 	return mutatedResources, nil
 }
 

--- a/pkg/lib/kptops/render_executor.go
+++ b/pkg/lib/kptops/render_executor.go
@@ -703,14 +703,19 @@ func buildPipelineInputWithScopedVisibility(node *pkgNode, childrenMap map[kptfi
 // runPipeline runs the pipeline defined at current pkgNode on given input resources.
 func (pn *pkgNode) runPipeline(ctx context.Context, hctx *hydrationContext, input []*yaml.RNode) ([]*yaml.RNode, error) {
 	const op errors.Op = "pipeline.run"
+
+	// TODO: the way this constructs the subpackage name does not fit Porch
+	hctx.runnerOptions.FullDisplayName = resolveFullDisplayName(pn.pkg, hctx.runnerOptions.RootDisplayName)
+
 	pr := printer.FromContextOrDie(ctx)
 	// TODO: the DisplayPath is a relative file path. It cannot represent the
-	// package structure. We should have function to get the relative package
-	// path here.
+	//       package structure. We should have function to get the relative package
+	//       path here.
+	// ^^^^^ did they mean something like pn.pkg.UniquePath.RelativePath()?
 	prOpts := printer.NewOpt().
 		Path(pn.pkg.UniquePath).
 		DisplayPath(pn.pkg.DisplayPath).
-		DisplayName(hctx.runnerOptions.RootPackageName)
+		DisplayName(hctx.runnerOptions.FullDisplayName)
 	pr.OptPrintf(prOpts, "\n")
 
 	pl, err := pn.pkg.Pipeline()
@@ -732,13 +737,49 @@ func (pn *pkgNode) runPipeline(ctx context.Context, hctx *hydrationContext, inpu
 
 	mutatedResources, err := pn.runMutators(ctx, hctx, input)
 	if err != nil {
-		return mutatedResources, errors.E(op, hctx.runnerOptions.RootPackageName, pn.pkg.UniquePath, err)
+		return mutatedResources, errors.E(op, hctx.runnerOptions.FullDisplayName, pn.pkg.UniquePath, err)
 	}
 
 	if err = pn.runValidators(ctx, hctx, mutatedResources); err != nil {
-		return mutatedResources, errors.E(op, hctx.runnerOptions.RootPackageName, pn.pkg.UniquePath, err)
+		return mutatedResources, errors.E(op, hctx.runnerOptions.FullDisplayName, pn.pkg.UniquePath, err)
 	}
 	return mutatedResources, nil
+}
+
+// resolveFullDisplayName constructs the "display name" of the current (sub)package
+// based on the parents' Kptfile metadata.name.
+// If `root` is non-empty, we substitute the first package's name.
+func resolveFullDisplayName(p *pkg.Pkg, root string) string {
+	var names []string
+	for pp := p; pp != nil; pp = pp.Parent {
+		names = append(names, resolvePackageName(pp))
+	}
+
+	slices.Reverse(names)
+	if root != "" {
+		names[0] = root
+	}
+	return strings.Join(names, "/")
+}
+
+func resolvePackageName(p *pkg.Pkg) string {
+	kptfile, err := p.Kptfile()
+	// try Kptfile metadata name first
+	if err == nil && kptfile.Name != "" {
+		return kptfile.Name
+	}
+
+	// try the basename of the directory
+	if p.DisplayPath != "" {
+		if lastSlash := strings.Index(string(p.DisplayPath), "/"); lastSlash > -1 {
+			return string(p.DisplayPath)[lastSlash+1:]
+		}
+
+		return string(p.DisplayPath)
+	}
+
+	// this should never happen
+	return "<UNKNOWN>"
 }
 
 // runMutators runs a set of mutators functions on given input resources.

--- a/pkg/lib/kptops/render_executor_test.go
+++ b/pkg/lib/kptops/render_executor_test.go
@@ -247,7 +247,7 @@ metadata:
 
 func setupRendererTest(t *testing.T, renderBfs bool) (*Renderer, *bytes.Buffer, context.Context) {
 	var outputBuffer bytes.Buffer
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = printer.WithContext(ctx, printer.New(&outputBuffer, &outputBuffer))
 
 	mockFileSystem := filesys.MakeFsInMemory()
@@ -302,10 +302,13 @@ metadata:
 `))
 	assert.NoError(t, err)
 
+	opts := runneroptions.RunnerOptions{}
+	opts.InitDefaults(runneroptions.GHCRImagePrefix)
 	renderer := &Renderer{
 		PkgPath:        rootPkgPath,
 		ResultsDirPath: "/results",
 		FileSystem:     mockFileSystem,
+		RunnerOptions:  opts,
 	}
 
 	return renderer, &outputBuffer, ctx
@@ -321,16 +324,16 @@ func TestRenderer_Execute_RenderOrder(t *testing.T) {
 			name:      "Use hydrateBfsOrder with renderBfs true",
 			renderBfs: true,
 			orderedOutput: []string{
-				`Package "root-package":`,
-				`Package "root-package/sibling-package":`,
+				`Package "root":`,
+				`Package "root/sibling":`,
 			},
 		},
 		{
 			name:      "Use default hydrate with renderBfs false",
 			renderBfs: false,
 			orderedOutput: []string{
-				`Package "root-package/sibling-package":`,
-				`Package "root-package":`,
+				`Package "root/sibling":`,
+				`Package "root":`,
 			},
 		},
 	}

--- a/pkg/lib/kptops/render_executor_test.go
+++ b/pkg/lib/kptops/render_executor_test.go
@@ -321,16 +321,16 @@ func TestRenderer_Execute_RenderOrder(t *testing.T) {
 			name:      "Use hydrateBfsOrder with renderBfs true",
 			renderBfs: true,
 			orderedOutput: []string{
-				`Package: "root"`,
-				`Package: "root/sibling"`,
+				`Package "root-package":`,
+				`Package "root-package/sibling-package":`,
 			},
 		},
 		{
 			name:      "Use default hydrate with renderBfs false",
 			renderBfs: false,
 			orderedOutput: []string{
-				`Package: "root/sibling"`,
-				`Package: "root"`,
+				`Package "root-package/sibling-package":`,
+				`Package "root-package":`,
 			},
 		},
 	}

--- a/pkg/lib/kptops/render_executor_test.go
+++ b/pkg/lib/kptops/render_executor_test.go
@@ -315,24 +315,22 @@ func TestRenderer_Execute_RenderOrder(t *testing.T) {
 	tests := []struct {
 		name          string
 		renderBfs     bool
-		expectedOrder func(output string) bool
+		orderedOutput []string
 	}{
 		{
 			name:      "Use hydrateBfsOrder with renderBfs true",
 			renderBfs: true,
-			expectedOrder: func(output string) bool {
-				rootIndex := strings.Index(output, `Package: "root"`)            // First
-				siblingIndex := strings.Index(output, `Package: "root/sibling"`) // Second
-				return rootIndex < siblingIndex
+			orderedOutput: []string{
+				`Package: "root"`,
+				`Package: "root/sibling"`,
 			},
 		},
 		{
 			name:      "Use default hydrate with renderBfs false",
 			renderBfs: false,
-			expectedOrder: func(output string) bool {
-				siblingIndex := strings.Index(output, `Package: "root/sibling"`) // First
-				rootIndex := strings.Index(output, `Package: "root"`)            // Fourth
-				return rootIndex > siblingIndex
+			orderedOutput: []string{
+				`Package: "root/sibling"`,
+				`Package: "root"`,
 			},
 		},
 	}
@@ -347,9 +345,20 @@ func TestRenderer_Execute_RenderOrder(t *testing.T) {
 			assert.Equal(t, 0, len(fnResults.Items))
 
 			output := outputBuffer.String()
-			assert.True(t, tc.expectedOrder(output))
+			assertOrder(t, output, tc.orderedOutput...)
 		})
 	}
+}
+
+func assertOrder(t *testing.T, output string, expected ...string) {
+	indices := make([]int, len(expected))
+	for i, logLine := range expected {
+		indices[i] = strings.Index(output, logLine)
+	}
+
+	assert.IsIncreasing(t, indices,
+		"Logs order differs from expected:\n%v\nActual:\n%s",
+		strings.Join(expected, "\n"), output)
 }
 
 func TestHydrate_ErrorCases(t *testing.T) {

--- a/pkg/lib/kptops/render_executor_util_test.go
+++ b/pkg/lib/kptops/render_executor_util_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 The kpt Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kptops
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/kptdev/kpt/pkg/lib/pkg"
+	"github.com/kptdev/kpt/pkg/lib/runneroptions"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveFullDisplayName(t *testing.T) {
+	testCases := map[string]struct {
+		opts     runneroptions.LogOptions
+		expected string
+	}{
+		"old kpt format": {
+			opts: runneroptions.LogOptions{
+				PkgNameFormat: "%s",
+				PkgNameSep:    "/",
+				PkgNameID:     runneroptions.DirName,
+			},
+			expected: "root/subpkg/child",
+		},
+		"new kpt format": {
+			opts: runneroptions.LogOptions{
+				PkgNameFormat: "%s",
+				PkgNameSep:    "/",
+				PkgNameID:     runneroptions.KptfileMeta,
+			},
+			expected: "root-package/sub-package/child-package",
+		},
+		"Porch format": {
+			opts: runneroptions.LogOptions{
+				PkgNameFormat: "repo.%s.v1",
+				PkgNameSep:    ".",
+				PkgNameID:     runneroptions.DirName,
+			},
+			expected: "repo.root.subpkg.child.v1",
+		},
+	}
+
+	r, _, _ := setupRendererTest(t, false)
+
+	rootpkg, err := pkg.New(r.FileSystem, "/root")
+	require.NoError(t, err)
+
+	rootsubpkgs, err := rootpkg.DirectSubpackages()
+	require.NoError(t, err)
+	require.Len(t, rootsubpkgs, 2)
+
+	subidx := slices.IndexFunc(rootsubpkgs, func(p *pkg.Pkg) bool {
+		return strings.Contains(string(p.UniquePath), "subpkg")
+	})
+
+	require.NotEqual(t, -1, subidx, "Could not find \"subpkg\"")
+
+	child1pkg := rootsubpkgs[subidx]
+
+	child1subpkgs, err := child1pkg.DirectSubpackages()
+	require.NoError(t, err)
+	require.Len(t, child1subpkgs, 1)
+
+	child2pkg := child1subpkgs[0]
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			actual := resolveFullDisplayName(child2pkg, tc.opts)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/pkg/lib/kptops/render_test.go
+++ b/pkg/lib/kptops/render_test.go
@@ -89,7 +89,7 @@ func TestPackagePrinter(t *testing.T) {
 		var errBuf bytes.Buffer
 		p := printer.New(io.Discard, &errBuf)
 
-		opt := printer.NewOpt().PkgName("my-package")
+		opt := printer.NewOpt().DisplayName("my-package")
 
 		p.OptPrintf(opt, "test message")
 		output := errBuf.String()
@@ -101,7 +101,7 @@ func TestPackagePrinter(t *testing.T) {
 		var errBuf bytes.Buffer
 		p := printer.New(io.Discard, &errBuf)
 
-		opt := printer.NewOpt().PkgDisplay("display/path")
+		opt := printer.NewOpt().DisplayPath("display/path")
 
 		p.OptPrintf(opt, "test message")
 		output := errBuf.String()
@@ -113,7 +113,7 @@ func TestPackagePrinter(t *testing.T) {
 		var errBuf bytes.Buffer
 		p := printer.New(io.Discard, &errBuf)
 
-		opt := printer.NewOpt().Pkg("unique/path")
+		opt := printer.NewOpt().Path("unique/path")
 
 		p.OptPrintf(opt, "test message")
 		output := errBuf.String()
@@ -126,9 +126,9 @@ func TestPackagePrinter(t *testing.T) {
 		p := printer.New(io.Discard, &errBuf)
 
 		opt := printer.NewOpt().
-			PkgName("display-name").
-			PkgDisplay("display/path").
-			Pkg("unique/path")
+			DisplayName("display-name").
+			DisplayPath("display/path").
+			Path("unique/path")
 
 		p.OptPrintf(opt, "test message")
 		output := errBuf.String()
@@ -199,7 +199,7 @@ func TestPackagePrinterStub(t *testing.T) {
 
 	t.Run("OptPrintf stub with options", func(t *testing.T) {
 		p := &packagePrinter{}
-		opt := printer.NewOpt().PkgName("my-package")
+		opt := printer.NewOpt().DisplayName("my-package")
 
 		assert.NotPanics(t, func() {
 			p.OptPrintf(opt, "test message")

--- a/pkg/lib/pkg/pkg.go
+++ b/pkg/lib/pkg/pkg.go
@@ -150,6 +150,10 @@ type Pkg struct {
 
 	// A package can contain zero or one ResourceGroup object.
 	rgFile *rgfilev1alpha1.ResourceGroup
+
+	// Parent is a pointer to the parent package.
+	// Nil if this is a root package.
+	Parent *Pkg
 }
 
 // New returns a pkg given an absolute OS-defined path.
@@ -232,6 +236,7 @@ func (p *Pkg) DirectSubpackages() ([]*Pkg, error) {
 		if err != nil {
 			return subPkgs, fmt.Errorf("failed to read package at path %q: %w", subPkgPath, err)
 		}
+		subPkg.Parent = p
 		if err := p.adjustDisplayPathForSubpkg(subPkg); err != nil {
 			return subPkgs, fmt.Errorf("failed to resolve display path for %q: %w", subPkgPath, err)
 		}

--- a/pkg/lib/pkg/pkg.go
+++ b/pkg/lib/pkg/pkg.go
@@ -139,6 +139,10 @@ type Pkg struct {
 	// be used for display purposes and is subject to change.
 	DisplayPath kptfilev1.DisplayPath
 
+	// DisplayName is a non-unique identifier used for logging.
+	// Overrides UniquePath and DisplayPath in the logs if set.
+	DisplayName string
+
 	// rootPkgParentDirPath is the absolute path to the parent directory of root package,
 	// root package is defined as the package on which the command is invoked by user
 	// this must be same for all the nested subpackages in root package

--- a/pkg/lib/pkg/pkg.go
+++ b/pkg/lib/pkg/pkg.go
@@ -139,10 +139,6 @@ type Pkg struct {
 	// be used for display purposes and is subject to change.
 	DisplayPath kptfilev1.DisplayPath
 
-	// DisplayName is a non-unique identifier used for logging.
-	// Overrides UniquePath and DisplayPath in the logs if set.
-	DisplayName string
-
 	// rootPkgParentDirPath is the absolute path to the parent directory of root package,
 	// root package is defined as the package on which the command is invoked by user
 	// this must be same for all the nested subpackages in root package

--- a/pkg/lib/runneroptions/runneroptions.go
+++ b/pkg/lib/runneroptions/runneroptions.go
@@ -164,20 +164,31 @@ type SingleLineFormatter struct {
 	Lines     []string // Lines to be joined
 	UseQuote  bool     // Whether to quote each line
 	Separator string   // Separator between lines (e.g., comma, space)
+
+	Indent     int // How many spaces to indent the whole text
+	LineIndent int // How many (extra) spaces to indent each line
 }
 
 func (sf *SingleLineFormatter) String() string {
-	strInterpolator := "%s"
+	mainIndent := strings.Repeat(" ", sf.Indent)
+
+	formatSb := strings.Builder{}
+
+	formatSb.WriteString(mainIndent)
+	formatSb.WriteString(strings.Repeat(" ", sf.LineIndent))
+
 	if sf.UseQuote {
-		strInterpolator = "%q"
+		formatSb.WriteString("%q")
+	} else {
+		formatSb.WriteString("%s")
 	}
 
 	var formattedLines []string
 	for _, line := range sf.Lines {
 		line = strings.ReplaceAll(line, "\n", " ")
 		line = strings.TrimSpace(line)
-		formattedLines = append(formattedLines, fmt.Sprintf(strInterpolator, line))
+		formattedLines = append(formattedLines, fmt.Sprintf(formatSb.String(), line))
 	}
 
-	return fmt.Sprintf("%s: %s", sf.Title, strings.Join(formattedLines, sf.Separator))
+	return fmt.Sprintf("%s%s:\n%s", mainIndent, sf.Title, strings.Join(formattedLines, sf.Separator))
 }

--- a/pkg/lib/runneroptions/runneroptions.go
+++ b/pkg/lib/runneroptions/runneroptions.go
@@ -67,22 +67,60 @@ type RunnerOptions struct {
 	// partial image reference to a fully qualified image reference
 	ImagePrefix string
 
-	// RootDisplayName is the optional display name for the *root* package.
-	// Only used for logging. Subpackage names will be appended with slashes.
-	RootDisplayName string
+	LogOptions LogOptions
 
 	// FullDisplayName is the resolved display name of the package or subpackage.
 	// Meant for internal usage, like the render executor.
 	FullDisplayName string
+}
+
+type PackageIDType int8
+
+const (
+	// Use directory name to identify the package/subpackage
+	DirName PackageIDType = iota
+	// Use Kptfile metadata.name to identify the package/subpackage
+	KptfileMeta
+)
+
+type LogOptions struct {
+	PkgNameFormat string
+	PkgNameSep    string
+	PkgNameID     PackageIDType
 
 	// TruncateImageName determines whether the full image name or just the base
 	// name and the tag will be logged.
 	TruncateImageName bool
 }
 
+func (o *LogOptions) IsZero() bool {
+	return o.PkgNameFormat == "" && o.PkgNameSep == "" && o.PkgNameID == 0 && !o.TruncateImageName
+}
+
+func (o *LogOptions) FillDefaults() {
+	defaults := DefaultLogOptions()
+	if o.PkgNameFormat == "" {
+		o.PkgNameFormat = defaults.PkgNameFormat
+	}
+	if o.PkgNameSep == "" {
+		o.PkgNameSep = defaults.PkgNameSep
+	}
+}
+
+func DefaultLogOptions() LogOptions {
+	return LogOptions{
+		PkgNameFormat: "%s",
+		PkgNameSep:    "/",
+		PkgNameID:     DirName,
+
+		TruncateImageName: false,
+	}
+}
+
 func (opts *RunnerOptions) InitDefaults(defaultImagePrefix string) {
 	opts.ImagePullPolicy = IfNotPresentPull
 	opts.ImagePrefix = defaultImagePrefix
+	opts.LogOptions = DefaultLogOptions()
 }
 
 // ResolveToImage converts the KRM function short path to the full image url.

--- a/pkg/lib/runneroptions/runneroptions.go
+++ b/pkg/lib/runneroptions/runneroptions.go
@@ -66,6 +66,13 @@ type RunnerOptions struct {
 	// ImagePrefix determines the prefix ResolveToImage will use when resolving a
 	// partial image reference to a fully qualified image reference
 	ImagePrefix string
+
+	// PackageName is the optional display name of the package. Purely for logging.
+	PackageName string
+
+	// TruncateImageName determines whether the full image name or just the base
+	// name and the tag will be logged.
+	TruncateImageName bool
 }
 
 func (opts *RunnerOptions) InitDefaults(defaultImagePrefix string) {

--- a/pkg/lib/runneroptions/runneroptions.go
+++ b/pkg/lib/runneroptions/runneroptions.go
@@ -67,9 +67,9 @@ type RunnerOptions struct {
 	// partial image reference to a fully qualified image reference
 	ImagePrefix string
 
-	// PackageName is the optional display name of the package. Purely for logging.
+	// RootPackageName is the optional display name of the package. Purely for logging.
 	// TODO: this does not account for subpackages
-	PackageName string
+	RootPackageName string
 
 	// TruncateImageName determines whether the full image name or just the base
 	// name and the tag will be logged.

--- a/pkg/lib/runneroptions/runneroptions.go
+++ b/pkg/lib/runneroptions/runneroptions.go
@@ -68,6 +68,7 @@ type RunnerOptions struct {
 	ImagePrefix string
 
 	// PackageName is the optional display name of the package. Purely for logging.
+	// TODO: this does not account for subpackages
 	PackageName string
 
 	// TruncateImageName determines whether the full image name or just the base

--- a/pkg/lib/runneroptions/runneroptions.go
+++ b/pkg/lib/runneroptions/runneroptions.go
@@ -67,9 +67,13 @@ type RunnerOptions struct {
 	// partial image reference to a fully qualified image reference
 	ImagePrefix string
 
-	// RootPackageName is the optional display name of the package. Purely for logging.
-	// TODO: this does not account for subpackages
-	RootPackageName string
+	// RootDisplayName is the optional display name for the *root* package.
+	// Only used for logging. Subpackage names will be appended with slashes.
+	RootDisplayName string
+
+	// FullDisplayName is the resolved display name of the package or subpackage.
+	// Meant for internal usage, like the render executor.
+	FullDisplayName string
 
 	// TruncateImageName determines whether the full image name or just the base
 	// name and the tag will be logged.

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -59,20 +59,20 @@ func NewOpt() *Options {
 	return &Options{}
 }
 
-// Pkg sets the package unique path in options
-func (opt *Options) Pkg(p kptfilev1.UniquePath) *Options {
+// Path sets the package unique path in options
+func (opt *Options) Path(p kptfilev1.UniquePath) *Options {
 	opt.PkgPath = p
 	return opt
 }
 
-// PkgDisplayPath sets the package display path in options
-func (opt *Options) PkgDisplay(p kptfilev1.DisplayPath) *Options {
+// DisplayPath sets the package display path in options
+func (opt *Options) DisplayPath(p kptfilev1.DisplayPath) *Options {
 	opt.PkgDisplayPath = p
 	return opt
 }
 
-// PkgName sets the package display name in options
-func (opt *Options) PkgName(name string) *Options {
+// DisplayName sets the package display name in options
+func (opt *Options) DisplayName(name string) *Options {
 	opt.PkgDisplayName = name
 	return opt
 }

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -29,7 +29,7 @@ import (
 var TruncateOutput bool
 
 const (
-	packagePrefixFormat = "Package: %q"
+	packagePrefixFormat = "Package %q:"
 )
 
 // Printer defines capabilities to display content in kpt CLI.
@@ -123,7 +123,7 @@ func (pr *printer) PrintPackage(p *pkg.Pkg, leadingNewline bool) {
 	if leadingNewline {
 		fmt.Fprint(pr.errStream, "\n")
 	}
-	fmt.Fprintf(pr.errStream, "Package: %q\n", p.DisplayPath)
+	fmt.Fprintf(pr.errStream, "Package %q:\n", p.DisplayPath)
 }
 
 // Printf is the wrapper over fmt.Printf that displays the output.

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -25,7 +25,7 @@ func TestOptPrintf_WithDisplayPath(t *testing.T) {
 	var buf bytes.Buffer
 	pr := New(&buf, &buf)
 
-	opt := NewOpt().PkgDisplay("my/display/path")
+	opt := NewOpt().DisplayPath("my/display/path")
 	pr.OptPrintf(opt, ": operation completed\n")
 
 	expected := "Package: \"my/display/path\": operation completed\n"
@@ -39,11 +39,26 @@ func TestOptPrintf_WithUniquePath(t *testing.T) {
 	var buf bytes.Buffer
 	pr := New(&buf, &buf)
 
-	opt := NewOpt().Pkg("my/unique/path")
+	opt := NewOpt().Path("my/unique/path")
 	pr.OptPrintf(opt, ": sync successful\n")
 
 	// RelativePath may fail, so fallback to absolute path
 	expected := "Package: \"my/unique/path\": sync successful\n"
+
+	if buf.String() != expected {
+		t.Errorf("Expected %q, got %q", expected, buf.String())
+	}
+}
+
+func TestOptPrintf_WithDisplayName(t *testing.T) {
+	var buf bytes.Buffer
+	pr := New(&buf, &buf)
+
+	opt := NewOpt().DisplayName("my-repo.my-package.v1")
+	pr.OptPrintf(opt, ": sync successful\n")
+
+	// RelativePath may fail, so fallback to absolute path
+	expected := "Package: \"my-repo.my-package.v1\": sync successful\n"
 
 	if buf.String() != expected {
 		t.Errorf("Expected %q, got %q", expected, buf.String())

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -26,9 +26,9 @@ func TestOptPrintf_WithDisplayPath(t *testing.T) {
 	pr := New(&buf, &buf)
 
 	opt := NewOpt().DisplayPath("my/display/path")
-	pr.OptPrintf(opt, ": operation completed\n")
+	pr.OptPrintf(opt, " operation completed\n")
 
-	expected := "Package: \"my/display/path\": operation completed\n"
+	expected := "Package \"my/display/path\": operation completed\n"
 
 	if buf.String() != expected {
 		t.Errorf("Expected %q, got %q", expected, buf.String())
@@ -40,10 +40,10 @@ func TestOptPrintf_WithUniquePath(t *testing.T) {
 	pr := New(&buf, &buf)
 
 	opt := NewOpt().Path("my/unique/path")
-	pr.OptPrintf(opt, ": sync successful\n")
+	pr.OptPrintf(opt, " sync successful\n")
 
 	// RelativePath may fail, so fallback to absolute path
-	expected := "Package: \"my/unique/path\": sync successful\n"
+	expected := "Package \"my/unique/path\": sync successful\n"
 
 	if buf.String() != expected {
 		t.Errorf("Expected %q, got %q", expected, buf.String())
@@ -55,10 +55,10 @@ func TestOptPrintf_WithDisplayName(t *testing.T) {
 	pr := New(&buf, &buf)
 
 	opt := NewOpt().DisplayName("my-repo.my-package.v1")
-	pr.OptPrintf(opt, ": sync successful\n")
+	pr.OptPrintf(opt, " sync successful\n")
 
 	// RelativePath may fail, so fallback to absolute path
-	expected := "Package: \"my-repo.my-package.v1\": sync successful\n"
+	expected := "Package \"my-repo.my-package.v1\": sync successful\n"
 
 	if buf.String() != expected {
 		t.Errorf("Expected %q, got %q", expected, buf.String())
@@ -84,7 +84,7 @@ func TestPrintPackage_WithLeadingNewline(t *testing.T) {
 	p := &pkg.Pkg{DisplayPath: "my/package/path"}
 	pr.PrintPackage(p, true)
 
-	expected := "\nPackage: \"my/package/path\"\n"
+	expected := "\nPackage \"my/package/path\":\n"
 	if buf.String() != expected {
 		t.Errorf("Expected %q, got %q", expected, buf.String())
 	}
@@ -97,7 +97,7 @@ func TestPrintPackage_WithoutLeadingNewline(t *testing.T) {
 	p := &pkg.Pkg{DisplayPath: "another/package"}
 	pr.PrintPackage(p, false)
 
-	expected := "Package: \"another/package\"\n"
+	expected := "Package \"another/package\":\n"
 	if buf.String() != expected {
 		t.Errorf("Expected %q, got %q", expected, buf.String())
 	}

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval_test.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval_test.go
@@ -222,6 +222,7 @@ apiVersion: v1
 				RunnerOptions: runneroptions.RunnerOptions{
 					ImagePullPolicy: runneroptions.IfNotPresentPull,
 					ImagePrefix:     runneroptions.GHCRImagePrefix,
+					LogOptions:      runneroptions.DefaultLogOptions(),
 				},
 				Env:                   []string{},
 				ContinueOnEmptyResult: true,
@@ -264,6 +265,7 @@ apiVersion: v1
 				RunnerOptions: runneroptions.RunnerOptions{
 					ImagePullPolicy: runneroptions.IfNotPresentPull,
 					ImagePrefix:     runneroptions.GHCRImagePrefix,
+					LogOptions:      runneroptions.DefaultLogOptions(),
 				},
 				Env:                   []string{"FOO=BAR", "BAR"},
 				ContinueOnEmptyResult: true,
@@ -292,6 +294,7 @@ apiVersion: v1
 				RunnerOptions: runneroptions.RunnerOptions{
 					ImagePullPolicy: runneroptions.IfNotPresentPull,
 					ImagePrefix:     runneroptions.GHCRImagePrefix,
+					LogOptions:      runneroptions.DefaultLogOptions(),
 				},
 				Env:                   []string{},
 				ContinueOnEmptyResult: true,


### PR DESCRIPTION
The main visible change in this PR is that now for every log line in render that starts with `[RUNNING]` we also log the package name after it. Also, the ":" in OptPrintf was moved to _after_ the package name. These were supposed to be part of the "port additional changes from Porch" but got lost somewhere in the merges.

The bulk of the changes are actually under the hood, preparing for a more in-depth change of the whole printer interface. This is mainly some new custom printer formatting options which can accomodate Porch's naming scheme for subpackages.

Auxiliary changes:
- added linker flags to all the test make targets

*Update: Looking into the docs revealed that when we merged things from Porch we actually lost a lot of the formatting (newlines, indentation, etc.). I mostly reverted those changes so the formatting now matches what was in the docs. Also updated the docs to contain the "on package..." on the appropriate lines.

AI attribution:
- Cursor's Grok 4.5 was used to update the E2E test configs the second time around.