### PR TITLE
Docs: inline function Dockerfile, remove kfn download link

### DIFF
--- a/documentation/content/en/book/05-developing-functions/_index.md
+++ b/documentation/content/en/book/05-developing-functions/_index.md
@@ -350,9 +350,18 @@ standard input. You can now debug the KRM function in the VSCode debugger.
 
 Build the image
 
-The "get-started" package provides the `Dockerfile` that you can download using:
-```shell
-wget https://raw.githubusercontent.com/kptdev/krm-functions-sdk/main/go/kfn/commands/embed/Dockerfile
+Create a `Dockerfile` in your function's directory:
+```dockerfile
+FROM golang:1.26-alpine3.23
+ENV CGO_ENABLED=0
+WORKDIR /go/src/
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o /usr/local/bin/function ./
+FROM scratch
+COPY --from=0 /usr/local/bin/function /usr/local/bin/function
+ENTRYPOINT ["function"]
 ```
 
 ```shell


### PR DESCRIPTION
  ## Description
  - **What changed:** Inlined the `Dockerfile` contents into the "Build the KRM function as a Docker image" section of the developing-functions book chapter, replacing the `wget` download of `https://raw.githubusercontent.com/kptdev/krm-functions-sdk/main/go/kfn/commands/embed/Dockerfile`.
  - **Why it's needed:** `kfn` is being removed from the project. That removal deletes `go/kfn/commands/embed/Dockerfile` in `krm-functions-sdk`, which would turn the `wget` link in this doc into a dead link.
  - **How it works:** The Dockerfile is now shown as a self-contained `dockerfile` code block, removing the dependency on the SDK repo's internal layout.

  ## Related Issue(s)

  - Related to #4731

  ## Type of Change

  - [x] Documentation

  ## Checklist

  - [x] Code follows project style guidelines
  - [x] Self-reviewed changes
  - [ ] Tests added/updated
  - [x] Documentation added/updated
  - [ ] All tests and gating checks pass

  ## AI Disclosure

  - [x] **I have used AI in the creation of this PR.**

  If so, please describe how:
    - Kiro to analyse the `kfn` removal impact and to draft the documentation change.