### PR TITLE
Docs: Document .krmignore file behaviour

### DIFF
--- a/documentation/content/en/book/03-packages/_index.md
+++ b/documentation/content/en/book/03-packages/_index.md
@@ -163,7 +163,7 @@ kpt fn eval wordpress -i search-replace:latest -- 'by-path=spec.selector.tier'
 ## Excluding files with `.krmignore`
 
 A package may contain files that should not be processed by kpt, such as test fixtures or local development overrides. 
-You can exclude them by creating a `.krmignore` file in the package directory.It uses the same pattern format as
+You can exclude them by creating a `.krmignore` file in the package directory. It uses the same pattern format as
 `.gitignore` (except recursive `**` patterns are not supported).
 
 For example, to exclude a `testdata/` directory and all `.bak` files:

--- a/documentation/content/en/book/03-packages/_index.md
+++ b/documentation/content/en/book/03-packages/_index.md
@@ -160,6 +160,22 @@ In addition, you can use a kpt function, such as `search-replace`, to run a quer
 kpt fn eval wordpress -i search-replace:latest -- 'by-path=spec.selector.tier'
 ```
 
+## Excluding files with `.krmignore`
+
+A package may contain files that should not be processed by kpt, such as test fixtures or local development overrides. 
+You can exclude them by creating a `.krmignore` file in the package directory.It uses the same pattern format as
+`.gitignore` (except recursive `**` patterns are not supported).
+
+For example, to exclude a `testdata/` directory and all `.bak` files:
+
+```
+testdata/
+*.bak
+```
+
+Files matching these patterns are excluded from `kpt fn render`, `kpt fn source`, `kpt fn eval`, and `kpt live apply`. 
+Each subpackage can have its own `.krmignore` that applies only within that subpackage.
+
 ## Editing a package
 
 kpt does not maintain any state on your local machine outside the directory from where you fetched the package. Making changes to the package is achieved by manipulating the local filesystem. At the lowest level, _editing_ a package is simply a process that does one of the following:


### PR DESCRIPTION
 ## Description
  - **What changed:** Added documentation for `.krmignore` file behavior to Chapter 3 (Packages) of the kpt book
  - **Why it's needed:** The `.krmignore` file has been supported since early kpt versions but was never documented on the site

  ## Related Issue(s)
  - Fixes #1733

  ## Type of Change
  - [x] Documentation

  ## Checklist
  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [x] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to triage the issue, draft the documentation and PR message