### PR TITLE
Fix Kptfile pipeline not updating on pkg update with fast-forward/force-delete-replace

### DIFF
--- a/commands/pkg/update/cmdupdate_test.go
+++ b/commands/pkg/update/cmdupdate_test.go
@@ -141,7 +141,7 @@ func TestCmd_subpkgVersions(t *testing.T) {
 		Branch: "master",
 	})
 	defer clean()
-	err := g.Tag("v1")
+	err := g.Tag("dataset1")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -153,7 +153,7 @@ func TestCmd_subpkgVersions(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	err = g.Tag("v2")
+	err = g.Tag("dataset2")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -162,9 +162,9 @@ func TestCmd_subpkgVersions(t *testing.T) {
 
 	dest := filepath.Join(w.WorkspaceDirectory, "mysql")
 
-	// Initial clone of package v1
+	// Initial clone of package version 'dataset1'
 	getCmd := get.NewRunner(fake.CtxWithDefaultPrinter(), "kpt")
-	getCmd.Command.SetArgs([]string{"file://" + g.RepoDirectory + ".git/mysql@v1", w.WorkspaceDirectory})
+	getCmd.Command.SetArgs([]string{"file://" + g.RepoDirectory + ".git/mysql@dataset1", w.WorkspaceDirectory})
 	err = getCmd.Command.Execute()
 	if !assert.NoError(t, err) {
 		return
@@ -173,9 +173,9 @@ func TestCmd_subpkgVersions(t *testing.T) {
 		return
 	}
 
-	// update the cloned package to v2
+	// update the cloned package to dataset2
 	updateCmd := update.NewRunner(fake.CtxWithDefaultPrinter(), "kpt")
-	updateCmd.Command.SetArgs([]string{"mysql@v2", "--strategy", "fast-forward"})
+	updateCmd.Command.SetArgs([]string{"mysql@dataset2", "--strategy", "fast-forward"})
 	if !assert.NoError(t, updateCmd.Command.Execute()) {
 		return
 	}
@@ -188,8 +188,8 @@ func TestCmd_subpkgVersions(t *testing.T) {
 		return
 	}
 
-	// Reference Kptfile for package v2
-	pkgV2Kptfile, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(g.DatasetDirectory, testutil.Dataset2, "mysql"))
+	// Reference Kptfile for package version 'dataset2'
+	pkgDs2Kptfile, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(g.DatasetDirectory, testutil.Dataset2, "mysql"))
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -209,7 +209,7 @@ func TestCmd_subpkgVersions(t *testing.T) {
 			Type: kptfilev1.GitOrigin,
 			Git: &kptfilev1.Git{
 				Repo:      "file://" + g.RepoDirectory,
-				Ref:       "v2",
+				Ref:       "dataset2",
 				Directory: "/mysql",
 			},
 			UpdateStrategy: kptfilev1.FastForward,
@@ -218,15 +218,15 @@ func TestCmd_subpkgVersions(t *testing.T) {
 			Type: kptfilev1.GitOrigin,
 			Git: &kptfilev1.GitLock{
 				Repo:      "file://" + g.RepoDirectory,
-				Ref:       "v2",
+				Ref:       "dataset2",
 				Directory: "/mysql",
 				Commit:    commit,
 			},
 		},
 		Info: &kptfilev1.PackageInfo{
-			Description: pkgV2Kptfile.Info.Description,
+			Description: pkgDs2Kptfile.Info.Description,
 		},
-		Pipeline: pkgV2Kptfile.Pipeline,
+		Pipeline: pkgDs2Kptfile.Pipeline,
 	}) {
 		return
 	}

--- a/commands/pkg/update/cmdupdate_test.go
+++ b/commands/pkg/update/cmdupdate_test.go
@@ -142,6 +142,9 @@ func TestCmd_subpkgVersions(t *testing.T) {
 	})
 	defer clean()
 	err := g.Tag("v1")
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
 	// update the master branch
 	if !assert.NoError(t, g.ReplaceData(testutil.Dataset2)) {
 		return
@@ -151,6 +154,9 @@ func TestCmd_subpkgVersions(t *testing.T) {
 		return
 	}
 	err = g.Tag("v2")
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
 

--- a/commands/pkg/update/cmdupdate_test.go
+++ b/commands/pkg/update/cmdupdate_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kptdev/kpt/pkg/printer/fake"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -127,6 +128,99 @@ func TestCmd_execute(t *testing.T) {
 				Commit:    commit,
 			},
 		},
+	}) {
+		return
+	}
+}
+
+// TestCmd_execute verifies that update is correctly invoked with an upstream 'mysql' package with multiple versions
+func TestCmd_subpkgVersions(t *testing.T) {
+	// Setup version v1 of upstream package
+	g, w, clean := testutil.SetupRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	})
+	defer clean()
+	err := g.Tag("v1")
+	// update the master branch
+	if !assert.NoError(t, g.ReplaceData(testutil.Dataset2)) {
+		return
+	}
+	_, err = g.Commit("modify upstream package -- ds2")
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = g.Tag("v2")
+
+	defer testutil.Chdir(t, w.WorkspaceDirectory)()
+
+	dest := filepath.Join(w.WorkspaceDirectory, "mysql")
+
+	// Initial clone of package v1
+	getCmd := get.NewRunner(fake.CtxWithDefaultPrinter(), "kpt")
+	getCmd.Command.SetArgs([]string{"file://" + g.RepoDirectory + ".git/mysql@v1", w.WorkspaceDirectory})
+	err = getCmd.Command.Execute()
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1, "mysql"), dest, true) {
+		return
+	}
+
+	// update the cloned package to v2
+	updateCmd := update.NewRunner(fake.CtxWithDefaultPrinter(), "kpt")
+	updateCmd.Command.SetArgs([]string{"mysql@v2", "--strategy", "fast-forward"})
+	if !assert.NoError(t, updateCmd.Command.Execute()) {
+		return
+	}
+	if !g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset2, "mysql"), dest, true) {
+		return
+	}
+
+	commit, err := g.GetCommit()
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Reference Kptfile for package v2
+	pkgV2Kptfile, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(g.DatasetDirectory, testutil.Dataset2, "mysql"))
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	if !g.AssertKptfile(t, dest, kptfilev1.KptFile{
+		ResourceMeta: yaml.ResourceMeta{
+			ObjectMeta: yaml.ObjectMeta{
+				NameMeta: yaml.NameMeta{
+					Name: "mysql",
+				},
+			},
+			TypeMeta: yaml.TypeMeta{
+				APIVersion: kptfilev1.TypeMeta.APIVersion,
+				Kind:       kptfilev1.TypeMeta.Kind},
+		},
+		Upstream: &kptfilev1.Upstream{
+			Type: kptfilev1.GitOrigin,
+			Git: &kptfilev1.Git{
+				Repo:      "file://" + g.RepoDirectory,
+				Ref:       "v2",
+				Directory: "/mysql",
+			},
+			UpdateStrategy: kptfilev1.FastForward,
+		},
+		UpstreamLock: &kptfilev1.UpstreamLock{
+			Type: kptfilev1.GitOrigin,
+			Git: &kptfilev1.GitLock{
+				Repo:      "file://" + g.RepoDirectory,
+				Ref:       "v2",
+				Directory: "/mysql",
+				Commit:    commit,
+			},
+		},
+		Info: &kptfilev1.PackageInfo{
+			Description: pkgV2Kptfile.Info.Description,
+		},
+		Pipeline: pkgV2Kptfile.Pipeline,
 	}) {
 		return
 	}

--- a/commands/pkg/update/cmdupdate_test.go
+++ b/commands/pkg/update/cmdupdate_test.go
@@ -30,6 +30,7 @@ import (
 	internalgitutil "github.com/kptdev/kpt/internal/gitutil"
 	"github.com/kptdev/kpt/internal/testutil"
 	"github.com/kptdev/kpt/internal/testutil/pkgbuilder"
+	"github.com/kptdev/kpt/pkg/kptfile/kptfileutil"
 	"github.com/kptdev/kpt/pkg/printer/fake"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -179,7 +180,7 @@ func TestCmd_subpkgVersions(t *testing.T) {
 	}
 
 	// Reference Kptfile for package version 'dataset1'
-	pkgDs1Kptfile, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(g.DatasetDirectory, testutil.Dataset1, "mysql"))
+	pkgDs1Kptfile, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(g.DatasetDirectory, testutil.Dataset1, "mysql"))
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -201,9 +202,9 @@ func TestCmd_subpkgVersions(t *testing.T) {
 				Ref:       "dataset1",
 				Directory: "/mysql",
 			},
-			UpdateStrategy: kptfilev1.ResourceMerge,  // Defaulted
+			UpdateStrategy: kptfilev1.ResourceMerge, // Defaulted
 		},
-		UpstreamLock: &kptfilev1.UpstreamLock{
+		UpstreamLock: &kptfilev1.Locator{
 			Type: kptfilev1.GitOrigin,
 			Git: &kptfilev1.GitLock{
 				Repo:      "file://" + g.RepoDirectory,
@@ -236,7 +237,7 @@ func TestCmd_subpkgVersions(t *testing.T) {
 	}
 
 	// Reference Kptfile for package version 'dataset2'
-	pkgDs2Kptfile, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(g.DatasetDirectory, testutil.Dataset2, "mysql"))
+	pkgDs2Kptfile, err := kptfileutil.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(g.DatasetDirectory, testutil.Dataset2, "mysql"))
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -261,7 +262,7 @@ func TestCmd_subpkgVersions(t *testing.T) {
 			},
 			UpdateStrategy: kptfilev1.FastForward,
 		},
-		UpstreamLock: &kptfilev1.UpstreamLock{
+		UpstreamLock: &kptfilev1.Locator{
 			Type: kptfilev1.GitOrigin,
 			Git: &kptfilev1.GitLock{
 				Repo:      "file://" + g.RepoDirectory,

--- a/commands/pkg/update/cmdupdate_test.go
+++ b/commands/pkg/update/cmdupdate_test.go
@@ -141,7 +141,12 @@ func TestCmd_subpkgVersions(t *testing.T) {
 		Branch: "master",
 	})
 	defer clean()
-	err := g.Tag("dataset1")
+
+	commitDs1, err := g.GetCommit()
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = g.Tag("dataset1")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -162,7 +167,7 @@ func TestCmd_subpkgVersions(t *testing.T) {
 
 	dest := filepath.Join(w.WorkspaceDirectory, "mysql")
 
-	// Initial clone of package version 'dataset1'
+	// pkg get package version 'dataset1'
 	getCmd := get.NewRunner(fake.CtxWithDefaultPrinter(), "kpt")
 	getCmd.Command.SetArgs([]string{"file://" + g.RepoDirectory + ".git/mysql@dataset1", w.WorkspaceDirectory})
 	err = getCmd.Command.Execute()
@@ -173,7 +178,49 @@ func TestCmd_subpkgVersions(t *testing.T) {
 		return
 	}
 
-	// update the cloned package to dataset2
+	// Reference Kptfile for package version 'dataset1'
+	pkgDs1Kptfile, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(g.DatasetDirectory, testutil.Dataset1, "mysql"))
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !g.AssertKptfile(t, dest, kptfilev1.KptFile{
+		ResourceMeta: yaml.ResourceMeta{
+			ObjectMeta: yaml.ObjectMeta{
+				NameMeta: yaml.NameMeta{
+					Name: "mysql",
+				},
+			},
+			TypeMeta: yaml.TypeMeta{
+				APIVersion: kptfilev1.TypeMeta.APIVersion,
+				Kind:       kptfilev1.TypeMeta.Kind},
+		},
+		Upstream: &kptfilev1.Upstream{
+			Type: kptfilev1.GitOrigin,
+			Git: &kptfilev1.Git{
+				Repo:      "file://" + g.RepoDirectory,
+				Ref:       "dataset1",
+				Directory: "/mysql",
+			},
+			UpdateStrategy: kptfilev1.ResourceMerge,  // Defaulted
+		},
+		UpstreamLock: &kptfilev1.UpstreamLock{
+			Type: kptfilev1.GitOrigin,
+			Git: &kptfilev1.GitLock{
+				Repo:      "file://" + g.RepoDirectory,
+				Ref:       "dataset1",
+				Directory: "/mysql",
+				Commit:    commitDs1,
+			},
+		},
+		Info: &kptfilev1.PackageInfo{
+			Description: pkgDs1Kptfile.Info.Description,
+		},
+		Pipeline: pkgDs1Kptfile.Pipeline,
+	}) {
+		return
+	}
+
+	// pkg update to version 'dataset2'
 	updateCmd := update.NewRunner(fake.CtxWithDefaultPrinter(), "kpt")
 	updateCmd.Command.SetArgs([]string{"mysql@dataset2", "--strategy", "fast-forward"})
 	if !assert.NoError(t, updateCmd.Command.Execute()) {
@@ -183,7 +230,7 @@ func TestCmd_subpkgVersions(t *testing.T) {
 		return
 	}
 
-	commit, err := g.GetCommit()
+	commitDs2, err := g.GetCommit()
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -220,7 +267,7 @@ func TestCmd_subpkgVersions(t *testing.T) {
 				Repo:      "file://" + g.RepoDirectory,
 				Ref:       "dataset2",
 				Directory: "/mysql",
-				Commit:    commit,
+				Commit:    commitDs2,
 			},
 		},
 		Info: &kptfilev1.PackageInfo{

--- a/commands/pkg/update/cmdupdate_test.go
+++ b/commands/pkg/update/cmdupdate_test.go
@@ -133,7 +133,7 @@ func TestCmd_execute(t *testing.T) {
 	}
 }
 
-// TestCmd_execute verifies that update is correctly invoked with an upstream 'mysql' package with multiple versions
+// TestCmd_subpkgVersions verifies that update is correctly invoked with an upstream 'mysql' package with multiple versions
 func TestCmd_subpkgVersions(t *testing.T) {
 	// Setup version v1 of upstream package
 	g, w, clean := testutil.SetupRepoAndWorkspace(t, testutil.Content{

--- a/internal/testutil/testdata/dataset1/mysql/Kptfile
+++ b/internal/testutil/testdata/dataset1/mysql/Kptfile
@@ -1,0 +1,16 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: mysql
+info:
+  description: kpt package for mysql
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+      configMap:
+        namespace: example-ns
+      name: set namespace
+    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+      configMap:
+        color: orange
+      name: set color label

--- a/internal/testutil/testdata/dataset1/mysql/Kptfile
+++ b/internal/testutil/testdata/dataset1/mysql/Kptfile
@@ -6,11 +6,11 @@ info:
   description: kpt package for mysql
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1
       configMap:
         namespace: example-ns
       name: set namespace
-    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.0
       configMap:
         color: orange
       name: set color label

--- a/internal/testutil/testdata/dataset2/mysql/Kptfile
+++ b/internal/testutil/testdata/dataset2/mysql/Kptfile
@@ -1,0 +1,20 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: mysql
+info:
+  description: mysql package
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+      configMap:
+        namespace: example-ns
+      name: set namespace
+    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+      configMap:
+        fruit: apple
+      name: set fruit label
+    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+      configMap:
+        color: orange
+      name: set color label

--- a/internal/testutil/testdata/dataset2/mysql/Kptfile
+++ b/internal/testutil/testdata/dataset2/mysql/Kptfile
@@ -6,15 +6,15 @@ info:
   description: mysql package
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1
       configMap:
         namespace: example-ns
       name: set namespace
-    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.0
       configMap:
         fruit: apple
       name: set fruit label
-    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.0
       configMap:
         color: orange
       name: set color label

--- a/internal/testutil/testdata/dataset3/mysql/Kptfile
+++ b/internal/testutil/testdata/dataset3/mysql/Kptfile
@@ -1,0 +1,20 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: mysql
+info:
+  description: mysql package
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+      configMap:
+        namespace: example-ns
+      name: set namespace
+    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+      configMap:
+        fruit: apple
+      name: set fruit label
+    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+      configMap:
+        color: orange
+      name: set color label

--- a/internal/testutil/testdata/dataset3/mysql/Kptfile
+++ b/internal/testutil/testdata/dataset3/mysql/Kptfile
@@ -6,15 +6,15 @@ info:
   description: mysql package
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1
       configMap:
         namespace: example-ns
       name: set namespace
-    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.0
       configMap:
         fruit: apple
       name: set fruit label
-    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.0
       configMap:
         color: orange
       name: set color label

--- a/internal/testutil/testdata/dataset4/mysql/Kptfile
+++ b/internal/testutil/testdata/dataset4/mysql/Kptfile
@@ -1,0 +1,20 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: mysql
+info:
+  description: mysql package
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+      configMap:
+        namespace: example-ns
+      name: set namespace
+    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+      configMap:
+        fruit: apple
+      name: set fruit label
+    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+      configMap:
+        color: orange
+      name: set color label

--- a/internal/testutil/testdata/dataset4/mysql/Kptfile
+++ b/internal/testutil/testdata/dataset4/mysql/Kptfile
@@ -6,15 +6,15 @@ info:
   description: mysql package
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1
       configMap:
         namespace: example-ns
       name: set namespace
-    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.0
       configMap:
         fruit: apple
       name: set fruit label
-    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.0
       configMap:
         color: orange
       name: set color label

--- a/internal/testutil/testdata/dataset5/mysql/Kptfile
+++ b/internal/testutil/testdata/dataset5/mysql/Kptfile
@@ -1,0 +1,20 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: mysql
+info:
+  description: mysql package
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+      configMap:
+        namespace: example-ns
+      name: set namespace
+    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+      configMap:
+        fruit: apple
+      name: set fruit label
+    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+      configMap:
+        color: orange
+      name: set color label

--- a/internal/testutil/testdata/dataset5/mysql/Kptfile
+++ b/internal/testutil/testdata/dataset5/mysql/Kptfile
@@ -6,15 +6,15 @@ info:
   description: mysql package
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1
       configMap:
         namespace: example-ns
       name: set namespace
-    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.0
       configMap:
         fruit: apple
       name: set fruit label
-    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.0
       configMap:
         color: orange
       name: set color label

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -97,8 +97,20 @@ func (g *TestGitRepo) AssertEqual(t *testing.T, sourceDir, destDir string, addMe
 	if !assert.NoError(t, err) {
 		return false
 	}
-	diff = diff.Difference(KptfileSet)
+	diff = removeKptfiles(diff)
 	return assert.Empty(t, diff.List())
+}
+
+// removeKptfiles removes all Kptfile paths (at any depth) from the diff set,
+// since Kptfile content is validated separately by AssertKptfile.
+func removeKptfiles(s sets.String) sets.String {
+	result := sets.String{}
+	for _, item := range s.List() {
+		if filepath.Base(item) != kptfilev1.KptFileName {
+			result.Insert(item)
+		}
+	}
+	return result
 }
 
 // KptfileAwarePkgEqual compares two packages (including any subpackages)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -47,10 +47,10 @@ const TmpDirPrefix = "test-kpt"
 
 const (
 	Dataset1            = "dataset1"
-	Dataset2            = "dataset2"
+	Dataset2            = "dataset2" // Dataset2 is a replica of Dataset1 with workload spec changes (ports, replica count etc.) and a Kptfile mod
 	Dataset3            = "dataset3"
-	Dataset4            = "dataset4" // Dataset4 is replica of Dataset2 with different setter values
-	Dataset5            = "dataset5" // Dataset5 is replica of Dataset2 with additional non KRM files
+	Dataset4            = "dataset4" // Dataset4 is a replica of Dataset2 with different setter values
+	Dataset5            = "dataset5" // Dataset5 is a replica of Dataset2 with additional non KRM files
 	Dataset6            = "dataset6" // Dataset6 contains symlinks
 	DatasetMerged       = "datasetmerged"
 	DiffOutput          = "diff_output"

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -15,7 +15,6 @@
 package testutil
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -273,12 +272,12 @@ func (g *TestGitRepo) AssertKptfile(t *testing.T, cloned string, kpkg kptfilev1.
 	if !assert.NoError(t, err) {
 		return false
 	}
-	var res bytes.Buffer
-	d := yaml.NewEncoder(&res)
-	if !assert.NoError(t, d.Encode(kpkg)) {
+	// This mirrors 'WriteFile' in pkg/kptfile/kptfileutil/util.go
+	res, err := yaml.MarshalWithOptions(kpkg, &yaml.EncoderOptions{SeqIndent: yaml.WideSequenceStyle})
+	if !assert.NoError(t, err) {
 		return false
 	}
-	return assert.Equal(t, res.String(), string(b))
+	return assert.Equal(t, string(res), string(b))
 }
 
 // CheckoutBranch checks out the git branch in the repo

--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -170,6 +170,19 @@ func DefaultKptfile(name string) *kptfilev1.KptFile {
 	}
 }
 
+// readKptfileOrEmpty reads the Kptfile at the given path, returning an empty
+// KptFile if the file does not exist. Any other error is returned as-is.
+func readKptfileOrEmpty(path string) (*kptfilev1.KptFile, error) {
+	kf, err := ReadKptfile(filesys.FileSystemOrOnDisk{}, path)
+	if err != nil {
+		if !goerrors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		return &kptfilev1.KptFile{}, nil
+	}
+	return kf, nil
+}
+
 // UpdateKptfileWithoutOrigin updates the Kptfile in the package specified by
 // localPath with values from the package specified by updatedPath using a 3-way
 // merge strategy, but where origin does not have any values.
@@ -177,24 +190,17 @@ func DefaultKptfile(name string) *kptfilev1.KptFile {
 // sections will also be copied into local.
 func UpdateKptfileWithoutOrigin(localPath, updatedPath string, updateUpstream bool) error {
 	const op errors.Op = "kptfileutil.UpdateKptfileWithoutOrigin"
-	localKf, err := ReadKptfile(filesys.FileSystemOrOnDisk{}, localPath)
+	localKf, err := readKptfileOrEmpty(localPath)
 	if err != nil {
-		if !goerrors.Is(err, os.ErrNotExist) {
-			return errors.E(op, kptfilev1.UniquePath(localPath), err)
-		}
-		localKf = &kptfilev1.KptFile{}
+		return errors.E(op, kptfilev1.UniquePath(localPath), err)
 	}
 
-	updatedKf, err := ReadKptfile(filesys.FileSystemOrOnDisk{}, updatedPath)
+	updatedKf, err := readKptfileOrEmpty(updatedPath)
 	if err != nil {
-		if !goerrors.Is(err, os.ErrNotExist) {
-			return errors.E(op, kptfilev1.UniquePath(updatedPath), err)
-		}
-		updatedKf = &kptfilev1.KptFile{}
+		return errors.E(op, kptfilev1.UniquePath(updatedPath), err)
 	}
 
-	err = MergeKptfiles(localKf, updatedKf, &kptfilev1.KptFile{})
-	if err != nil {
+	if err = MergeKptfiles(localKf, updatedKf, &kptfilev1.KptFile{}); err != nil {
 		return err
 	}
 
@@ -202,8 +208,7 @@ func UpdateKptfileWithoutOrigin(localPath, updatedPath string, updateUpstream bo
 		updateUpstreamAndUpstreamLock(localKf, updatedKf)
 	}
 
-	err = WriteFile(localPath, localKf)
-	if err != nil {
+	if err = WriteFile(localPath, localKf); err != nil {
 		return errors.E(op, kptfilev1.UniquePath(localPath), err)
 	}
 	return nil
@@ -216,32 +221,22 @@ func UpdateKptfileWithoutOrigin(localPath, updatedPath string, updateUpstream bo
 // sections will also be copied into local.
 func UpdateKptfile(localPath, updatedPath, originPath string, updateUpstream bool) error {
 	const op errors.Op = "kptfileutil.UpdateKptfile"
-	localKf, err := ReadKptfile(filesys.FileSystemOrOnDisk{}, localPath)
+	localKf, err := readKptfileOrEmpty(localPath)
 	if err != nil {
-		if !goerrors.Is(err, os.ErrNotExist) {
-			return errors.E(op, kptfilev1.UniquePath(localPath), err)
-		}
-		localKf = &kptfilev1.KptFile{}
+		return errors.E(op, kptfilev1.UniquePath(localPath), err)
 	}
 
-	updatedKf, err := ReadKptfile(filesys.FileSystemOrOnDisk{}, updatedPath)
+	updatedKf, err := readKptfileOrEmpty(updatedPath)
 	if err != nil {
-		if !goerrors.Is(err, os.ErrNotExist) {
-			return errors.E(op, kptfilev1.UniquePath(localPath), err)
-		}
-		updatedKf = &kptfilev1.KptFile{}
+		return errors.E(op, kptfilev1.UniquePath(localPath), err)
 	}
 
-	originKf, err := ReadKptfile(filesys.FileSystemOrOnDisk{}, originPath)
+	originKf, err := readKptfileOrEmpty(originPath)
 	if err != nil {
-		if !goerrors.Is(err, os.ErrNotExist) {
-			return errors.E(op, kptfilev1.UniquePath(localPath), err)
-		}
-		originKf = &kptfilev1.KptFile{}
+		return errors.E(op, kptfilev1.UniquePath(localPath), err)
 	}
 
-	err = MergeKptfiles(localKf, updatedKf, originKf)
-	if err != nil {
+	if err = MergeKptfiles(localKf, updatedKf, originKf); err != nil {
 		return err
 	}
 
@@ -249,8 +244,7 @@ func UpdateKptfile(localPath, updatedPath, originPath string, updateUpstream boo
 		updateUpstreamAndUpstreamLock(localKf, updatedKf)
 	}
 
-	err = WriteFile(localPath, localKf)
-	if err != nil {
+	if err = WriteFile(localPath, localKf); err != nil {
 		return errors.E(op, kptfilev1.UniquePath(localPath), err)
 	}
 	return nil
@@ -266,20 +260,14 @@ func UpdateKptfile(localPath, updatedPath, originPath string, updateUpstream boo
 // inventory is typically set locally by kpt live init).
 func ReplaceKptfile(localPath, updatedPath string) error {
 	const op errors.Op = "kptfileutil.ReplaceKptfile"
-	localKf, err := ReadKptfile(filesys.FileSystemOrOnDisk{}, localPath)
+	localKf, err := readKptfileOrEmpty(localPath)
 	if err != nil {
-		if !goerrors.Is(err, os.ErrNotExist) {
-			return errors.E(op, kptfilev1.UniquePath(localPath), err)
-		}
-		localKf = &kptfilev1.KptFile{}
+		return errors.E(op, kptfilev1.UniquePath(localPath), err)
 	}
 
-	updatedKf, err := ReadKptfile(filesys.FileSystemOrOnDisk{}, updatedPath)
+	updatedKf, err := readKptfileOrEmpty(updatedPath)
 	if err != nil {
-		if !goerrors.Is(err, os.ErrNotExist) {
-			return errors.E(op, kptfilev1.UniquePath(localPath), err)
-		}
-		updatedKf = &kptfilev1.KptFile{}
+		return errors.E(op, kptfilev1.UniquePath(localPath), err)
 	}
 
 	// Take content fields directly from upstream.
@@ -298,8 +286,7 @@ func ReplaceKptfile(localPath, updatedPath string) error {
 	// Always update upstream tracking fields.
 	updateUpstreamAndUpstreamLock(localKf, updatedKf)
 
-	err = WriteFile(localPath, localKf)
-	if err != nil {
+	if err = WriteFile(localPath, localKf); err != nil {
 		return errors.E(op, kptfilev1.UniquePath(localPath), err)
 	}
 	return nil

--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -256,6 +256,55 @@ func UpdateKptfile(localPath, updatedPath, originPath string, updateUpstream boo
 	return nil
 }
 
+// ReplaceKptfile replaces the Kptfile at localPath with content from the
+// package at updatedPath. Unlike UpdateKptfile, it does not perform a 3-way
+// merge — it takes all content fields directly from the updated Kptfile.
+// This is appropriate for update strategies that discard local changes
+// (fast-forward, force-delete-replace).
+// The package name and namespace from local are preserved. The inventory
+// field is preserved if the updated Kptfile does not define one (since
+// inventory is typically set locally by kpt live init).
+func ReplaceKptfile(localPath, updatedPath string) error {
+	const op errors.Op = "kptfileutil.ReplaceKptfile"
+	localKf, err := ReadKptfile(filesys.FileSystemOrOnDisk{}, localPath)
+	if err != nil {
+		if !goerrors.Is(err, os.ErrNotExist) {
+			return errors.E(op, kptfilev1.UniquePath(localPath), err)
+		}
+		localKf = &kptfilev1.KptFile{}
+	}
+
+	updatedKf, err := ReadKptfile(filesys.FileSystemOrOnDisk{}, updatedPath)
+	if err != nil {
+		if !goerrors.Is(err, os.ErrNotExist) {
+			return errors.E(op, kptfilev1.UniquePath(localPath), err)
+		}
+		updatedKf = &kptfilev1.KptFile{}
+	}
+
+	// Take content fields directly from upstream.
+	localKf.Annotations = updatedKf.Annotations
+	localKf.Labels = updatedKf.Labels
+	localKf.Info = updatedKf.Info
+	localKf.Pipeline = updatedKf.Pipeline
+	localKf.Status = updatedKf.Status
+
+	// Preserve local inventory if upstream doesn't define one, since
+	// inventory is typically set locally by kpt live init.
+	if updatedKf.Inventory != nil {
+		localKf.Inventory = updatedKf.Inventory
+	}
+
+	// Always update upstream tracking fields.
+	updateUpstreamAndUpstreamLock(localKf, updatedKf)
+
+	err = WriteFile(localPath, localKf)
+	if err != nil {
+		return errors.E(op, kptfilev1.UniquePath(localPath), err)
+	}
+	return nil
+}
+
 // UpdateUpstreamLockFromGit updates the upstreamLock of the package specified
 // by path by using the values from spec. It will also populate the commit
 // field in upstreamLock using the latest commit of the git repo given

--- a/pkg/kptfile/kptfileutil/util_test.go
+++ b/pkg/kptfile/kptfileutil/util_test.go
@@ -1680,3 +1680,141 @@ upstreamLock:
 		})
 	}
 }
+
+func TestReplaceKptfile_errorPaths(t *testing.T) {
+	writeInvalidKptfile := func(tt *testing.T) string {
+		dir := tt.TempDir()
+		err := os.WriteFile(filepath.Join(dir, kptfilev1.KptFileName), []byte(`
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: bad
+`), 0600)
+		if !assert.NoError(tt, err) {
+			tt.FailNow()
+		}
+		return dir
+	}
+
+	writeValidKptfile := func(tt *testing.T) string {
+		dir := tt.TempDir()
+		err := os.WriteFile(filepath.Join(dir, kptfilev1.KptFileName), []byte(`
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: valid
+`), 0600)
+		if !assert.NoError(tt, err) {
+			tt.FailNow()
+		}
+		return dir
+	}
+
+	t.Run("error reading local Kptfile", func(t *testing.T) {
+		localDir := writeInvalidKptfile(t)
+		updatedDir := writeValidKptfile(t)
+
+		err := ReplaceKptfile(localDir, updatedDir)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "kptfileutil.ReplaceKptfile")
+	})
+
+	t.Run("error reading updated Kptfile", func(t *testing.T) {
+		localDir := writeValidKptfile(t)
+		updatedDir := writeInvalidKptfile(t)
+
+		err := ReplaceKptfile(localDir, updatedDir)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "kptfileutil.ReplaceKptfile")
+	})
+
+	t.Run("error writing Kptfile", func(t *testing.T) {
+		localDir := writeValidKptfile(t)
+		updatedDir := writeValidKptfile(t)
+
+		err := os.Chmod(filepath.Join(localDir, kptfilev1.KptFileName), 0444)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		err = os.Chmod(localDir, 0555)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		defer func() {
+			_ = os.Chmod(localDir, 0755)
+			_ = os.Chmod(filepath.Join(localDir, kptfilev1.KptFileName), 0644)
+		}()
+
+		err = ReplaceKptfile(localDir, updatedDir)
+		assert.Error(t, err)
+	})
+}
+
+func TestUpdateKptfileWithoutOrigin_errorPaths(t *testing.T) {
+	writeInvalidKptfile := func(tt *testing.T) string {
+		dir := tt.TempDir()
+		err := os.WriteFile(filepath.Join(dir, kptfilev1.KptFileName), []byte(`
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: bad
+`), 0600)
+		if !assert.NoError(tt, err) {
+			tt.FailNow()
+		}
+		return dir
+	}
+
+	writeValidKptfile := func(tt *testing.T) string {
+		dir := tt.TempDir()
+		err := os.WriteFile(filepath.Join(dir, kptfilev1.KptFileName), []byte(`
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: valid
+`), 0600)
+		if !assert.NoError(tt, err) {
+			tt.FailNow()
+		}
+		return dir
+	}
+
+	t.Run("error reading local Kptfile", func(t *testing.T) {
+		localDir := writeInvalidKptfile(t)
+		updatedDir := writeValidKptfile(t)
+
+		err := UpdateKptfileWithoutOrigin(localDir, updatedDir, true)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "kptfileutil.UpdateKptfileWithoutOrigin")
+	})
+
+	t.Run("error reading updated Kptfile", func(t *testing.T) {
+		localDir := writeValidKptfile(t)
+		updatedDir := writeInvalidKptfile(t)
+
+		err := UpdateKptfileWithoutOrigin(localDir, updatedDir, true)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "kptfileutil.UpdateKptfileWithoutOrigin")
+	})
+
+	t.Run("error writing Kptfile", func(t *testing.T) {
+		localDir := writeValidKptfile(t)
+		updatedDir := writeValidKptfile(t)
+
+		err := os.Chmod(filepath.Join(localDir, kptfilev1.KptFileName), 0444)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		err = os.Chmod(localDir, 0555)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		defer func() {
+			_ = os.Chmod(localDir, 0755)
+			_ = os.Chmod(filepath.Join(localDir, kptfilev1.KptFileName), 0644)
+		}()
+
+		err = UpdateKptfileWithoutOrigin(localDir, updatedDir, false)
+		assert.Error(t, err)
+	})
+}

--- a/pkg/kptfile/kptfileutil/util_test.go
+++ b/pkg/kptfile/kptfileutil/util_test.go
@@ -1438,11 +1438,11 @@ upstream:
     ref: v1
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1
       configMap:
         namespace: example-ns
       name: set namespace
-    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.0
       configMap:
         color: orange
       name: set color label
@@ -1460,15 +1460,15 @@ upstream:
     ref: v2
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1
       configMap:
         namespace: example-ns
       name: set namespace
-    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.0
       configMap:
         fruit: apple
       name: set fruit label
-    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.0
       configMap:
         color: orange
       name: set color label
@@ -1486,15 +1486,15 @@ upstream:
     ref: v2
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-namespace:v0.4.1
       configMap:
         namespace: example-ns
       name: set namespace
-    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.0
       configMap:
         fruit: apple
       name: set fruit label
-    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.2.0
       configMap:
         color: orange
       name: set color label

--- a/pkg/kptfile/kptfileutil/util_test.go
+++ b/pkg/kptfile/kptfileutil/util_test.go
@@ -1408,3 +1408,275 @@ pipeline:
 		})
 	}
 }
+
+func TestReplaceKptfile(t *testing.T) {
+	writeKptfileToTemp := func(tt *testing.T, content string) string {
+		dir := tt.TempDir()
+		err := os.WriteFile(filepath.Join(dir, kptfilev1.KptFileName), []byte(content), 0600)
+		if !assert.NoError(tt, err) {
+			tt.FailNow()
+		}
+		return dir
+	}
+
+	testCases := map[string]struct {
+		updated  string
+		local    string
+		expected string
+	}{
+		"pipeline is taken from updated, preserving order": {
+			local: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: mysql
+upstream:
+  type: git
+  git:
+    repo: github.com/example/repo
+    directory: /mysql
+    ref: v1
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+      configMap:
+        namespace: example-ns
+      name: set namespace
+    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+      configMap:
+        color: orange
+      name: set color label
+`,
+			updated: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: mysql
+upstream:
+  type: git
+  git:
+    repo: github.com/example/repo
+    directory: /mysql
+    ref: v2
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+      configMap:
+        namespace: example-ns
+      name: set namespace
+    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+      configMap:
+        fruit: apple
+      name: set fruit label
+    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+      configMap:
+        color: orange
+      name: set color label
+`,
+			expected: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: mysql
+upstream:
+  type: git
+  git:
+    repo: github.com/example/repo
+    directory: /mysql
+    ref: v2
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+      configMap:
+        namespace: example-ns
+      name: set namespace
+    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+      configMap:
+        fruit: apple
+      name: set fruit label
+    - image: gcr.io/kpt-fn/set-labels:v0.2.0
+      configMap:
+        color: orange
+      name: set color label
+`,
+		},
+
+		"local inventory is preserved when updated has none": {
+			local: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: foo
+inventory:
+  namespace: test-ns
+  name: test-name
+  inventoryID: test-id
+pipeline:
+  mutators:
+    - image: foo:bar
+`,
+			updated: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: foo
+pipeline:
+  mutators:
+    - image: foo:baz
+`,
+			expected: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: foo
+pipeline:
+  mutators:
+    - image: foo:baz
+inventory:
+  namespace: test-ns
+  name: test-name
+  inventoryID: test-id
+`,
+		},
+
+		"inventory is replaced when updated defines one": {
+			local: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: foo
+inventory:
+  namespace: old-ns
+  name: old-name
+  inventoryID: old-id
+`,
+			updated: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: foo
+inventory:
+  namespace: new-ns
+  name: new-name
+  inventoryID: new-id
+`,
+			expected: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: foo
+inventory:
+  namespace: new-ns
+  name: new-name
+  inventoryID: new-id
+`,
+		},
+
+		"name and namespace are preserved from local": {
+			local: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: my-local-name
+  namespace: my-ns
+`,
+			updated: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: upstream-name
+  namespace: upstream-ns
+info:
+  description: from upstream
+`,
+			expected: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: my-local-name
+  namespace: my-ns
+info:
+  description: from upstream
+`,
+		},
+
+		"upstream and upstreamLock are updated from updated": {
+			local: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: foo
+upstream:
+  type: git
+  git:
+    repo: github.com/example/repo
+    directory: /
+    ref: v1
+upstreamLock:
+  type: git
+  git:
+    repo: github.com/example/repo
+    directory: /
+    ref: v1
+    commit: aaa111
+`,
+			updated: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: foo
+upstream:
+  type: git
+  git:
+    repo: github.com/example/repo
+    directory: /
+    ref: v2
+upstreamLock:
+  type: git
+  git:
+    repo: github.com/example/repo
+    directory: /
+    ref: v2
+    commit: bbb222
+`,
+			expected: `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: foo
+upstream:
+  type: git
+  git:
+    repo: github.com/example/repo
+    directory: /
+    ref: v2
+upstreamLock:
+  type: git
+  git:
+    repo: github.com/example/repo
+    directory: /
+    ref: v2
+    commit: bbb222
+`,
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			localDir := writeKptfileToTemp(t, tc.local)
+			updatedDir := writeKptfileToTemp(t, tc.updated)
+
+			err := ReplaceKptfile(localDir, updatedDir)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			c, err := os.ReadFile(filepath.Join(localDir, kptfilev1.KptFileName))
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			assert.Equal(t, strings.TrimSpace(tc.expected)+"\n", string(c))
+		})
+	}
+}

--- a/pkg/kptfile/kptfileutil/util_test.go
+++ b/pkg/kptfile/kptfileutil/util_test.go
@@ -25,6 +25,33 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
+// writeKptfileToTemp writes the given Kptfile content to a fresh temporary
+// directory and returns that directory's path.
+func writeKptfileToTemp(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, kptfilev1.KptFileName), []byte(content), 0600)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	return dir
+}
+
+const (
+	invalidKptfileContent = `
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: bad
+`
+	validKptfileContent = `
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: valid
+`
+)
+
 // TestValidateInventory tests the ValidateInventory function.
 func TestValidateInventory(t *testing.T) {
 	// nil inventory should not validate
@@ -61,15 +88,6 @@ func TestValidateInventory(t *testing.T) {
 }
 
 func TestUpdateKptfile(t *testing.T) {
-	writeKptfileToTemp := func(tt *testing.T, content string) string {
-		dir := tt.TempDir()
-		err := os.WriteFile(filepath.Join(dir, kptfilev1.KptFileName), []byte(content), 0600)
-		if !assert.NoError(t, err) {
-			t.FailNow()
-		}
-		return dir
-	}
-
 	testCases := map[string]struct {
 		origin         string
 		updated        string
@@ -1410,15 +1428,6 @@ pipeline:
 }
 
 func TestReplaceKptfile(t *testing.T) {
-	writeKptfileToTemp := func(tt *testing.T, content string) string {
-		dir := tt.TempDir()
-		err := os.WriteFile(filepath.Join(dir, kptfilev1.KptFileName), []byte(content), 0600)
-		if !assert.NoError(tt, err) {
-			tt.FailNow()
-		}
-		return dir
-	}
-
 	testCases := map[string]struct {
 		updated  string
 		local    string
@@ -1682,37 +1691,9 @@ upstreamLock:
 }
 
 func TestReplaceKptfile_errorPaths(t *testing.T) {
-	writeInvalidKptfile := func(tt *testing.T) string {
-		dir := tt.TempDir()
-		err := os.WriteFile(filepath.Join(dir, kptfilev1.KptFileName), []byte(`
-apiVersion: kpt.dev/v1alpha1
-kind: Kptfile
-metadata:
-  name: bad
-`), 0600)
-		if !assert.NoError(tt, err) {
-			tt.FailNow()
-		}
-		return dir
-	}
-
-	writeValidKptfile := func(tt *testing.T) string {
-		dir := tt.TempDir()
-		err := os.WriteFile(filepath.Join(dir, kptfilev1.KptFileName), []byte(`
-apiVersion: kpt.dev/v1
-kind: Kptfile
-metadata:
-  name: valid
-`), 0600)
-		if !assert.NoError(tt, err) {
-			tt.FailNow()
-		}
-		return dir
-	}
-
 	t.Run("error reading local Kptfile", func(t *testing.T) {
-		localDir := writeInvalidKptfile(t)
-		updatedDir := writeValidKptfile(t)
+		localDir := writeKptfileToTemp(t, invalidKptfileContent)
+		updatedDir := writeKptfileToTemp(t, validKptfileContent)
 
 		err := ReplaceKptfile(localDir, updatedDir)
 		assert.Error(t, err)
@@ -1720,8 +1701,8 @@ metadata:
 	})
 
 	t.Run("error reading updated Kptfile", func(t *testing.T) {
-		localDir := writeValidKptfile(t)
-		updatedDir := writeInvalidKptfile(t)
+		localDir := writeKptfileToTemp(t, validKptfileContent)
+		updatedDir := writeKptfileToTemp(t, invalidKptfileContent)
 
 		err := ReplaceKptfile(localDir, updatedDir)
 		assert.Error(t, err)
@@ -1729,8 +1710,8 @@ metadata:
 	})
 
 	t.Run("error writing Kptfile", func(t *testing.T) {
-		localDir := writeValidKptfile(t)
-		updatedDir := writeValidKptfile(t)
+		localDir := writeKptfileToTemp(t, validKptfileContent)
+		updatedDir := writeKptfileToTemp(t, validKptfileContent)
 
 		err := os.Chmod(filepath.Join(localDir, kptfilev1.KptFileName), 0444)
 		if !assert.NoError(t, err) {
@@ -1751,37 +1732,9 @@ metadata:
 }
 
 func TestUpdateKptfileWithoutOrigin_errorPaths(t *testing.T) {
-	writeInvalidKptfile := func(tt *testing.T) string {
-		dir := tt.TempDir()
-		err := os.WriteFile(filepath.Join(dir, kptfilev1.KptFileName), []byte(`
-apiVersion: kpt.dev/v1alpha1
-kind: Kptfile
-metadata:
-  name: bad
-`), 0600)
-		if !assert.NoError(tt, err) {
-			tt.FailNow()
-		}
-		return dir
-	}
-
-	writeValidKptfile := func(tt *testing.T) string {
-		dir := tt.TempDir()
-		err := os.WriteFile(filepath.Join(dir, kptfilev1.KptFileName), []byte(`
-apiVersion: kpt.dev/v1
-kind: Kptfile
-metadata:
-  name: valid
-`), 0600)
-		if !assert.NoError(tt, err) {
-			tt.FailNow()
-		}
-		return dir
-	}
-
 	t.Run("error reading local Kptfile", func(t *testing.T) {
-		localDir := writeInvalidKptfile(t)
-		updatedDir := writeValidKptfile(t)
+		localDir := writeKptfileToTemp(t, invalidKptfileContent)
+		updatedDir := writeKptfileToTemp(t, validKptfileContent)
 
 		err := UpdateKptfileWithoutOrigin(localDir, updatedDir, true)
 		assert.Error(t, err)
@@ -1789,8 +1742,8 @@ metadata:
 	})
 
 	t.Run("error reading updated Kptfile", func(t *testing.T) {
-		localDir := writeValidKptfile(t)
-		updatedDir := writeInvalidKptfile(t)
+		localDir := writeKptfileToTemp(t, validKptfileContent)
+		updatedDir := writeKptfileToTemp(t, invalidKptfileContent)
 
 		err := UpdateKptfileWithoutOrigin(localDir, updatedDir, true)
 		assert.Error(t, err)
@@ -1798,8 +1751,8 @@ metadata:
 	})
 
 	t.Run("error writing Kptfile", func(t *testing.T) {
-		localDir := writeValidKptfile(t)
-		updatedDir := writeValidKptfile(t)
+		localDir := writeKptfileToTemp(t, validKptfileContent)
+		updatedDir := writeKptfileToTemp(t, validKptfileContent)
 
 		err := os.Chmod(filepath.Join(localDir, kptfilev1.KptFileName), 0444)
 		if !assert.NoError(t, err) {

--- a/pkg/lib/update/replace.go
+++ b/pkg/lib/update/replace.go
@@ -36,8 +36,9 @@ var _ updatetypes.Updater = &ReplaceUpdater{}
 func (u ReplaceUpdater) Update(options updatetypes.Options) error {
 	const op errors.Op = "update.Update"
 
-	// Update Kptfile for root package
-	if err := kptfileutil.UpdateKptfile(options.LocalPath, options.UpdatedPath, options.OriginPath, true); err != nil {
+	// Replace Kptfile wholesale — no 3-way merge needed since this strategy
+	// discards local changes.
+	if err := kptfileutil.ReplaceKptfile(options.LocalPath, options.UpdatedPath); err != nil {
 		return errors.E(op, kptfilev1.UniquePath(options.LocalPath), err)
 	}
 


### PR DESCRIPTION
Fixes #4012 

With test cases taken from #4030 

Instead of performing a three way merge the KPT file is directly updated from upstream when using strategies that should not respect local changes like fast-forward and force-delete-replace, allowing the upstream to update the pipeline.
