### PR TITLE
Docs: Clarify the use of --reconcile-timeout in getting-started guide

### DIFF
--- a/documentation/content/en/book/01-getting-started/_index.md
+++ b/documentation/content/en/book/01-getting-started/_index.md
@@ -175,7 +175,9 @@ Apply the resources to the cluster:
 kpt live apply --reconcile-timeout=15m
 ```
 
-This waits for the resources to be reconciled on the cluster by monitoring their status.
+The `--reconcile-timeout=15m` flag sets a maximum wait time for all resources to reach a healthy
+state. Without it, the command waits indefinitely until all resources reconcile. Setting a timeout is recommended 
+to avoid hanging in CI pipelines or interactive use.
 
 ### Updating the package
 


### PR DESCRIPTION
## Description
  - **What changed:** Updated the getting-started guide to explain why `--reconcile-timeout=15m` is used in `kpt live apply` examples.
  - **Why it's needed:** The previous text did not explain the timeout aspect or what happens without the flag, which was reported in #1865.
  - **How it works:** Replaced the brief one-liner with an explanation that clarifies what the flag does, what happens without it (waits indefinitely), and why setting a timeout is recommended.

  ## Related Issue(s)

  - Fixes #1865

  ## Type of Change

  - [x] Documentation

  ## Checklist

  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [x] Documentation added/updated
  - [x] All tests and gating checks pass


  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to investigate the issue, compare `--reconcile-timeout` behaviour with other tools (`kubectl`, `Helm`), draft the documentation fix and draft PR message.