### PR TITLE
Fix incorrect handling when unfetched packages are deleted from upstream

### DIFF
--- a/commands/pkg/update/cmdupdate_test.go
+++ b/commands/pkg/update/cmdupdate_test.go
@@ -686,6 +686,106 @@ Updating package "subpkg1" with strategy "resource-merge".
 Updated 2 package(s).
 `,
 		},
+		"unfetched subpackage deleted from upstream": {
+			reposChanges: map[string][]testutil.Content{
+				testutil.Upstream: {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile().
+							WithResource(pkgbuilder.DeploymentResource).
+							WithSubPackages(
+								pkgbuilder.NewSubPkg("subpkg1").
+									WithKptfile(
+										pkgbuilder.NewKptfile().
+											WithUpstreamRef("foo", "/", "master", "resource-merge"),
+									),
+								pkgbuilder.NewSubPkg("subpkg2").
+									WithKptfile(
+										pkgbuilder.NewKptfile().
+											WithUpstreamRef("foo", "/", "master", "resource-merge"),
+									),
+							),
+						Branch: "master",
+					},
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile().
+							WithResource(pkgbuilder.SecretResource),
+					},
+				},
+				"foo": {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile().
+							WithResource(pkgbuilder.DeploymentResource),
+						Branch: "master",
+					},
+				},
+			},
+			updatedLocal: testutil.Content{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile(
+						pkgbuilder.NewKptfile().
+							WithUpstreamRef(testutil.Upstream, "/", "master", "resource-merge").
+							WithUpstreamLockRef(testutil.Upstream, "/", "master", 0),
+					).
+					WithResource(pkgbuilder.DeploymentResource).
+					WithSubPackages(
+						pkgbuilder.NewSubPkg("subpkg1").
+							WithKptfile(
+								pkgbuilder.NewKptfile().
+									WithUpstreamRef("foo", "/", "master", "resource-merge").
+									WithUpstreamLockRef("foo", "/", "master", 0),
+							).
+							WithResource(pkgbuilder.DeploymentResource, pkgbuilder.SetFieldPath("5", "spec", "replicas")),
+						pkgbuilder.NewSubPkg("subpkg2").
+							WithKptfile(
+								pkgbuilder.NewKptfile().
+									WithUpstreamRef("foo", "/", "master", "resource-merge").
+									WithUpstreamLockRef("foo", "/", "master", 0),
+							).
+							WithResource(pkgbuilder.DeploymentResource),
+					),
+			},
+			expectedLocal: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstreamRef(testutil.Upstream, "/", "master", "resource-merge").
+						WithUpstreamLockRef(testutil.Upstream, "/", "master", 1),
+				).
+				WithResource(pkgbuilder.SecretResource).
+				WithSubPackages(
+					pkgbuilder.NewSubPkg("subpkg1").
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("foo", "/", "master", "resource-merge").
+								WithUpstreamLockRef("foo", "/", "master", 0),
+						).
+						WithResource(pkgbuilder.DeploymentResource, pkgbuilder.SetFieldPath("5", "spec", "replicas")),
+				),
+			expectedOutput: `
+Package "{{ .PKG_NAME }}":
+Fetching upstream from {{ (index .REPOS "upstream").RepoDirectory }}@master
+<git_output>
+Fetching origin from {{ (index .REPOS "upstream").RepoDirectory }}@master
+<git_output>
+Updating package "{{ .PKG_NAME }}" with strategy "resource-merge".
+<git_output>
+Adding package "".
+Deleting package "subpkg2" from local since it is removed in upstream.
+<git_output>
+Adding package "".
+Package "subpkg1" deleted from upstream, but keeping local since it has changes.
+
+Package "{{ .PKG_NAME }}/subpkg1":
+Fetching upstream from {{ (index .REPOS "foo").RepoDirectory }}@master
+<git_output>
+Fetching origin from {{ (index .REPOS "foo").RepoDirectory }}@master
+Updating package "subpkg1" with strategy "resource-merge".
+
+Updated 2 package(s).
+`,
+		},
 		"Adding package in upstream": {
 			reposChanges: map[string][]testutil.Content{
 				testutil.Upstream: {

--- a/pkg/lib/update/update.go
+++ b/pkg/lib/update/update.go
@@ -395,6 +395,45 @@ func (u Command) updatePackage(ctx context.Context, subPkgPath, localPath, updat
 
 	// Package deleted from upstream
 	case originExists && localExists && !updatedExists:
+		// If the package has been deleted from upstream, we only want to delete
+		// it from local if it has no changes.
+		originUnfetched, err := pkg.IsPackageUnfetched(originPath)
+		if err != nil {
+			return errors.E(op, kptfilev1.UniquePath(localPath), err)
+		}
+		// If the package in origin is in the unfetched state, we need to fetch
+		// it before we can diff with local. Otherwise the diff will always show
+		// changes since origin only contains the Kptfile while local has the
+		// full fetched content.
+		if originUnfetched {
+			// We want to fetch the package here, but we need to use the
+			// commit sha from the package in local to make sure we get the correct
+			// ref from origin. So we read the Kptfile in local and use the
+			// commit sha from there.
+			localKf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, localPath)
+			if err != nil {
+				return errors.E(op, kptfilev1.UniquePath(localPath), err)
+			}
+			localOriginSha := localKf.UpstreamLock.Git.Commit
+			p, err := pkg.New(filesys.FileSystemOrOnDisk{}, originPath)
+			if err != nil {
+				return errors.E(op, kptfilev1.UniquePath(localPath), err)
+			}
+			// Fetch the package, but provide the correct commit sha rather
+			// than just fetching based on the ref in the Kptfile. If the ref
+			// points to a branch, we don't want to end up getting a different
+			// ref than was used by local.
+			if err := (fetch.Command{
+				Pkg:    p,
+				Commit: localOriginSha,
+			}).Run(ctx); err != nil {
+				return errors.E(op, kptfilev1.UniquePath(localPath), err)
+			}
+			// Add merge comments to make sure we don't get unnecessary diffs.
+			if err := addmergecomment.Process(originPath); err != nil {
+				return errors.E(op, kptfilev1.UniquePath(localPath), err)
+			}
+		}
 		// Check the diff. If there are local changes, we keep the subpackage.
 		diff, err := copyutil.Diff(originPath, localPath)
 		if err != nil {

--- a/pkg/lib/update/update.go
+++ b/pkg/lib/update/update.go
@@ -407,19 +407,23 @@ func (u Command) updatePackage(ctx context.Context, subPkgPath, localPath, updat
 		// full fetched content.
 		if originUnfetched {
 			// We want to fetch the package here, but we need to use the
-			// commit sha from the package in local to make sure we get the correct
+			// commit SHA from the package in local to make sure we get the correct
 			// ref from origin. So we read the Kptfile in local and use the
-			// commit sha from there.
+			// commit SHA from there.
 			localKf, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, localPath)
 			if err != nil {
 				return errors.E(op, kptfilev1.UniquePath(localPath), err)
+			}
+			if localKf.UpstreamLock == nil || localKf.UpstreamLock.Git == nil {
+				return errors.E(op, kptfilev1.UniquePath(localPath),
+					fmt.Errorf("local package missing upstreamLock.git, cannot determine origin commit"))
 			}
 			localOriginSha := localKf.UpstreamLock.Git.Commit
 			p, err := pkg.New(filesys.FileSystemOrOnDisk{}, originPath)
 			if err != nil {
 				return errors.E(op, kptfilev1.UniquePath(localPath), err)
 			}
-			// Fetch the package, but provide the correct commit sha rather
+			// Fetch the package, but provide the correct commit SHA rather
 			// than just fetching based on the ref in the Kptfile. If the ref
 			// points to a branch, we don't want to end up getting a different
 			// ref than was used by local.

--- a/pkg/lib/update/update_test.go
+++ b/pkg/lib/update/update_test.go
@@ -3525,6 +3525,149 @@ func TestRun_remote_subpackages(t *testing.T) {
 						WithResource(pkgbuilder.ConfigMapResource),
 				),
 		},
+		"unfetched subpackage deleted from upstream with no local changes": {
+			reposChanges: map[string][]testutil.Content{
+				testutil.Upstream: {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithResource(pkgbuilder.DeploymentResource).
+							WithSubPackages(
+								pkgbuilder.NewSubPkg("subpkg1").
+									WithKptfile(
+										pkgbuilder.NewKptfile().
+											WithUpstreamRef("foo", "/", masterBranch, "resource-merge"),
+									),
+								pkgbuilder.NewSubPkg("subpkg2").
+									WithKptfile(
+										pkgbuilder.NewKptfile().
+											WithUpstreamRef("foo", "/", masterBranch, "resource-merge"),
+									),
+							),
+						Branch: masterBranch,
+					},
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile().
+							WithResource(pkgbuilder.ConfigMapResource),
+					},
+				},
+				"foo": {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithResource(pkgbuilder.DeploymentResource),
+						Branch: masterBranch,
+					},
+				},
+			},
+			updatedLocal: testutil.Content{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile(
+						pkgbuilder.NewKptfile().
+							WithUpstreamRef(testutil.Upstream, "/", masterBranch, "resource-merge").
+							WithUpstreamLockRef(testutil.Upstream, "/", masterBranch, 0),
+					).
+					WithResource(pkgbuilder.DeploymentResource).
+					WithSubPackages(
+						pkgbuilder.NewSubPkg("subpkg1").
+							WithKptfile(
+								pkgbuilder.NewKptfile().
+									WithUpstreamRef("foo", "/", masterBranch, "resource-merge").
+									WithUpstreamLockRef("foo", "/", masterBranch, 0),
+							).
+							WithResource(pkgbuilder.DeploymentResource),
+						pkgbuilder.NewSubPkg("subpkg2").
+							WithKptfile(
+								pkgbuilder.NewKptfile().
+									WithUpstreamRef("foo", "/", masterBranch, "resource-merge").
+									WithUpstreamLockRef("foo", "/", masterBranch, 0),
+							).
+							WithResource(pkgbuilder.DeploymentResource),
+					),
+			},
+			expectedLocal: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstreamRef(testutil.Upstream, "/", masterBranch, "resource-merge").
+						WithUpstreamLockRef(testutil.Upstream, "/", masterBranch, 1),
+				).
+				WithResource(pkgbuilder.ConfigMapResource),
+		},
+		"unfetched subpackage deleted from upstream but local has changes": {
+			reposChanges: map[string][]testutil.Content{
+				testutil.Upstream: {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithResource(pkgbuilder.DeploymentResource).
+							WithSubPackages(
+								pkgbuilder.NewSubPkg("subpkg1").
+									WithKptfile(
+										pkgbuilder.NewKptfile().
+											WithUpstreamRef("foo", "/", masterBranch, "resource-merge"),
+									),
+								pkgbuilder.NewSubPkg("subpkg2").
+									WithKptfile(
+										pkgbuilder.NewKptfile().
+											WithUpstreamRef("foo", "/", masterBranch, "resource-merge"),
+									),
+							),
+						Branch: masterBranch,
+					},
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile().
+							WithResource(pkgbuilder.ConfigMapResource),
+					},
+				},
+				"foo": {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithResource(pkgbuilder.DeploymentResource),
+						Branch: masterBranch,
+					},
+				},
+			},
+			updatedLocal: testutil.Content{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile(
+						pkgbuilder.NewKptfile().
+							WithUpstreamRef(testutil.Upstream, "/", masterBranch, "resource-merge").
+							WithUpstreamLockRef(testutil.Upstream, "/", masterBranch, 0),
+					).
+					WithResource(pkgbuilder.DeploymentResource).
+					WithSubPackages(
+						pkgbuilder.NewSubPkg("subpkg1").
+							WithKptfile(
+								pkgbuilder.NewKptfile().
+									WithUpstreamRef("foo", "/", masterBranch, "resource-merge").
+									WithUpstreamLockRef("foo", "/", masterBranch, 0),
+							).
+							WithResource(pkgbuilder.DeploymentResource, pkgbuilder.SetFieldPath("5", "spec", "replicas")),
+						pkgbuilder.NewSubPkg("subpkg2").
+							WithKptfile(
+								pkgbuilder.NewKptfile().
+									WithUpstreamRef("foo", "/", masterBranch, "resource-merge").
+									WithUpstreamLockRef("foo", "/", masterBranch, 0),
+							).
+							WithResource(pkgbuilder.DeploymentResource),
+					),
+			},
+			expectedLocal: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstreamRef(testutil.Upstream, "/", masterBranch, "resource-merge").
+						WithUpstreamLockRef(testutil.Upstream, "/", masterBranch, 1),
+				).
+				WithResource(pkgbuilder.ConfigMapResource).
+				WithSubPackages(
+					pkgbuilder.NewSubPkg("subpkg1").
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("foo", "/", masterBranch, "resource-merge").
+								WithUpstreamLockRef("foo", "/", masterBranch, 0),
+						).
+						WithResource(pkgbuilder.DeploymentResource, pkgbuilder.SetFieldPath("5", "spec", "replicas")),
+				),
+		},
 	}
 
 	for tn, tc := range testCases {

--- a/pkg/lib/util/fetch/fetch.go
+++ b/pkg/lib/util/fetch/fetch.go
@@ -38,7 +38,15 @@ import (
 // provided package, and fetches the package referenced if it isn't already
 // there.
 type Command struct {
+	// Pkg is required and contains information about the package that should be
+	// fetched. The package directory referenced must contain a valid Kptfile.
 	Pkg *pkg.Pkg
+
+	// Commit stores a git commit sha. If this is set when invoking the command,
+	// the package will be fetched based on this commit sha rather than based on
+	// the ref provided in the Kptfile. This allows for fetching specific
+	// commits even if the Kptfile references a branch.
+	Commit string
 }
 
 // Run runs the Command.
@@ -58,6 +66,7 @@ func (c Command) Run(ctx context.Context) error {
 		OrgRepo: g.Repo,
 		Path:    g.Directory,
 		Ref:     g.Ref,
+		Commit:  c.Commit,
 	}
 	err = NewCloner(repoSpec).cloneAndCopy(ctx, c.Pkg.UniquePath.String())
 	if err != nil {
@@ -176,21 +185,22 @@ func (c *Cloner) ClonerUsingGitExec(ctx context.Context) error {
 		c.cachedRepo[c.repoSpec.CloneSpec()] = upstreamRepo
 	}
 
-	// Check if we have a ref in the upstream that matches the package-specific
-	// reference. If we do, we use that reference.
-	ps := strings.Split(c.repoSpec.Path, "/")
-	for len(ps) != 0 {
-		p := path.Join(ps...)
-		packageRef := path.Join(strings.TrimLeft(p, "/"), c.repoSpec.Ref)
-		if _, found := upstreamRepo.ResolveTag(packageRef); found {
-			c.repoSpec.Ref = packageRef
-			break
-		}
-		ps = ps[:len(ps)-1]
+	var commit string
+	// If a commit sha is provided in the repoSpec, we use it directly instead
+	// of resolving the ref. This allows fetching a specific commit even if the
+	// ref (e.g. a branch) has since moved forward.
+	if c.repoSpec.Commit != "" {
+		commit = c.repoSpec.Commit
+	} else {
+		// Check if we have a ref in the upstream that matches the package-specific
+		// reference. If we do, we use that reference.
+		ref := checkPackageTags(c.repoSpec.Path, c.repoSpec.Ref, upstreamRepo)
+		c.repoSpec.Ref = ref
+		commit = upstreamRepo.ResolveRef(ref)
 	}
 
 	// Pull the required ref into the repo git cache.
-	dir, err := upstreamRepo.GetRepo(ctx, []string{c.repoSpec.Ref})
+	dir, err := upstreamRepo.GetRepo(ctx, []string{commit})
 	if err != nil {
 		return errors.E(op, errors.Git, errors.Repo(c.repoSpec.CloneSpec()), err)
 	}
@@ -199,10 +209,6 @@ func (c *Cloner) ClonerUsingGitExec(ctx context.Context) error {
 	if err != nil {
 		return errors.E(op, errors.Git, errors.Repo(c.repoSpec.CloneSpec()), err)
 	}
-
-	// Find the commit SHA for the ref that was just fetched. We need the SHA
-	// rather than the ref to be able to do a hard reset of the cache repo.
-	commit := upstreamRepo.ResolveRef(c.repoSpec.Ref)
 
 	// Reset the local repo to the commit we need. Doing a hard reset instead of
 	// a checkout means we don't create any local branches so we don't need to
@@ -288,4 +294,20 @@ func copyDir(ctx context.Context, srcDir string, dstDir string) error {
 		},
 	}
 	return copy.Copy(srcDir, dstDir, opts)
+}
+
+// checkPackageTags looks up the most specific tag for the package at the
+// provided pkgPath. It checks if there is a tag in the upstream that matches
+// a package-specific reference (i.e. path/ref).
+func checkPackageTags(pkgPath, ref string, upstreamRepo internalgitutil.GitUpstreamRepo) string {
+	ps := strings.Split(pkgPath, "/")
+	for len(ps) != 0 {
+		p := path.Join(ps...)
+		packageRef := path.Join(strings.TrimLeft(p, "/"), ref)
+		if _, found := upstreamRepo.ResolveTag(packageRef); found {
+			return packageRef
+		}
+		ps = ps[:len(ps)-1]
+	}
+	return ref
 }

--- a/pkg/lib/util/fetch/fetch.go
+++ b/pkg/lib/util/fetch/fetch.go
@@ -42,8 +42,8 @@ type Command struct {
 	// fetched. The package directory referenced must contain a valid Kptfile.
 	Pkg *pkg.Pkg
 
-	// Commit stores a git commit sha. If this is set when invoking the command,
-	// the package will be fetched based on this commit sha rather than based on
+	// Commit stores a git commit SHA. If this is set when invoking the command,
+	// the package will be fetched based on this commit SHA rather than based on
 	// the ref provided in the Kptfile. This allows for fetching specific
 	// commits even if the Kptfile references a branch.
 	Commit string
@@ -186,7 +186,7 @@ func (c *Cloner) ClonerUsingGitExec(ctx context.Context) error {
 	}
 
 	var commit string
-	// If a commit sha is provided in the repoSpec, we use it directly instead
+	// If a commit SHA is provided in the repoSpec, we use it directly instead
 	// of resolving the ref. This allows fetching a specific commit even if the
 	// ref (e.g. a branch) has since moved forward.
 	if c.repoSpec.Commit != "" {

--- a/pkg/lib/util/fetch/fetch_test.go
+++ b/pkg/lib/util/fetch/fetch_test.go
@@ -699,3 +699,87 @@ func TestCommand_Run_failInvalidTag(t *testing.T) {
 		t.FailNow()
 	}
 }
+
+func TestCommand_Run_specificCommit(t *testing.T) {
+	testCases := map[string]struct {
+		setCommit bool
+		expected  *pkgbuilder.RootPkg
+	}{
+		"ref is branch without commit specified": {
+			setCommit: false,
+			expected: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstreamRef(testutil.Upstream, "/", "foo", "resource-merge").
+						WithUpstreamLockRef(testutil.Upstream, "/", "foo", 1),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+		},
+		"ref is branch with commit specified": {
+			setCommit: true,
+			expected: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstreamRef(testutil.Upstream, "/", "foo", "resource-merge").
+						WithUpstreamLockRef(testutil.Upstream, "/", "foo", 0),
+				).
+				WithResource(pkgbuilder.SecretResource),
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			repoContent := map[string][]testutil.Content{
+				testutil.Upstream: {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithResource(pkgbuilder.SecretResource),
+						Branch: "foo",
+					},
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithResource(pkgbuilder.DeploymentResource),
+					},
+				},
+			}
+			repos, w, clean := testutil.SetupReposAndWorkspace(t, repoContent)
+			defer clean()
+			if err := testutil.UpdateRepos(t, repos, repoContent); err != nil {
+				t.FailNow()
+			}
+
+			g := repos[testutil.Upstream]
+			w.PackageDir = g.RepoName
+
+			err := os.MkdirAll(w.FullPackagePath(), 0700)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			err = createKptfile(w, &kptfilev1.Git{
+				Repo:      g.RepoDirectory,
+				Directory: "/",
+				Ref:       "foo",
+			}, kptfilev1.ResourceMerge)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			actualPkg := testutil.CreatePkgOrFail(t, w.FullPackagePath())
+			var commit string
+			if tc.setCommit {
+				commit = g.Commits[0]
+			}
+			err = fetch.Command{
+				Pkg:    actualPkg,
+				Commit: commit,
+			}.Run(fake.CtxWithDefaultPrinter())
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			expectedPath := tc.expected.ExpandPkgWithName(t, w.PackageDir, testutil.ToReposInfo(repos))
+			testutil.KptfileAwarePkgEqual(t, expectedPath, w.FullPackagePath(), false)
+		})
+	}
+}


### PR DESCRIPTION
 ## Description
  - **What changed**: When a subpackage deleted from upstream is in the unfetched state in origin (only contains a Kptfile), the update logic now fetches the full origin content at the correct commit SHA before performing the diff against local.
  - **Why it's needed:** Previously, the diff between an unfetched origin (bare Kptfile) and local (full fetched content) always showed differences, so the subpackage was never deleted even when the user had made no local changes.
  - **How it works:** The `updatePackage` function in `pkg/lib/update/update.go` detects the unfetched origin state via `pkg.IsPackageUnfetched()`, reads the commit SHA from the local `upstreamLock`, fetches origin at that exact commit using a new `Commit` field on `fetch.Command`, adds merge comments, and then performs the diff as before.

This PR is based on #2230, which was authored against the old codebase structure (when packages lived under `internal/`). That PR was never merged. These changes port the same approach to the current codebase (packages now under `pkg/lib/`) with adapted API signatures and additional test coverage.

  ## Related Issue(s)

  - Fixes #2216

  ## Type of Change

  - [x] Bug fix
  - [x] Refactor
  - [x] Tests

  ## Checklist

  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [x] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Amazon Q Developer CLI to port and review the changes against the original PR #2230 and perform manual end-to-end testing and to draft the PR Message.