### PR TITLE
fixed render displaying sub packages without any pipelines

### DIFF
--- a/pkg/lib/kptops/render_executor.go
+++ b/pkg/lib/kptops/render_executor.go
@@ -707,15 +707,6 @@ func (pn *pkgNode) runPipeline(ctx context.Context, hctx *hydrationContext, inpu
 	hctx.runnerOptions.FullDisplayName = resolveFullDisplayName(pn.pkg, hctx.runnerOptions.LogOptions)
 
 	pr := printer.FromContextOrDie(ctx)
-	// TODO: the DisplayPath is a relative file path. It cannot represent the
-	//       package structure. We should have function to get the relative package
-	//       path here.
-	// ^^^^^ did they mean something like pn.pkg.UniquePath.RelativePath()?
-	prOpts := printer.NewOpt().
-		Path(pn.pkg.UniquePath).
-		DisplayPath(pn.pkg.DisplayPath).
-		DisplayName(hctx.runnerOptions.FullDisplayName)
-	pr.OptPrintf(prOpts, "\n")
 
 	pl, err := pn.pkg.Pipeline()
 	if err != nil {
@@ -728,6 +719,16 @@ func (pn *pkgNode) runPipeline(ctx context.Context, hctx *hydrationContext, inpu
 		}
 		return input, nil
 	}
+
+	// TODO: the DisplayPath is a relative file path. It cannot represent the
+	//       package structure. We should have function to get the relative package
+	//       path here.
+	// ^^^^^ did they mean something like pn.pkg.UniquePath.RelativePath()?
+	prOpts := printer.NewOpt().
+		Path(pn.pkg.UniquePath).
+		DisplayPath(pn.pkg.DisplayPath).
+		DisplayName(hctx.runnerOptions.FullDisplayName)
+	pr.OptPrintf(prOpts, "\n")
 
 	// perform runtime validation for pipeline
 	if err := pn.pkg.ValidatePipeline(); err != nil {

--- a/pkg/lib/kptops/render_executor_test.go
+++ b/pkg/lib/kptops/render_executor_test.go
@@ -475,18 +475,22 @@ metadata:
 			renderer := &Renderer{
 				PkgPath:    rootPkgPath,
 				FileSystem: mockFileSystem,
-				Runtime:    &runtime{},
+				RunnerOptions: func() runneroptions.RunnerOptions {
+					opts := runneroptions.RunnerOptions{}
+					opts.InitDefaults(runneroptions.GHCRImagePrefix)
+					return opts
+				}(),
 			}
 
 			_, err = renderer.Execute(ctx)
 			assert.NoError(t, err)
 
 			output := outputBuffer.String()
-			assert.Contains(t, output, `Package: "root"`)
+			assert.Contains(t, output, `Package "root":`)
 			if tc.expectSubPkgName {
-				assert.Contains(t, output, `Package: "root/subpkg"`)
+				assert.Contains(t, output, `Package "root/subpkg":`)
 			} else {
-				assert.NotContains(t, output, `Package: "root/subpkg"`)
+				assert.NotContains(t, output, `Package "root/subpkg":`)
 			}
 		})
 	}

--- a/pkg/lib/kptops/render_executor_test.go
+++ b/pkg/lib/kptops/render_executor_test.go
@@ -261,44 +261,88 @@ func setupRendererTest(t *testing.T, renderBfs bool) (*Renderer, *bytes.Buffer, 
 	assert.NoError(t, err)
 
 	childPkgPath := "/root/subpkg/child"
-	err = mockFileSystem.Mkdir(subPkgPath)
+	err = mockFileSystem.Mkdir(childPkgPath)
 	assert.NoError(t, err)
 
 	siblingPkgPath := "/root/sibling"
-	err = mockFileSystem.Mkdir(subPkgPath)
+	err = mockFileSystem.Mkdir(siblingPkgPath)
 	assert.NoError(t, err)
 
-	err = mockFileSystem.WriteFile(filepath.Join(rootPkgPath, "Kptfile"), fmt.Appendf(nil, `
-apiVersion: kpt.dev/v1
+	err = mockFileSystem.WriteFile(filepath.Join(rootPkgPath, "Kptfile"), fmt.Appendf(nil, `apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: root-package
   annotations:
-    kpt.dev/bfs-rendering: %t
+    kpt.dev/bfs-rendering: "%t"
+pipeline:
+  mutators:
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
+      configMap:
+        app: root
 `, renderBfs))
 	assert.NoError(t, err)
 
-	err = mockFileSystem.WriteFile(filepath.Join(subPkgPath, "Kptfile"), []byte(`
-apiVersion: kpt.dev/v1
+	err = mockFileSystem.WriteFile(filepath.Join(rootPkgPath, "resources.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: root-cm
+`))
+	assert.NoError(t, err)
+
+	err = mockFileSystem.WriteFile(filepath.Join(subPkgPath, "Kptfile"), []byte(`apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: sub-package
+pipeline:
+  mutators:
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
+      configMap:
+        app: sub
 `))
 	assert.NoError(t, err)
 
-	err = mockFileSystem.WriteFile(filepath.Join(siblingPkgPath, "Kptfile"), []byte(`
-apiVersion: kpt.dev/v1
+	err = mockFileSystem.WriteFile(filepath.Join(subPkgPath, "resources.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sub-cm
+`))
+	assert.NoError(t, err)
+
+	err = mockFileSystem.WriteFile(filepath.Join(siblingPkgPath, "Kptfile"), []byte(`apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: sibling-package
+pipeline:
+  mutators:
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
+      configMap:
+        app: sibling
 `))
 	assert.NoError(t, err)
 
-	err = mockFileSystem.WriteFile(filepath.Join(childPkgPath, "Kptfile"), []byte(`
-apiVersion: kpt.dev/v1
+	err = mockFileSystem.WriteFile(filepath.Join(siblingPkgPath, "resources.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sibling-cm
+`))
+	assert.NoError(t, err)
+
+	err = mockFileSystem.WriteFile(filepath.Join(childPkgPath, "Kptfile"), []byte(`apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: child-package
+pipeline:
+  mutators:
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
+      configMap:
+        app: child
+`))
+	assert.NoError(t, err)
+
+	err = mockFileSystem.WriteFile(filepath.Join(childPkgPath, "resources.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: child-cm
 `))
 	assert.NoError(t, err)
 
@@ -345,12 +389,141 @@ func TestRenderer_Execute_RenderOrder(t *testing.T) {
 			fnResults, err := renderer.Execute(ctx)
 			assert.NoError(t, err)
 			assert.NotNil(t, fnResults)
-			assert.Equal(t, 0, len(fnResults.Items))
+			assert.Equal(t, 4, len(fnResults.Items))
 
 			output := outputBuffer.String()
 			assertOrder(t, output, tc.orderedOutput...)
 		})
 	}
+}
+func TestRunPipeline_DoesNotPrintSubpkgNameWhenPipelineIsEmpty(t *testing.T) {
+	var outputBuffer bytes.Buffer
+	ctx := context.Background()
+	ctx = printer.WithContext(ctx, printer.New(&outputBuffer, &outputBuffer))
+
+	mockFileSystem := filesys.MakeFsInMemory()
+
+	rootPkgPath := rootString
+	err := mockFileSystem.Mkdir(rootPkgPath)
+	assert.NoError(t, err)
+
+	subPkgPath := subPkgString
+	err = mockFileSystem.Mkdir(subPkgPath)
+	assert.NoError(t, err)
+
+	err = mockFileSystem.WriteFile(filepath.Join(rootPkgPath, "Kptfile"), []byte(`apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: root-package
+pipeline:
+  mutators:
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
+      configMap:
+        app: myapp
+`))
+	assert.NoError(t, err)
+
+	err = mockFileSystem.WriteFile(filepath.Join(rootPkgPath, "resources.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: root-cm
+`))
+	assert.NoError(t, err)
+
+	// Subpackage has no pipeline
+	err = mockFileSystem.WriteFile(filepath.Join(subPkgPath, "Kptfile"), []byte(`apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: sub-package
+`))
+	assert.NoError(t, err)
+
+	err = mockFileSystem.WriteFile(filepath.Join(subPkgPath, "resources.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sub-cm
+`))
+	assert.NoError(t, err)
+
+	renderer := &Renderer{
+		PkgPath:    rootPkgPath,
+		FileSystem: mockFileSystem,
+		Runtime:    &runtime{},
+	}
+
+	_, err = renderer.Execute(ctx)
+	assert.NoError(t, err)
+
+	output := outputBuffer.String()
+	assert.Contains(t, output, `Package: "root"`)
+	assert.NotContains(t, output, `Package: "root/subpkg"`)
+}
+func TestRunPipeline_PrintsSubpkgNameWhenPipelineIsNotEmpty(t *testing.T) {
+	var outputBuffer bytes.Buffer
+	ctx := context.Background()
+	ctx = printer.WithContext(ctx, printer.New(&outputBuffer, &outputBuffer))
+
+	mockFileSystem := filesys.MakeFsInMemory()
+
+	rootPkgPath := rootString
+	err := mockFileSystem.Mkdir(rootPkgPath)
+	assert.NoError(t, err)
+
+	subPkgPath := subPkgString
+	err = mockFileSystem.Mkdir(subPkgPath)
+	assert.NoError(t, err)
+
+	err = mockFileSystem.WriteFile(filepath.Join(rootPkgPath, "Kptfile"), []byte(`apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: root-package
+pipeline:
+  mutators:
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
+      configMap:
+        app: myapp
+`))
+	assert.NoError(t, err)
+
+	err = mockFileSystem.WriteFile(filepath.Join(rootPkgPath, "resources.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: root-cm
+`))
+	assert.NoError(t, err)
+
+	// Subpackage has a pipeline
+	err = mockFileSystem.WriteFile(filepath.Join(subPkgPath, "Kptfile"), []byte(`apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: sub-package
+pipeline:
+  mutators:
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
+      configMap:
+        tier: backend
+`))
+	assert.NoError(t, err)
+
+	err = mockFileSystem.WriteFile(filepath.Join(subPkgPath, "resources.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sub-cm
+`))
+	assert.NoError(t, err)
+
+	renderer := &Renderer{
+		PkgPath:    rootPkgPath,
+		FileSystem: mockFileSystem,
+		Runtime:    &runtime{},
+	}
+
+	_, err = renderer.Execute(ctx)
+	assert.NoError(t, err)
+
+	output := outputBuffer.String()
+	assert.Contains(t, output, `Package: "root"`)
+	assert.Contains(t, output, `Package: "root/subpkg"`)
 }
 
 func assertOrder(t *testing.T, output string, expected ...string) {

--- a/pkg/lib/kptops/render_executor_test.go
+++ b/pkg/lib/kptops/render_executor_test.go
@@ -396,104 +396,24 @@ func TestRenderer_Execute_RenderOrder(t *testing.T) {
 		})
 	}
 }
-func TestRunPipeline_DoesNotPrintSubpkgNameWhenPipelineIsEmpty(t *testing.T) {
-	var outputBuffer bytes.Buffer
-	ctx := context.Background()
-	ctx = printer.WithContext(ctx, printer.New(&outputBuffer, &outputBuffer))
-
-	mockFileSystem := filesys.MakeFsInMemory()
-
-	rootPkgPath := rootString
-	err := mockFileSystem.Mkdir(rootPkgPath)
-	assert.NoError(t, err)
-
-	subPkgPath := subPkgString
-	err = mockFileSystem.Mkdir(subPkgPath)
-	assert.NoError(t, err)
-
-	err = mockFileSystem.WriteFile(filepath.Join(rootPkgPath, "Kptfile"), []byte(`apiVersion: kpt.dev/v1
-kind: Kptfile
-metadata:
-  name: root-package
-pipeline:
-  mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
-      configMap:
-        app: myapp
-`))
-	assert.NoError(t, err)
-
-	err = mockFileSystem.WriteFile(filepath.Join(rootPkgPath, "resources.yaml"), []byte(`apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: root-cm
-`))
-	assert.NoError(t, err)
-
-	// Subpackage has no pipeline
-	err = mockFileSystem.WriteFile(filepath.Join(subPkgPath, "Kptfile"), []byte(`apiVersion: kpt.dev/v1
+func TestRunPipeline_SubpkgNameDisplay(t *testing.T) {
+	tests := []struct {
+		name             string
+		subPkgKptfile    string
+		expectSubPkgName bool
+	}{
+		{
+			name: "does not print subpkg name when pipeline is empty",
+			subPkgKptfile: `apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: sub-package
-`))
-	assert.NoError(t, err)
-
-	err = mockFileSystem.WriteFile(filepath.Join(subPkgPath, "resources.yaml"), []byte(`apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: sub-cm
-`))
-	assert.NoError(t, err)
-
-	renderer := &Renderer{
-		PkgPath:    rootPkgPath,
-		FileSystem: mockFileSystem,
-		Runtime:    &runtime{},
-	}
-
-	_, err = renderer.Execute(ctx)
-	assert.NoError(t, err)
-
-	output := outputBuffer.String()
-	assert.Contains(t, output, `Package: "root"`)
-	assert.NotContains(t, output, `Package: "root/subpkg"`)
-}
-func TestRunPipeline_PrintsSubpkgNameWhenPipelineIsNotEmpty(t *testing.T) {
-	var outputBuffer bytes.Buffer
-	ctx := context.Background()
-	ctx = printer.WithContext(ctx, printer.New(&outputBuffer, &outputBuffer))
-
-	mockFileSystem := filesys.MakeFsInMemory()
-
-	rootPkgPath := rootString
-	err := mockFileSystem.Mkdir(rootPkgPath)
-	assert.NoError(t, err)
-
-	subPkgPath := subPkgString
-	err = mockFileSystem.Mkdir(subPkgPath)
-	assert.NoError(t, err)
-
-	err = mockFileSystem.WriteFile(filepath.Join(rootPkgPath, "Kptfile"), []byte(`apiVersion: kpt.dev/v1
-kind: Kptfile
-metadata:
-  name: root-package
-pipeline:
-  mutators:
-    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
-      configMap:
-        app: myapp
-`))
-	assert.NoError(t, err)
-
-	err = mockFileSystem.WriteFile(filepath.Join(rootPkgPath, "resources.yaml"), []byte(`apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: root-cm
-`))
-	assert.NoError(t, err)
-
-	// Subpackage has a pipeline
-	err = mockFileSystem.WriteFile(filepath.Join(subPkgPath, "Kptfile"), []byte(`apiVersion: kpt.dev/v1
+`,
+			expectSubPkgName: false,
+		},
+		{
+			name: "prints subpkg name when pipeline is not empty",
+			subPkgKptfile: `apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
   name: sub-package
@@ -502,28 +422,74 @@ pipeline:
     - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
       configMap:
         tier: backend
-`))
-	assert.NoError(t, err)
+`,
+			expectSubPkgName: true,
+		},
+	}
 
-	err = mockFileSystem.WriteFile(filepath.Join(subPkgPath, "resources.yaml"), []byte(`apiVersion: v1
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var outputBuffer bytes.Buffer
+			ctx := context.Background()
+			ctx = printer.WithContext(ctx, printer.New(&outputBuffer, &outputBuffer))
+
+			mockFileSystem := filesys.MakeFsInMemory()
+
+			rootPkgPath := rootString
+			err := mockFileSystem.Mkdir(rootPkgPath)
+			assert.NoError(t, err)
+
+			subPkgPath := subPkgString
+			err = mockFileSystem.Mkdir(subPkgPath)
+			assert.NoError(t, err)
+
+			err = mockFileSystem.WriteFile(filepath.Join(rootPkgPath, "Kptfile"), []byte(`apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: root-package
+pipeline:
+  mutators:
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:latest
+      configMap:
+        app: myapp
+`))
+			assert.NoError(t, err)
+
+			err = mockFileSystem.WriteFile(filepath.Join(rootPkgPath, "resources.yaml"), []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: root-cm
+`))
+			assert.NoError(t, err)
+
+			err = mockFileSystem.WriteFile(filepath.Join(subPkgPath, "Kptfile"), []byte(tc.subPkgKptfile))
+			assert.NoError(t, err)
+
+			err = mockFileSystem.WriteFile(filepath.Join(subPkgPath, "resources.yaml"), []byte(`apiVersion: v1
 kind: ConfigMap
 metadata:
   name: sub-cm
 `))
-	assert.NoError(t, err)
+			assert.NoError(t, err)
 
-	renderer := &Renderer{
-		PkgPath:    rootPkgPath,
-		FileSystem: mockFileSystem,
-		Runtime:    &runtime{},
+			renderer := &Renderer{
+				PkgPath:    rootPkgPath,
+				FileSystem: mockFileSystem,
+				Runtime:    &runtime{},
+			}
+
+			_, err = renderer.Execute(ctx)
+			assert.NoError(t, err)
+
+			output := outputBuffer.String()
+			assert.Contains(t, output, `Package: "root"`)
+			if tc.expectSubPkgName {
+				assert.Contains(t, output, `Package: "root/subpkg"`)
+			} else {
+				assert.NotContains(t, output, `Package: "root/subpkg"`)
+			}
+		})
 	}
-
-	_, err = renderer.Execute(ctx)
-	assert.NoError(t, err)
-
-	output := outputBuffer.String()
-	assert.Contains(t, output, `Package: "root"`)
-	assert.Contains(t, output, `Package: "root/subpkg"`)
 }
 
 func assertOrder(t *testing.T, output string, expected ...string) {


### PR DESCRIPTION
Fixes: #2053 

Moved package print statement to below the empty check statement and added some tests



