### PR TITLE
Add sonar gen CI workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -70,18 +70,30 @@ jobs:
           podman version
       - name: Check out code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - name: Build, Test, Lint
+      - name: Configure Git
         run: |
           git config --global user.email you@example.com
           git config --global user.name Your Name
-          make all
-          make test-docker
+      - name: Lint and Format
+        run: make fix vet fmt lint
+      - name: Test with Coverage
+        run: make test-coverage
+      - name: Docker Runtime Tests
+        run: make test-docker
         env:
           KRM_FN_RUNTIME: ${{ matrix.runtime }}
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-report-${{ matrix.runtime }}
+          path: ./coverage.out
+          retention-days: 1
 
   build-macos:
     name: build-macos
@@ -98,6 +110,21 @@ jobs:
       - name: Build
         run: |
           make build
+
+  save-pr-number:
+    name: Save PR Number
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        run: echo ${{ github.event.number }} > PR_NUMBER.txt
+
+      - name: Archive PR number
+        uses: actions/upload-artifact@v6
+        with:
+          name: PR_NUMBER
+          path: PR_NUMBER.txt
+          retention-days: 1
 
   go-gate:
     name: go

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,161 @@
+# Copyright 2026 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: SonarCloud analysis
+
+on:
+  workflow_run:
+    workflows: [Go]
+    types: [completed]
+
+jobs:
+  check-artifacts:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      actions: read
+    outputs:
+      has-artifacts: ${{ steps.check.outputs.has-artifacts }}
+    steps:
+      - name: Check for coverage artifact
+        id: check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }}
+            });
+            const hasCoverage = artifacts.data.artifacts.some(a => a.name.startsWith('coverage-report-'));
+            core.setOutput('has-artifacts', hasCoverage);
+
+  sonarqube:
+    needs: check-artifacts
+    if: needs.check-artifacts.outputs.has-artifacts == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Download PR number artifact
+        if: github.event.workflow_run.event == 'pull_request'
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: Go
+          run_id: ${{ github.event.workflow_run.id }}
+          name: PR_NUMBER
+        continue-on-error: true
+
+      - name: Read PR_NUMBER.txt
+        if: github.event.workflow_run.event == 'pull_request' && hashFiles('PR_NUMBER.txt') != ''
+        id: pr_number
+        uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18 # v1.1.8
+        with:
+          path: ./PR_NUMBER.txt
+
+      - name: Request GitHub API for PR data
+        if: github.event.workflow_run.event == 'pull_request' && hashFiles('PR_NUMBER.txt') != ''
+        uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0
+        id: get_pr_data
+        with:
+          route: GET /repos/{full_name}/pulls/{number}
+          number: ${{ steps.pr_number.outputs.content }}
+          full_name: ${{ github.event.repository.full_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract PR metadata
+        if: github.event.workflow_run.event == 'pull_request' && hashFiles('PR_NUMBER.txt') != ''
+        id: pr_meta
+        env:
+          PR_DATA: ${{ steps.get_pr_data.outputs.data }}
+        run: |
+          echo "number=$(echo "$PR_DATA" | jq -r '.number')" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(echo "$PR_DATA" | jq -r '.head.ref')" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$(echo "$PR_DATA" | jq -r '.base.ref')" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout PR head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          allow-unsafe-pr-checkout: true
+
+      - name: Checkout base branch
+        if: github.event.workflow_run.event == 'pull_request'
+        env:
+          BASE_REF: ${{ steps.pr_meta.outputs.base_ref }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          CLONE_URL: ${{ github.event.repository.clone_url }}
+        run: |
+          git remote add upstream "$CLONE_URL"
+          git fetch upstream
+          git checkout -B "$BASE_REF" "upstream/$BASE_REF"
+          git checkout "$HEAD_SHA"
+          git clean -ffdx && git reset --hard HEAD
+
+      - name: Download coverage artifact (docker)
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: Go
+          run_id: ${{ github.event.workflow_run.id }}
+          name: coverage-report-docker
+          use_unzip: true
+        continue-on-error: true
+
+      - name: Download coverage artifact (podman)
+        if: hashFiles('coverage.out') == ''
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: Go
+          run_id: ${{ github.event.workflow_run.id }}
+          name: coverage-report-podman
+          use_unzip: true
+        continue-on-error: true
+
+      - name: Fix Go module paths in coverage
+        run: |
+          sed -i 's|github.com/kptdev/kpt|.|g' coverage.out
+
+      - name: SonarQube Scan on PR
+        if: github.event.workflow_run.event == 'pull_request' && hashFiles('PR_NUMBER.txt') != ''
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args:
+            -Dsonar.projectKey=kptdev_kpt
+            -Dsonar.organization=kptdev
+            -Dproject.settings=sonar.properties
+            -Dsonar.pullrequest.key=${{ steps.pr_meta.outputs.number }}
+            -Dsonar.pullrequest.branch=${{ steps.pr_meta.outputs.head_ref }}
+            -Dsonar.pullrequest.base=${{ steps.pr_meta.outputs.base_ref }}
+
+      - name: SonarCloud Scan on push
+        if: >-
+          github.event.workflow_run.event == 'push' &&
+          github.event.workflow_run.head_repository.full_name == github.event.repository.full_name
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args:
+            -Dsonar.projectKey=kptdev_kpt
+            -Dsonar.organization=kptdev
+            -Dproject.settings=sonar.properties
+

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ go.work.sum
 .idea/
 *.iml
 coverage.out
+coverage_unit.html
+func_coverage.out
 kpt/kpt
 *.exe
 *.gif

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ SHELL := bash
 .SHELLFLAGS := -exc
 
 include ./make/info.mk
+include ./make/testing.mk
 
 all: fix vet fmt lint test build tidy
 

--- a/make/testing.mk
+++ b/make/testing.mk
@@ -1,0 +1,37 @@
+# Copyright 2026 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Testing tools and targets for SonarQube coverage generation
+
+TEST_COVERAGE_FILE=coverage.out
+TEST_COVERAGE_HTML_FILE=coverage_unit.html
+TEST_COVERAGE_FUNC_FILE=func_coverage.out
+
+##@ Testing
+
+.PHONY: test-coverage
+test-coverage: ## Generate coverage reports (runs tests with coverage instrumentation)
+	go test -cover -coverprofile=$(TEST_COVERAGE_FILE) ${LDFLAGS} ./...
+	go tool cover -html=$(TEST_COVERAGE_FILE) -o $(TEST_COVERAGE_HTML_FILE)
+	go tool cover -func=$(TEST_COVERAGE_FILE) -o $(TEST_COVERAGE_FUNC_FILE)
+	@echo "Coverage reports generated:"
+	@echo "  - $(TEST_COVERAGE_FILE): Coverage data (for SonarQube)"
+	@echo "  - $(TEST_COVERAGE_HTML_FILE): HTML coverage report"
+	@echo "  - $(TEST_COVERAGE_FUNC_FILE): Function-level coverage"
+
+.PHONY: test-clean
+test-clean: ## Clean up coverage artifacts
+	rm -f $(TEST_COVERAGE_FILE) $(TEST_COVERAGE_HTML_FILE) $(TEST_COVERAGE_FUNC_FILE)
+	@echo "Coverage artifacts cleaned"
+

--- a/sonar.properties
+++ b/sonar.properties
@@ -1,0 +1,24 @@
+# Required metadata
+sonar.projectKey=kptdev_kpt
+sonar.projectName=kpt
+sonar.organization=kptdev
+
+sonar.language=go
+
+# Path to your Go source code
+# Includes all relevant source directories, excluding vendor and thirdparty
+sonar.sources=commands,pkg,run,internal,mdtogo,api/fnresult,api/kptfile,api/resourcegroup,api/schema
+
+# Exclude files if needed
+sonar.exclusions=**/test/**, **/examples/*, **/scripts/*, **/*_test.go, **/testing*, **/generated/**, **/testdata/**, **/*zz_generated.*, vendor/**, thirdparty/**, .github/**, documentation/**, Formula/**
+
+# To include test coverage reports
+sonar.test.inclusions=**/*_test.go
+sonar.coverage.exclusions=**/test/**, **/*_test.go, **/testing*, **/generated/**, **/*zz_generated.*
+
+# Coverage and test report paths
+sonar.go.tests.reportPaths=report.xml
+sonar.go.coverage.reportPaths=coverage.out
+
+# To exclude duplicated blocks from CPD (Copy-Paste Detection)
+sonar.cpd.exclusions=**/*_test.go, **/test/**, **/testing**, **/generated/**, **/*zz_generated.*


### PR DESCRIPTION
Add SonarCloud continuous code quality analysis to kpt CI/CD pipeline.

## Changes

- **sonar.properties**: Project configuration for SonarCloud analysis
- **.github/workflows/go.yml**: Integrated coverage report generation via `make test-coverage`
- **.github/workflows/sonarcloud.yml**: Automated analysis workflow triggered on successful builds
- **make/testing.mk**: New makefile with coverage generation targets

## Motivation

Enables automated code quality tracking, coverage metrics, and security scanning on every PR and push. Coverage reports generated during CI and analyzed by SonarCloud without duplicating test runs.

## Integration

- Tests run once: `make test-coverage` generates coverage data
- Coverage artifact uploaded from go.yml
- sonarcloud.yml downloads and sends to SonarCloud
- PR comments with quality metrics and coverage deltas
- Dashboard tracking at https://sonarcloud.io/project/overview?id=kptdev_kpt

