### PR TITLE
Add needs step to save PR num

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -113,6 +113,7 @@ jobs:
 
   save-pr-number:
     name: Save PR Number
+    needs: [build-test, build-macos]
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Fix sonar analysis to ensure PR num is saved and passed to sonar jobs
