### PR TITLE
Improve kpt version resolution in setup-go-kpt composite action

### DIFF
--- a/.github/actions/setup-go-kpt/action.yml
+++ b/.github/actions/setup-go-kpt/action.yml
@@ -23,7 +23,7 @@ inputs:
   kpt-fallback-version:
     description: "Fallback kpt version if extraction from go.mod fails"
     required: false
-    default: "v1.0.0-beta.65"
+    default: "v1.0.0"
   go-version:
     description: "Exact version for Go version setup, go-version-file is ignored if set"
     required: false
@@ -31,6 +31,10 @@ inputs:
     description: "Path to go.mod file for Go version setup"
     required: false
     default: "go.mod"
+  kpt-version-file:
+    description: "Path to the go.mod file used to resolve the kpt version. Defaults to go-version-file."
+    required: false
+    default: ""
   go-cache:
     description: "Enable Go module caching"
     required: false
@@ -62,14 +66,26 @@ runs:
       shell: bash
       env:
         GO_VERSION_FILE: ${{ inputs.go-version-file }}
+        KPT_VERSION_FILE: ${{ inputs.kpt-version-file }}
         KPT_FALLBACK: ${{ inputs.kpt-fallback-version }}
       run: |
-        GO_MOD_DIR=$(dirname -- "$GO_VERSION_FILE")
-        KPT_VERSION=$(cd "$GO_MOD_DIR" && go list -m -f '{{.Version}}' github.com/kptdev/kpt 2>/dev/null)
+        set -euo pipefail
+        VERSION_FILE="${KPT_VERSION_FILE:-$GO_VERSION_FILE}"
+        KPT_VERSION=""
+        if [ ! -f "$VERSION_FILE" ]; then
+          echo "::warning::kpt version file '${VERSION_FILE}' not found; using fallback ${KPT_FALLBACK}."
+        else
+          GO_MOD_DIR=$(dirname -- "$VERSION_FILE")
+          KPT_VERSION=$(cd "$GO_MOD_DIR" && go mod edit -json \
+            | jq -r '(.Require[]? | select(.Path=="github.com/kptdev/kpt") | .Version) // ""')
+          if [ -z "$KPT_VERSION" ]; then
+            echo "::warning::Could not resolve github.com/kptdev/kpt from ${VERSION_FILE}; using fallback ${KPT_FALLBACK}."
+          fi
+        fi
         if [ -z "$KPT_VERSION" ]; then
-          echo "Warning: Could not resolve kpt version from ${GO_VERSION_FILE}, using fallback."
           KPT_VERSION="$KPT_FALLBACK"
         fi
+        echo "Using kpt version: ${KPT_VERSION}"
         echo "version=${KPT_VERSION}" >> "$GITHUB_OUTPUT"
 
     - name: Install kpt


### PR DESCRIPTION
 ## Description

  **What changed:**
  - Resolve the kpt version with `go mod edit -json` (parsing the `require` block) instead of `go list -m`, reading the version directly from the target `go.mod` without resolving the full module graph. This mirrors the approach already used by the sibling `check-go-mod-replace` action.
    - Add an optional `kpt-version-file` input so callers can resolve the kpt version from a `go.mod` different from the one used for Go setup. It defaults to `go-version-file`, preserving existing behaviour.
  - Surface fallback conditions with `::warning::` annotations (missing version file, or `github.com/kptdev/kpt` not found in the `require` block) instead of a silently swallowed message, and log the resolved kpt version.
    - Harden the resolution step with `set -euo pipefail` and a file-existence check before use.
    - Update the default `kpt-fallback-version` from `v1.0.0-beta.65` to `v1.0.0` (the current latest kpt release) so the safety-net default is not stale.

  **Why it's needed:**
  - A recent `krm-functions-catalog` e2e-ci run showed the previous `go list -m ... 2>/dev/null` logic returning an empty version and silently falling back, then installing a kpt binary that did not match the version the e2e module was built against.

  **How it works:**
  - `go mod edit -json | jq` reads the declared version straight from the `require` block of the resolved version file (`kpt-version-file` if set, otherwise `go-version-file`), making resolution deterministic and authoritative.
    - If the file is missing, or kpt is not a direct requirement, a `::warning::` annotation is emitted and the action falls back to `kpt-fallback-version`.
  - This action is consumed by `porch`, `krm-functions-catalog`, and `krm-functions-sdk`. The change is backward compatible: all `install-kpt: "false"` call sites are unaffected, and every install call site resolves to the same version as before (`porch` `go.mod` -> `v1.0.0-beta.67`, `krm-functions-catalog` `tests/e2etest/go.mod` -> `v1.0.0-beta.65.1`). The new input is opt-in with a behaviour-preserving default, and the fallback default change is inert for current consumers because the fallback path is not exercised when kpt is a direct dependency.


  ## Type of Change

  - [ ] Bug fix
  - [ ] New feature
  - [x] Enhancement
  - [x] Refactor
  - [ ] Documentation
  - [ ] Tests
  - [ ] Other: ________

  ## Checklist

  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [ ] Documentation added/updated
  - [x] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to analyse the composite action and its consumers, verify version resolution behaviour, and draft the PR changes and PR description.