### PR TITLE
Docs: Enforce documentation style guide with spelling check and style fixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,6 +72,10 @@ jobs:
         working-directory: documentation
         run: go mod verify
 
+      - name: Verify spelling
+        working-directory: documentation
+        run: make verify
+
   docs-gate:
     name: docs
     needs: [changes, docs-verify-module]

--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -12,6 +12,10 @@ serve:
 		--templateMetricsHints \
 		--gc
 
+.PHONY: verify
+verify:
+	go run github.com/golangci/misspell/cmd/misspell@v0.8.0 -error content/
+
 production-build:
 	git submodule update --init --recursive
 	git fetch --tags

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -80,13 +80,13 @@ git submodule update --init --recursive
    - Correct:
 
    ```shell
-   $ kpt fn eval my-package --image ghcr.io/kptdev/krm-functions-catalog/search-replace
+   kpt fn eval my-package --image ghcr.io/kptdev/krm-functions-catalog/search-replace
    ```
 
    - Incorrect:
 
    ```shell
-   $ kpt fn eval --image ghcr.io/kptdev/krm-functions-catalog/search-replace my-package
+   kpt fn eval --image ghcr.io/kptdev/krm-functions-catalog/search-replace my-package
    ```
 
 10. The name of the tool should always appear as small caps (even at start of
@@ -102,6 +102,30 @@ git submodule update --init --recursive
    - Incorrect: ConfigMap
 
 12. Do not add any TBDs to the documentation. If something is missing, create an [issue](https://github.com/kptdev/kpt/issues) for it.
+
+13. Do not prefix shell commands with `$` in code blocks that contain only commands.
+   Use `$` only when a block shows both the command and its output, to distinguish
+   the command from the output:
+
+   - Correct (command only):
+
+   ```shell
+   kpt fn render my-package
+   ```
+
+   - Correct (command + output):
+
+   ```shell
+   $ kpt fn render my-package
+   Package "my-package":
+   [PASS] "ghcr.io/kptdev/krm-functions-catalog/set-labels:latest"
+   ```
+
+   - Incorrect (command only with $):
+
+   ```shell
+   $ kpt fn render my-package
+   ```
 
 
 ## License

--- a/documentation/content/en/book/05-developing-functions/_index.md
+++ b/documentation/content/en/book/05-developing-functions/_index.md
@@ -272,7 +272,7 @@ metadata: # kpt-merge: /nginx-deployment
 
 Let's amend the example to set the "config.kubernetes.io/managed-by" annotation to a value we provide.
 
-Change the implementaiton of the `Run` function above as follows. Change the line:
+Change the implementation of the `Run` function above as follows. Change the line:
 
 ```shell
 kubeObject.SetAnnotation("config.kubernetes.io/managed-by", "kpt")
@@ -340,7 +340,7 @@ set the KRM function launch configuration for debugging:
 ```
 
 You launch your KRM function in VSCode with the "Launch KRM function" configuration. Paste the ResourceList yaml (output of the `kpt fn source testdata`
-plus your function configuraiton) into the VSCode terminal and type "ctrl-D" (EOF) so that the KRM function can read the ResourceList from its
+plus your function configuration) into the VSCode terminal and type "ctrl-D" (EOF) so that the KRM function can read the ResourceList from its
 standard input. You can now debug the KRM function in the VSCode debugger.
 
 ![img](/images/debug-fn-in-vscode.png)

--- a/documentation/content/en/book/07-effective-customizations/_index.md
+++ b/documentation/content/en/book/07-effective-customizations/_index.md
@@ -27,7 +27,7 @@ that talks about using functions as well as the [updating a package](../03-packa
 ### Scenario
 
 I have a single value replacement in my package. I don’t want to force package consumers 
-to look through all the yaml files to find the occurrances the value I want them to set. It 
+to look through all the yaml files to find the occurrences the value I want them to set. It 
 seems easier to just create a parameter for this value and have the user use the `Kptfile`
 for setting the value.
 

--- a/documentation/content/en/book/08-ci-user-guide/_index.md
+++ b/documentation/content/en/book/08-ci-user-guide/_index.md
@@ -70,7 +70,7 @@ runners.
 ## Rendering in CI
 
 Rendering is the most important CI step in a kpt workflow. The `kpt fn render` command executes the package pipeline
-declared in the `Kptfile`, running mutators and validators in a predictable order. The output is the fully hydrated
+declared in the `Kptfile`, running mutators and validators in a predictable order. The output is the fully rendered
 configuration that CI can use for downstream steps.
 
 ### Prerequisites

--- a/documentation/content/en/faq.md
+++ b/documentation/content/en/faq.md
@@ -124,7 +124,7 @@ don't have to alias it. It is pronounced "kept".
   https://github.com/kubernetes/design-proposals-archive/blob/main/architecture/resource-management.md
 [declarative application management in kubernetes]:
   https://github.com/kubernetes/design-proposals-archive/blob/main/architecture/declarative-application-management.md
-[rationale]: https://kpt.dev/guides/rationale
+[rationale]: /guides/rationale
 [functions]: /reference/cli/fn/eval/
 [using functions]: /book/04-using-functions/
 [contact]: /contact/

--- a/documentation/content/en/guides/namespace-provisioning-cli.md
+++ b/documentation/content/en/guides/namespace-provisioning-cli.md
@@ -38,23 +38,23 @@ via the GitHub GUI.
 # (optional) skip if you've authenticated. 
 # Authenticate gh to create a repository.
 
-$ gh auth login
+gh auth login
 
 # Create the "blueprint" and "deployment" repos if you don't have them yet
 
-$ gh repo create blueprint
-$ gh repo create deployment
+gh repo create blueprint
+gh repo create deployment
 
 
 # clone and enter the blueprint repo
-$ USER=<YOUR GITHUB USERNAME>
-$ BLUEPRINT_REPO=git@github.com:${USER}/blueprint.git
-$ DEPLOYMENT_REPO=git@github.com:${USER}/deployment.git
+USER=<YOUR GITHUB USERNAME>
+BLUEPRINT_REPO=git@github.com:${USER}/blueprint.git
+DEPLOYMENT_REPO=git@github.com:${USER}/deployment.git
 
-$ git clone ${BLUEPRINT_REPO}
-$ git clone ${DEPLOYMENT_REPO}
+git clone ${BLUEPRINT_REPO}
+git clone ${DEPLOYMENT_REPO}
 
-$ cd blueprint
+cd blueprint
 
 ```
 
@@ -77,7 +77,7 @@ Run the following bash snippet to create our little k8s manifest generator calle
 kube-gen.sh.
 
 ```shell
-$ cat << 'EOF' > kube-gen.sh
+cat << 'EOF' > kube-gen.sh
 
 #!/usr/bin/env bash
 #kube-gen.sh resource-type args
@@ -97,10 +97,10 @@ Follow the steps below to make sure that script can be invoked from the command 
 
 ```shell
 # make the script executable
-$ chmod a+x kube-gen.sh
+chmod a+x kube-gen.sh
 
 # let's make it available in our $PATH
-$ sudo mv kube-gen.sh /usr/local/bin
+sudo mv kube-gen.sh /usr/local/bin
 
 # test the script out
 $ kube-gen.sh --help
@@ -140,10 +140,10 @@ provisioning a namespace.
 
 ```shell
 # ensure that we are working in the basens directory
-$ cd basens
+cd basens
 
 # create namespace
-$ kube-gen.sh namespace example > namespace.yaml
+kube-gen.sh namespace example > namespace.yaml
 
 # you should see namespace resource
 $ kpt pkg tree
@@ -213,7 +213,7 @@ Successfully executed 1 function(s) in 1 package(s).
 
 Note: if you are curious about how KRM functions are implemented. Take a look
 at [set-namespace code](https://github.com/kptdev/krm-functions-catalog/blob/main/functions/go/set-namespace/transformer/namespace.go)
-to get a feel for the implementation. You can also check out [Chapter 5: Developing Functions](https://kpt.dev/book/05-developing-functions/)
+to get a feel for the implementation. You can also check out [Chapter 5: Developing Functions](/book/05-developing-functions/)
 of the kpt book.
 
 ### Permissions
@@ -229,7 +229,7 @@ managing this tenant.
 
 ```shell
 # create rolebinding and try out the simple value propagation scenario
-$ kube-gen.sh rolebinding app-admin --clusterrole=app-admin --group=example.admin@bigco.com > rolebinding.yaml
+kube-gen.sh rolebinding app-admin --clusterrole=app-admin --group=example.admin@bigco.com > rolebinding.yaml
 
 $ cat rolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -258,7 +258,7 @@ Here is an snippet that does that:
 # get the value of package name from configmap in `package-context.yaml`
 # and use it to update the name of the entry in subjects section of app-admin
 # role binding with a Group kind. Save the config to update-rolebinding.yaml.
-$ cat > update-rolebinding.yaml << EOF
+cat > update-rolebinding.yaml << EOF
 
 apiVersion: fn.kpt.dev/v1alpha1
 kind: ApplyReplacements
@@ -292,7 +292,7 @@ $ kpt fn eval -i apply-replacements:latest --fn-config update-rolebinding.yaml -
 Added "ghcr.io/kptdev/krm-functions-catalog/apply-replacements:latest" as mutator in the Kptfile.
 
 # ensure our package is being rendered correctly
-$ kpt fn render
+kpt fn render
 ```
 
 ### Quota
@@ -300,8 +300,8 @@ $ kpt fn render
 Let’s add quota limits for this tenant.
 
 ```shell
-$ kube-gen.sh quota default --hard=cpu=40,memory=40G > resourcequota.yaml
-$ kpt fn render
+kube-gen.sh quota default --hard=cpu=40,memory=40G > resourcequota.yaml
+kpt fn render
 
 $ cat resourcequota.yaml
 apiVersion: v1
@@ -336,10 +336,10 @@ Now that we have a basic namespace package in place, let's publish it so that
 other users can consume it.
 
 ```shell
-$ cd .. && git add basens && git commit -am "initial pkg"
-$ git push origin main
+cd .. && git add basens && git commit -am "initial pkg"
+git push origin main
 
-$ git tag basens/v0 && git push origin basens/v0
+git tag basens/v0 && git push origin basens/v0
 ```
 
 So, now the package should be available in the `blueprint` repo. Consumers
@@ -356,7 +356,7 @@ You need to do this step in the deployment repo.
 
 ```shell
 # Redirect yourself to $DEPLOYMENT_REPO, which is created in "Prerequisites – Repositories
-$ cd ../deployment
+cd ../deployment
 
 $ kpt pkg get ${BLUEPRINT_REPO}/basens/@v0 backend --for-deployment
 Package "backend":
@@ -411,11 +411,11 @@ the deployment repo.
 ```shell
 # assuming you are in deployment repo
 
-$ git add backend && git commit -am "initial pkg for deployment"
-$ git push origin main
+git add backend && git commit -am "initial pkg for deployment"
+git push origin main
 
 # tag the package
-$ git tag backend/v0 main && git push origin backend/v0
+git tag backend/v0 main && git push origin backend/v0
 
 ```
 

--- a/documentation/content/en/guides/rationale.md
+++ b/documentation/content/en/guides/rationale.md
@@ -49,7 +49,7 @@ door to other automation.
 
 It is an emerging trend to provide GUIs over GitOps, but their ability to automate changes to configurations in git so
 far has been quite limited and narrow, such as to change template parameter values or configure the GitOps
-reconciliation process itself, because the representations are generaly so hostile to mechanical manipulation. The
+reconciliation process itself, because the representations are generally so hostile to mechanical manipulation. The
 combination of these limitations creates friction in managing infrastructure across multiple teams and applications.
 Cross-functional collaboration across platform and application teams can quickly become a bottleneck especially as the
 needs of individual teams differ from one another, requiring frequent template changes that potentially affect all uses

--- a/documentation/content/en/guides/tenant-onboarding.md
+++ b/documentation/content/en/guides/tenant-onboarding.md
@@ -163,15 +163,15 @@ package by tagging the version as shown below:
 
 ```shell
 # Assuming you are in the pkg catalog repo where tenant package exists
-$ cd $PKG_CATALOG_DIR
+cd $PKG_CATALOG_DIR
 
 # Please remove the inventory information from the Kptfile before publishing
 
 # create new tag
-$ git tag tenant/v0.1 main
+git tag tenant/v0.1 main
 
 # push the tag to the upstream
-$ git push origin tenant/v0.1
+git push origin tenant/v0.1
 
 ```
 
@@ -186,16 +186,16 @@ they can request for new tenants by simply issuing a PR against the platform rep
 
 # assuming you have a fork of the platform repo residing locally at pointed by
 # by PLATFORM_DIR env variable locally. 
-$ cd $PLATFORM_DIR
+cd $PLATFORM_DIR
 
 # create a new branch to onboard new tenant
-$ git checkout -b onboarding-tenant-a
+git checkout -b onboarding-tenant-a
 
-$ cd tenants
+cd tenants
 
 # create an instance `tenant-a` of the upstream tenant package using `kpt pkg get`
 # Ensure PKG_CATALOG_REPO env variable points to the pkg catalog repo.
-$ kpt pkg get $PKG_CATALOG_REPO/tenant@v0.1 tenant-a
+kpt pkg get $PKG_CATALOG_REPO/tenant@v0.1 tenant-a
 
 # tenant customizations:
 # change the namespace to tenant-a in the tenant-a/Kptfile
@@ -205,12 +205,12 @@ $ kpt pkg get $PKG_CATALOG_REPO/tenant@v0.1 tenant-a
 
 # render the package to ensure all customizations are applied
 # and validations are run.
-$ kpt fn render tenant-a
+kpt fn render tenant-a
 
 # if all invariants passed, then we are all set.
 
-$ git commit -am "added tenant-a"
-$ git push origin onboarding-tenant-a
+git commit -am "added tenant-a"
+git push origin onboarding-tenant-a
 
 # make a pull request for platform team to merge
 # Create a PR with the changes above. 
@@ -228,19 +228,19 @@ Let’s go through the steps needed to update the tenant package.
 
 # assuming you have a fork of the platform repo residing locally at pointed by
 # by PLATFORM_DIR env variable locally. 
-$ cd $PLATFORM_DIR
+cd $PLATFORM_DIR
 
 # create a new branch to update tenant
-$ git checkout -b update-tenant-a
+git checkout -b update-tenant-a
 
-$ kpt pkg update tenant-a@tenants/v0.2
+kpt pkg update tenant-a@tenants/v0.2
 
-$ kpt fn render tenant-a
+kpt fn render tenant-a
 
 # if all invariants passed, then we are all set.
 
-$ git commit -am "updated tenant-a to newer version"
-$ git push origin update-tenant-a
+git commit -am "updated tenant-a to newer version"
+git push origin update-tenant-a
 
 # make a pull request for platform team to merge
 ```

--- a/documentation/content/en/guides/variant-constructor-pattern.md
+++ b/documentation/content/en/guides/variant-constructor-pattern.md
@@ -160,9 +160,9 @@ So for a package consumer, creating a deployable instance involves the following
 
 ```shell
 # pick name of the deployable instance say `my-pkg-instance`
-$ kpt pkg get <path-to-abstract-pkg> <my-pkg-instance> --for-deployement
+kpt pkg get <path-to-abstract-pkg> <my-pkg-instance> --for-deployement
 
-$ kpt fn render <my-pkg-instance>
+kpt fn render <my-pkg-instance>
 
 ```
 

--- a/documentation/content/en/installation/migration.md
+++ b/documentation/content/en/installation/migration.md
@@ -46,7 +46,7 @@ kpt `v1.0`.
 To start with, all the commands in kpt `v1.0` will follow the consistent pattern
 
 ```
-$ kpt <group> <command> <positional_args> [PKG_PATH | DIR | - STDIN] [flags]
+kpt <group> <command> <positional_args> [PKG_PATH | DIR | - STDIN] [flags]
 ```
 
 Almost all the existing commands/features in kpt `v0.39` are also offered in kpt
@@ -208,17 +208,17 @@ of published package on your local disk. If you do not already have it, you can 
 the latest version of remote package on to your local disk.
 
 ```shell
-$ DEMO_HOME=$(mktemp -d); cd $DEMO_HOME
+DEMO_HOME=$(mktemp -d); cd $DEMO_HOME
 ```
 
 ```shell
 # replace it with your package repo uri
-$ git clone https://github.com/kptdev/krm-functions-catalog.git
+git clone https://github.com/kptdev/krm-functions-catalog.git
 ```
 
 ```shell
 # cd to the package directory which you want to migrate
-$ cd kpt-functions-catalog/testdata/fix/nginx-v1alpha1
+cd kpt-functions-catalog/testdata/fix/nginx-v1alpha1
 ```
 
 ```shell
@@ -231,12 +231,12 @@ Invoke `ghcr.io/kptdev/krm-functions-catalog/fix` function on the kpt package.
 
 ```shell
 # you must be using 1.0+ version of kpt
-$ kpt fn eval --image ghcr.io/kptdev/krm-functions-catalog/fix:latest --include-meta-resources --truncate-output=false
+kpt fn eval --image ghcr.io/kptdev/krm-functions-catalog/fix:latest --include-meta-resources --truncate-output=false
 ```
 
 ```shell
 # observe the changes done by the fix function
-$ git diff
+git diff
 ```
 
 ##### Changes made by the function
@@ -300,7 +300,7 @@ and migrate the local customizations(if any) already performed to their existing
   from your existing package directory.
 
 ```shell
-$ DEMO_HOME=$(mktemp -d); cd $DEMO_HOME
+DEMO_HOME=$(mktemp -d); cd $DEMO_HOME
 ```
 
 ```shell
@@ -311,7 +311,7 @@ $ kpt version
 
 ```shell
 # fetch the package with upgraded version
-$ kpt pkg get https://github.com/kptdev/krm-functions-catalog.git/testdata/fix/nginx-v1@master
+kpt pkg get https://github.com/kptdev/krm-functions-catalog.git/testdata/fix/nginx-v1@master
 ```
 
 - You might have performed some customizations to your existing package such as,
@@ -322,7 +322,7 @@ $ kpt pkg get https://github.com/kptdev/krm-functions-catalog.git/testdata/fix/n
 - Render the package resources with customizations
 
 ```shell
-$ kpt fn render nginx-v1/
+kpt fn render nginx-v1/
 ```
 
 - The step is only applicable if you're using `kpt live` functionality.
@@ -354,7 +354,7 @@ kpt `v0.39`) to `v1` version(compatible with kpt `v1.0`).
    kpt `v1.0`.
 
 [v0.39 commands]: https://kptdev.github.io/kpt/reference/
-[v1.0 commands]: https://kpt.dev/reference/cli/
+[v1.0 commands]: /reference/cli/
 [v1 kptfile]: https://github.com/kptdev/kpt/blob/main/pkg/api/kptfile/v1/types.go
 [starlark function]: https://catalog.kpt.dev/starlark/v0.2/
 [apply-setters]: https://catalog.kpt.dev/apply-setters/v0.1/
@@ -364,19 +364,19 @@ kpt `v0.39`) to `v1` version(compatible with kpt `v1.0`).
 [auto-setters]: https://kptdev.github.io/kpt/concepts/setters/#auto-setters
 [migrating inventory objects]: https://kptdev.github.io/kpt/reference/live/alpha/
 [live migration]: https://kptdev.github.io/kpt/reference/cli/live/alpha/
-[configpath]: https://kpt.dev/book/04-using-functions/01-declarative-function-execution?id=configpath
+[configpath]: /book/04-using-functions/01-declarative-function-execution?id=configpath
 [example kpt package]: https://github.com/kptdev/krm-functions-catalog/tree/master/testdata/fix
 [simple example]: https://github.com/kptdev/krm-functions-catalog/tree/master/functions/go/fix#examples
-[function config]: https://kpt.dev/book/04-using-functions/01-declarative-function-execution?id=configpath
+[function config]: /book/04-using-functions/01-declarative-function-execution?id=configpath
 [starlark runtime]: https://kptdev.github.io/kpt/guides/producer/functions/starlark/
-[update guide]: https://kpt.dev/book/03-packages/05-updating-a-package
-[render guide]: https://kpt.dev/book/04-using-functions/01-declarative-function-execution
-[eval guide]: https://kpt.dev/book/04-using-functions/02-imperative-function-execution
-[function results]: https://kpt.dev/book/04-using-functions/03-function-results
-[the kpt book]: https://kpt.dev/book/
-[installation instructions]: https://kpt.dev/installation/
-[install]: https://kpt.dev/installation/
+[update guide]: /book/03-packages/05-updating-a-package
+[render guide]: /book/04-using-functions/01-declarative-function-execution
+[eval guide]: /book/04-using-functions/02-imperative-function-execution
+[function results]: /book/04-using-functions/03-function-results
+[the kpt book]: /book/
+[installation instructions]: /installation/
+[install]: /installation/
 [kpt-functions-catalog]: https://catalog.kpt.dev/
 [v1alpha1 kptfile]: https://github.com/kptdev/kpt/blob/master/pkg/kptfile/pkgfile.go#L39
 [git clone]: https://git-scm.com/docs/git-clone
-[publish your package]: https://kpt.dev/book/03-packages/08-publishing-a-package
+[publish your package]: /book/03-packages/08-publishing-a-package

--- a/documentation/content/en/reference/cli/alpha/license/info/_index.md
+++ b/documentation/content/en/reference/cli/alpha/license/info/_index.md
@@ -27,7 +27,7 @@ kpt alpha license info
 
 ```shell
 # display license information for OSS libraries.
-$ kpt alpha license info | less
+kpt alpha license info | less
 ```
 
 <!--mdtogo-->

--- a/documentation/content/en/reference/cli/alpha/live/plan/_index.md
+++ b/documentation/content/en/reference/cli/alpha/live/plan/_index.md
@@ -80,6 +80,6 @@ PKG_PATH | -:
 
 ```shell
 # create a plan for the package in the current directory and output in KRM format.
-$ kpt alpha live plan --output=krm
+kpt alpha live plan --output=krm
 ```
 <!--mdtogo-->

--- a/documentation/content/en/reference/cli/alpha/sync/create/_index.md
+++ b/documentation/content/en/reference/cli/alpha/sync/create/_index.md
@@ -44,7 +44,7 @@ DEPLOYMENT_NAME:
 
 ```shell
 # get a specific package in the default namespace
-$ kpt alpha sync create my-app --package=deployment-8f9a0c7bf29eb2cbac9476319cd1ad2e897be4f9 --namespace=default
+kpt alpha sync create my-app --package=deployment-8f9a0c7bf29eb2cbac9476319cd1ad2e897be4f9 --namespace=default
 ```
 
 <!--mdtogo-->

--- a/documentation/content/en/reference/cli/alpha/sync/delete/_index.md
+++ b/documentation/content/en/reference/cli/alpha/sync/delete/_index.md
@@ -47,7 +47,7 @@ DEPLOYMENT_NAME:
 ```shell
 # remove the my-app sync resource from the cluster. Wait up to 5 minutes for
 # resources to be deleted.
-$ kpt alpha sync delete my-app --timeout=5m
+kpt alpha sync delete my-app --timeout=5m
 ```
 
 <!--mdtogo-->

--- a/documentation/content/en/reference/cli/alpha/wasm/pull/_index.md
+++ b/documentation/content/en/reference/cli/alpha/wasm/pull/_index.md
@@ -37,7 +37,7 @@ LOCAL_PATH:
 
 ```shell
 # pull image ghcr.io/my-org/my-fn:v1.0.0 and decompress it to ./my-fn.wasm
-$ kpt alpha wasm pull ghcr.io/my-org/my-fn:v1.0.0 ./my-fn.wasm
+kpt alpha wasm pull ghcr.io/my-org/my-fn:v1.0.0 ./my-fn.wasm
 ```
 
 

--- a/documentation/content/en/reference/cli/fn/sink/_index.md
+++ b/documentation/content/en/reference/cli/fn/sink/_index.md
@@ -41,7 +41,7 @@ DIR:
 ```shell
 # read resources from DIR directory, execute my-fn on them and write the
 # output to DIR directory.
-$ kpt fn source DIR |
+kpt fn source DIR |
   kpt fn eval - --image ghcr.io/example.com/my-fn |
   kpt fn sink NEW_DIR
 ```

--- a/documentation/content/en/reference/cli/live/destroy/_index.md
+++ b/documentation/content/en/reference/cli/live/destroy/_index.md
@@ -94,7 +94,7 @@ PKG_PATH | -:
 
 ```shell
 # remove all resources in the current package from the cluster.
-$ kpt live destroy
+kpt live destroy
 ```
 
 <!--mdtogo-->

--- a/documentation/content/en/reference/cli/live/install-resource-group/_index.md
+++ b/documentation/content/en/reference/cli/live/install-resource-group/_index.md
@@ -30,7 +30,7 @@ kpt live install-resource-group
 
 ```shell
 # install ResourceGroup CRD into the current cluster.
-$ kpt live install-resource-group
+kpt live install-resource-group
 ```
 
 <!--mdtogo-->

--- a/documentation/content/en/reference/cli/live/migrate/_index.md
+++ b/documentation/content/en/reference/cli/live/migrate/_index.md
@@ -50,7 +50,7 @@ PKG_PATH:
   Go through the steps of migration, but don't make any changes.
 
 --force:
-  Forces the inventory values in the ResourceGroup manfiest to be updated,
+  Forces the inventory values in the ResourceGroup manifest to be updated,
   even if they are already set. Defaults to false.
 
 --name:

--- a/documentation/content/en/reference/cli/pkg/diff/_index.md
+++ b/documentation/content/en/reference/cli/pkg/diff/_index.md
@@ -110,7 +110,7 @@ KPT_CACHE_DIR:
 
 ```shell
 # Show changes in current package relative to upstream source package.
-$ kpt pkg diff
+kpt pkg diff
 ```
 
 <!--mdtogo-->

--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -399,7 +399,7 @@ var SinkLong = `
 var SinkExamples = `
   # read resources from DIR directory, execute my-fn on them and write the
   # output to DIR directory.
-  $ kpt fn source DIR |
+  kpt fn source DIR |
     kpt fn eval - --image ghcr.io/example.com/my-fn |
     kpt fn sink NEW_DIR
 `

--- a/internal/docs/generated/livedocs/docs.go
+++ b/internal/docs/generated/livedocs/docs.go
@@ -179,7 +179,7 @@ Flags:
 `
 var DestroyExamples = `
   # remove all resources in the current package from the cluster.
-  $ kpt live destroy
+  kpt live destroy
 `
 
 var InitShort = `Initialize a package with the information needed for inventory tracking.`
@@ -234,7 +234,7 @@ var InstallResourceGroupLong = `
 `
 var InstallResourceGroupExamples = `
   # install ResourceGroup CRD into the current cluster.
-  $ kpt live install-resource-group
+  kpt live install-resource-group
 `
 
 var MigrateShort = `Migrate a package and the inventory object to use the ResourceGroup CRD.`
@@ -254,7 +254,7 @@ Flags:
     Go through the steps of migration, but don't make any changes.
   
   --force:
-    Forces the inventory values in the ResourceGroup manfiest to be updated,
+    Forces the inventory values in the ResourceGroup manifest to be updated,
     even if they are already set. Defaults to false.
   
   --name:

--- a/internal/docs/generated/pkgdocs/docs.go
+++ b/internal/docs/generated/pkgdocs/docs.go
@@ -120,7 +120,7 @@ Environment Variables:
 var DiffExamples = `
 
   # Show changes in current package relative to upstream source package.
-  $ kpt pkg diff
+  kpt pkg diff
 `
 
 var GetShort = `Fetch a package from a git repo.`

--- a/internal/docs/generated/syncdocs/docs.go
+++ b/internal/docs/generated/syncdocs/docs.go
@@ -23,7 +23,7 @@ Flags:
 `
 var CreateExamples = `
   # get a specific package in the default namespace
-  $ kpt alpha sync create my-app --package=deployment-8f9a0c7bf29eb2cbac9476319cd1ad2e897be4f9 --namespace=default
+  kpt alpha sync create my-app --package=deployment-8f9a0c7bf29eb2cbac9476319cd1ad2e897be4f9 --namespace=default
 `
 
 var DeleteShort = `Remove a sync resource from the cluster.`
@@ -46,7 +46,7 @@ Flags:
 var DeleteExamples = `
   # remove the my-app sync resource from the cluster. Wait up to 5 minutes for
   # resources to be deleted.
-  $ kpt alpha sync delete my-app --timeout=5m
+  kpt alpha sync delete my-app --timeout=5m
 `
 
 var GetShort = `Get sync resources from the cluster.`

--- a/internal/docs/generated/wasmdocs/docs.go
+++ b/internal/docs/generated/wasmdocs/docs.go
@@ -19,7 +19,7 @@ Args:
 `
 var PullExamples = `
   # pull image ghcr.io/my-org/my-fn:v1.0.0 and decompress it to ./my-fn.wasm
-  $ kpt alpha wasm pull ghcr.io/my-org/my-fn:v1.0.0 ./my-fn.wasm
+  kpt alpha wasm pull ghcr.io/my-org/my-fn:v1.0.0 ./my-fn.wasm
 `
 
 var PushShort = `Compress a WASM module and push it as an OCI image.`


### PR DESCRIPTION
## Description
  - **What changed:** Added automated spelling check, fixed style violations, and documented the `$` prefix convention.
  - **Why it's needed:** Issue #1652 requested a linter to enforce documentation style rules. This PR addresses all remaining unchecked items.
  - **How it works:** Uses `golangci/misspell` (the maintained fork used by golangci-lint) to check markdown files for spelling errors, integrated into CI via the existing docs workflow.

  ## Related Issue(s)

  - Fixes #1652

  ## Type of Change

  - [x] Enhancement
  - [x] Documentation

  ## Checklist

  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [x] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
  - Kiro to investigate the issue, research tooling approaches (kubernetes/website, kustomize, Vale, codespell), implement the spelling check, and apply style fixes across the documentation.