### PR TITLE
Fix API release workflow

### DIFF
--- a/.github/workflows/release-api.yml
+++ b/.github/workflows/release-api.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: api/go.mod
+          go-version-file: go.mod
           cache-dependency-path: api/go.sum
       - name: Check for replace directives in api/go.mod
         uses: ./.github/actions/check-go-mod-replace


### PR DESCRIPTION
Currently, the API release workflow fails linting, because the version of the linter used requires a newer go version.

There is no problem with using the main module's newer go version to build and lint the API module which uses an older one.